### PR TITLE
[codex] Add JSON5 data import and export

### DIFF
--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = PZV43D6HWT;
 				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -157,6 +158,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = PZV43D6HWT;
 				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
 				IPHONEOS_DEPLOYMENT_TARGET = 26.4;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -185,10 +187,9 @@
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -211,10 +212,9 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.2.0;
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;

--- a/MigraineTrackerApp/Sources/Features/Export/DataTransfer.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/DataTransfer.swift
@@ -1,0 +1,360 @@
+import Foundation
+import SwiftData
+import UniformTypeIdentifiers
+
+extension UTType {
+    static let migraineTrackerJSON5 = UTType(filenameExtension: "json5") ?? .json
+}
+
+enum DataTransferError: LocalizedError {
+    case invalidFormat
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFormat:
+            return "Die Datei enthält kein unterstütztes MigraineTracker-Datenformat."
+        }
+    }
+}
+
+struct DataTransferSnapshot: Codable {
+    let formatVersion: Int
+    let exportedAt: Date
+    let episodes: [EpisodePayload]
+    let customMedicationDefinitions: [MedicationDefinitionPayload]
+
+    init(
+        formatVersion: Int = 1,
+        exportedAt: Date = .now,
+        episodes: [EpisodePayload],
+        customMedicationDefinitions: [MedicationDefinitionPayload]
+    ) {
+        self.formatVersion = formatVersion
+        self.exportedAt = exportedAt
+        self.episodes = episodes
+        self.customMedicationDefinitions = customMedicationDefinitions
+    }
+
+    init(episodes: [Episode], customMedicationDefinitions: [MedicationDefinition]) {
+        self.init(
+            episodes: episodes.map(EpisodePayload.init),
+            customMedicationDefinitions: customMedicationDefinitions.map(MedicationDefinitionPayload.init)
+        )
+    }
+
+    func writeToTemporaryFile() throws -> URL {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        let fileName = "migraine-tracker-export-\(Self.fileDateFormatter.string(from: exportedAt)).json5"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        let data = try encoder.encode(self)
+
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    static func load(from url: URL) throws -> DataTransferSnapshot {
+        let shouldStopAccess = url.startAccessingSecurityScopedResource()
+        defer {
+            if shouldStopAccess {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.allowsJSON5 = true
+        decoder.dateDecodingStrategy = .iso8601
+
+        let snapshot = try decoder.decode(DataTransferSnapshot.self, from: data)
+        guard snapshot.formatVersion == 1 else {
+            throw DataTransferError.invalidFormat
+        }
+
+        return snapshot
+    }
+
+    func merge(into context: ModelContext) throws {
+        let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
+        let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
+
+        let existingDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
+        let customDefinitionsByKey = Dictionary(
+            uniqueKeysWithValues: existingDefinitions
+                .filter(\.isCustom)
+                .map { ($0.catalogKey, $0) }
+        )
+
+        for payload in customMedicationDefinitions {
+            if let definition = customDefinitionsByKey[payload.catalogKey] {
+                payload.apply(to: definition)
+            } else {
+                context.insert(payload.makeModel())
+            }
+        }
+
+        for payload in episodes {
+            if let episode = episodesByID[payload.id] {
+                payload.apply(to: episode, in: context)
+            } else {
+                context.insert(payload.makeModel())
+            }
+        }
+
+        try context.save()
+    }
+
+    private static let fileDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        return formatter
+    }()
+}
+
+struct EpisodePayload: Codable {
+    let id: UUID
+    let startedAt: Date
+    let endedAt: Date?
+    let type: EpisodeType
+    let intensity: Int
+    let painLocation: String
+    let painCharacter: String
+    let notes: String
+    let symptoms: [String]
+    let triggers: [String]
+    let functionalImpact: String
+    let menstruationStatus: MenstruationStatus
+    let medications: [MedicationEntryPayload]
+    let weatherSnapshot: WeatherSnapshotPayload?
+
+    init(episode: Episode) {
+        self.id = episode.id
+        self.startedAt = episode.startedAt
+        self.endedAt = episode.endedAt
+        self.type = episode.type
+        self.intensity = episode.intensity
+        self.painLocation = episode.painLocation
+        self.painCharacter = episode.painCharacter
+        self.notes = episode.notes
+        self.symptoms = episode.symptoms
+        self.triggers = episode.triggers
+        self.functionalImpact = episode.functionalImpact
+        self.menstruationStatus = episode.menstruationStatus
+        self.medications = episode.medications.map(MedicationEntryPayload.init)
+        self.weatherSnapshot = episode.weatherSnapshot.map(WeatherSnapshotPayload.init)
+    }
+
+    func makeModel() -> Episode {
+        let episode = Episode(
+            id: id,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            type: type,
+            intensity: intensity,
+            painLocation: painLocation,
+            painCharacter: painCharacter,
+            notes: notes,
+            symptoms: symptoms,
+            triggers: triggers,
+            functionalImpact: functionalImpact,
+            menstruationStatus: menstruationStatus
+        )
+
+        episode.medications = medications.map { $0.makeModel(for: episode) }
+        episode.weatherSnapshot = weatherSnapshot?.makeModel(for: episode)
+        return episode
+    }
+
+    func apply(to episode: Episode, in context: ModelContext) {
+        episode.startedAt = startedAt
+        episode.endedAt = endedAt
+        episode.type = type
+        episode.intensity = intensity
+        episode.painLocation = painLocation
+        episode.painCharacter = painCharacter
+        episode.notes = notes
+        episode.symptoms = symptoms
+        episode.triggers = triggers
+        episode.functionalImpact = functionalImpact
+        episode.menstruationStatus = menstruationStatus
+
+        let existingMedicationsByID = Dictionary(uniqueKeysWithValues: episode.medications.map { ($0.id, $0) })
+        let importedMedicationIDs = Set(medications.map(\.id))
+
+        for medication in episode.medications where !importedMedicationIDs.contains(medication.id) {
+            context.delete(medication)
+        }
+
+        episode.medications = medications.map { payload in
+            if let medication = existingMedicationsByID[payload.id] {
+                payload.apply(to: medication, for: episode)
+                return medication
+            }
+
+            return payload.makeModel(for: episode)
+        }
+
+        if let weatherSnapshot {
+            if let existingWeatherSnapshot = episode.weatherSnapshot {
+                weatherSnapshot.apply(to: existingWeatherSnapshot, for: episode)
+            } else {
+                episode.weatherSnapshot = weatherSnapshot.makeModel(for: episode)
+            }
+        } else if let existingWeatherSnapshot = episode.weatherSnapshot {
+            context.delete(existingWeatherSnapshot)
+            episode.weatherSnapshot = nil
+        }
+    }
+}
+
+struct MedicationEntryPayload: Codable {
+    let id: UUID
+    let name: String
+    let category: MedicationCategory
+    let dosage: String
+    let quantity: Int
+    let takenAt: Date
+    let effectiveness: MedicationEffectiveness
+    let reliefStartedAt: Date?
+    let isRepeatDose: Bool
+
+    init(entry: MedicationEntry) {
+        self.id = entry.id
+        self.name = entry.name
+        self.category = entry.category
+        self.dosage = entry.dosage
+        self.quantity = entry.quantity
+        self.takenAt = entry.takenAt
+        self.effectiveness = entry.effectiveness
+        self.reliefStartedAt = entry.reliefStartedAt
+        self.isRepeatDose = entry.isRepeatDose
+    }
+
+    func makeModel(for episode: Episode) -> MedicationEntry {
+        MedicationEntry(
+            id: id,
+            name: name,
+            category: category,
+            dosage: dosage,
+            quantity: quantity,
+            takenAt: takenAt,
+            effectiveness: effectiveness,
+            reliefStartedAt: reliefStartedAt,
+            isRepeatDose: isRepeatDose,
+            episode: episode
+        )
+    }
+
+    func apply(to entry: MedicationEntry, for episode: Episode) {
+        entry.name = name
+        entry.category = category
+        entry.dosage = dosage
+        entry.quantity = quantity
+        entry.takenAt = takenAt
+        entry.effectiveness = effectiveness
+        entry.reliefStartedAt = reliefStartedAt
+        entry.isRepeatDose = isRepeatDose
+        entry.episode = episode
+    }
+}
+
+struct WeatherSnapshotPayload: Codable {
+    let id: UUID
+    let recordedAt: Date
+    let temperature: Double?
+    let condition: String
+    let humidity: Double?
+    let pressure: Double?
+    let source: String
+
+    init(snapshot: WeatherSnapshot) {
+        self.id = snapshot.id
+        self.recordedAt = snapshot.recordedAt
+        self.temperature = snapshot.temperature
+        self.condition = snapshot.condition
+        self.humidity = snapshot.humidity
+        self.pressure = snapshot.pressure
+        self.source = snapshot.source
+    }
+
+    func makeModel(for episode: Episode) -> WeatherSnapshot {
+        WeatherSnapshot(
+            id: id,
+            recordedAt: recordedAt,
+            temperature: temperature,
+            condition: condition,
+            humidity: humidity,
+            pressure: pressure,
+            source: source,
+            episode: episode
+        )
+    }
+
+    func apply(to snapshot: WeatherSnapshot, for episode: Episode) {
+        snapshot.recordedAt = recordedAt
+        snapshot.temperature = temperature
+        snapshot.condition = condition
+        snapshot.humidity = humidity
+        snapshot.pressure = pressure
+        snapshot.source = source
+        snapshot.episode = episode
+    }
+}
+
+struct MedicationDefinitionPayload: Codable {
+    let catalogKey: String
+    let groupID: String
+    let groupTitle: String
+    let groupFooter: String?
+    let name: String
+    let category: MedicationCategory
+    let suggestedDosage: String
+    let sortOrder: Int
+    let isCustom: Bool
+    let createdAt: Date
+
+    init(definition: MedicationDefinition) {
+        self.catalogKey = definition.catalogKey
+        self.groupID = definition.groupID
+        self.groupTitle = definition.groupTitle
+        self.groupFooter = definition.groupFooter
+        self.name = definition.name
+        self.category = definition.category
+        self.suggestedDosage = definition.suggestedDosage
+        self.sortOrder = definition.sortOrder
+        self.isCustom = definition.isCustom
+        self.createdAt = definition.createdAt
+    }
+
+    func makeModel() -> MedicationDefinition {
+        MedicationDefinition(
+            catalogKey: catalogKey,
+            groupID: groupID,
+            groupTitle: groupTitle,
+            groupFooter: groupFooter,
+            name: name,
+            category: category,
+            suggestedDosage: suggestedDosage,
+            sortOrder: sortOrder,
+            isCustom: isCustom,
+            createdAt: createdAt
+        )
+    }
+
+    func apply(to definition: MedicationDefinition) {
+        definition.groupID = groupID
+        definition.groupTitle = groupTitle
+        definition.groupFooter = groupFooter
+        definition.name = name
+        definition.category = category
+        definition.suggestedDosage = suggestedDosage
+        definition.sortOrder = sortOrder
+        definition.isCustom = isCustom
+        definition.createdAt = createdAt
+    }
+}

--- a/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
@@ -2,11 +2,16 @@ import SwiftData
 import SwiftUI
 
 struct ExportView: View {
+    @Environment(\.modelContext) private var modelContext
     @State private var startDate = Calendar.current.date(byAdding: .day, value: -30, to: .now) ?? .now
     @State private var endDate = Date()
     @State private var exportURL: URL?
     @State private var exportErrorMessage: String?
+    @State private var dataExportURL: URL?
+    @State private var dataTransferMessage: String?
+    @State private var isImportingData = false
     @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var episodes: [Episode]
+    @Query(filter: #Predicate<MedicationDefinition> { $0.isCustom }, sort: [SortDescriptor(\MedicationDefinition.sortOrder)]) private var customMedicationDefinitions: [MedicationDefinition]
 
     var body: some View {
         let summary = exportSummary
@@ -26,6 +31,36 @@ struct ExportView: View {
                 }
                 Text("Der PDF-Export wird lokal erzeugt und über das iOS-Share-Sheet geteilt.")
                     .foregroundStyle(.secondary)
+            }
+
+            Section("Daten sichern") {
+                Text("JSON5-Export enthält alle Episoden sowie eigene Medikamentenvorlagen.")
+                    .foregroundStyle(.secondary)
+
+                Button("JSON5 erstellen") {
+                    createDataExport()
+                }
+                .disabled(!hasTransferData)
+                .accessibilityHint(hasTransferData ? "Erstellt eine lokale JSON5-Sicherungsdatei mit allen Episoden." : "Lege zuerst Episoden oder eigene Medikamentenvorlagen an, damit ein JSON5-Export erstellt werden kann.")
+
+                Button("JSON5 importieren") {
+                    isImportingData = true
+                }
+                .accessibilityHint("Importiert eine zuvor exportierte JSON5-Datei und ergänzt oder aktualisiert vorhandene Daten.")
+
+                if let dataExportURL {
+                    ShareLink(item: dataExportURL) {
+                        Label("JSON5 teilen", systemImage: "square.and.arrow.up")
+                    }
+                    .accessibilityHint("Öffnet das Teilen-Menü für die bereits erzeugte JSON5-Datei.")
+                }
+
+                if let dataTransferMessage {
+                    Text(dataTransferMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(dataTransferMessage.contains("Fehler") ? .red : .secondary)
+                        .accessibilityLabel(dataTransferMessage)
+                }
             }
 
             Section("Aktionen") {
@@ -85,10 +120,20 @@ struct ExportView: View {
             }
         }
         .navigationTitle("Export")
+        .fileImporter(
+            isPresented: $isImportingData,
+            allowedContentTypes: [.migraineTrackerJSON5, .json, .plainText]
+        ) { result in
+            importData(from: result)
+        }
     }
 
     private var canExport: Bool {
         !exportSummary.records.isEmpty && startDate <= endDate
+    }
+
+    private var hasTransferData: Bool {
+        !episodes.isEmpty || !customMedicationDefinitions.isEmpty
     }
 
     private var exportSummary: ExportPeriodSummary {
@@ -118,6 +163,42 @@ struct ExportView: View {
             exportURL = try PDFExportWriter.write(summary: exportSummary)
         } catch {
             exportErrorMessage = "Der PDF-Export konnte nicht erstellt werden."
+        }
+    }
+
+    private func createDataExport() {
+        dataTransferMessage = nil
+        dataExportURL = nil
+
+        guard hasTransferData else {
+            dataTransferMessage = "Es sind noch keine Daten für einen JSON5-Export vorhanden."
+            return
+        }
+
+        do {
+            let snapshot = DataTransferSnapshot(
+                episodes: episodes,
+                customMedicationDefinitions: customMedicationDefinitions
+            )
+            dataExportURL = try snapshot.writeToTemporaryFile()
+            dataTransferMessage = "JSON5-Datei wurde lokal erstellt."
+        } catch {
+            dataTransferMessage = "Fehler beim Erstellen der JSON5-Datei."
+        }
+    }
+
+    private func importData(from result: Result<URL, Error>) {
+        dataTransferMessage = nil
+
+        do {
+            let url = try result.get()
+            let snapshot = try DataTransferSnapshot.load(from: url)
+            try snapshot.merge(into: modelContext)
+            dataTransferMessage = "JSON5-Daten wurden importiert."
+        } catch CocoaError.userCancelled {
+            return
+        } catch {
+            dataTransferMessage = "Fehler beim Import der JSON5-Datei."
         }
     }
 


### PR DESCRIPTION
## Was geändert wurde
- ergänzt einen JSON5-Datensnapshot für Episoden, Medikamente und eigene Medikamentenvorlagen
- erweitert den Export-Tab um JSON5-Erstellung, Teilen und Import per Dateiauswahl
- importiert Snapshots per Merge über stabile IDs, statt bestehende Daten pauschal zu überschreiben

## Warum
Die App konnte bislang nur PDF-Berichte exportieren. Für Backups, Gerätewechsel oder Testdaten fehlt damit ein maschinenlesbarer Import-/Exportpfad.

## Auswirkungen
- Nutzer:innen können ihre lokalen Daten als `.json5` sichern und wieder einspielen.
- Beim Import werden bestehende Episoden anhand ihrer IDs aktualisiert, neue ergänzt und zugehörige Medikamente/Wetterdaten konsistent übernommen.
- Eigene Medikamentenvorlagen werden mit exportiert und beim Import aktualisiert oder ergänzt.

## Validierung
- `xcodebuild -project MigraineTracker.xcodeproj -scheme MigraineTrackerApp -destination 'platform=iOS Simulator,name=iPhone 17' build`