### PR TITLE
[codex] Add robust cloud sync architecture

### DIFF
--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_ENTITLEMENTS = MigraineTrackerApp/MigraineTrackerApp.entitlements;
 				DEVELOPMENT_TEAM = PZV43D6HWT;
 				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -156,6 +157,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_ENTITLEMENTS = MigraineTrackerApp/MigraineTrackerApp.entitlements;
 				DEVELOPMENT_TEAM = PZV43D6HWT;
 				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;

--- a/MigraineTrackerApp/Info.plist
+++ b/MigraineTrackerApp/Info.plist
@@ -26,6 +26,10 @@
 	<string>public.app-category.medical</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/MigraineTrackerApp/MigraineTrackerApp.entitlements
+++ b/MigraineTrackerApp/MigraineTrackerApp.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.eu.mpwg.MigraineTracker</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)eu.mpwg.MigraineTracker</string>
+</dict>
+</plist>

--- a/MigraineTrackerApp/Sources/App/AppTab.swift
+++ b/MigraineTrackerApp/Sources/App/AppTab.swift
@@ -18,7 +18,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         case .history:
             "Verlauf"
         case .export:
-            "Export"
+            "Sync"
         }
     }
 
@@ -31,7 +31,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         case .history:
             "calendar"
         case .export:
-            "square.and.arrow.up"
+            "arrow.trianglehead.2.clockwise.icloud"
         }
     }
 }

--- a/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
+++ b/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
@@ -3,7 +3,10 @@ import SwiftData
 
 @main
 struct MigraineTrackerApp: App {
-    private let modelContainer: ModelContainer = {
+    private let modelContainer: ModelContainer
+    @StateObject private var syncCoordinator: SyncCoordinator
+
+    init() {
         let schema = Schema([
             Episode.self,
             MedicationEntry.self,
@@ -16,15 +19,17 @@ struct MigraineTrackerApp: App {
         do {
             let container = try ModelContainer(for: schema, configurations: [configuration])
             MedicationCatalog.importSeedDataIfNeeded(into: container)
-            return container
+            self.modelContainer = container
+            _syncCoordinator = StateObject(wrappedValue: SyncCoordinator(modelContainer: container))
         } catch {
             fatalError("ModelContainer konnte nicht erstellt werden: \(error)")
         }
-    }()
+    }
 
     var body: some Scene {
         WindowGroup {
             AppShellView()
+                .environmentObject(syncCoordinator)
         }
         .modelContainer(modelContainer)
     }

--- a/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
+++ b/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
@@ -9,7 +9,11 @@ struct MigraineTrackerApp: App {
     init() {
         let schema = Schema(versionedSchema: MigraineTrackerSchemaV2.self)
 
-        let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: false,
+            cloudKitDatabase: .none
+        )
 
         do {
             let container = try ModelContainer(

--- a/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
+++ b/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
@@ -7,17 +7,16 @@ struct MigraineTrackerApp: App {
     @StateObject private var syncCoordinator: SyncCoordinator
 
     init() {
-        let schema = Schema([
-            Episode.self,
-            MedicationEntry.self,
-            MedicationDefinition.self,
-            WeatherSnapshot.self,
-        ])
+        let schema = Schema(versionedSchema: MigraineTrackerSchemaV2.self)
 
         let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
         do {
-            let container = try ModelContainer(for: schema, configurations: [configuration])
+            let container = try ModelContainer(
+                for: schema,
+                migrationPlan: MigraineTrackerMigrationPlan.self,
+                configurations: [configuration]
+            )
             MedicationCatalog.importSeedDataIfNeeded(into: container)
             self.modelContainer = container
             _syncCoordinator = StateObject(wrappedValue: SyncCoordinator(modelContainer: container))

--- a/MigraineTrackerApp/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/MigraineTrackerApp/Sources/Features/Capture/EpisodeEditorView.swift
@@ -9,7 +9,7 @@ struct EpisodeEditorView: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: [SortDescriptor(\MedicationDefinition.sortOrder), SortDescriptor(\MedicationDefinition.name)]) private var medicationDefinitions: [MedicationDefinition]
+    @Query(sort: [SortDescriptor(\MedicationDefinition.sortOrder), SortDescriptor(\MedicationDefinition.name)]) private var storedMedicationDefinitions: [MedicationDefinition]
 
     private let mode: EditorMode
     private let episode: Episode?
@@ -385,6 +385,7 @@ struct EpisodeEditorView: View {
 
         let target = episode ?? Episode(startedAt: startedAt, intensity: Int(intensity))
 
+        target.markUpdated()
         target.type = type
         target.startedAt = startedAt
         target.endedAt = endedAtEnabled ? endedAt : nil
@@ -638,6 +639,7 @@ struct EpisodeEditorView: View {
 
         if let existingDefinition = medicationDefinitions.first(where: { $0.catalogKey == draft.id }) {
             definition = existingDefinition
+            definition.markUpdated()
             definition.name = trimmedName
             definition.category = draft.category
             definition.suggestedDosage = trimmedDosage
@@ -689,7 +691,7 @@ struct EpisodeEditorView: View {
 
     private func deleteCustomMedication(_ definition: MedicationDefinition) {
         medications.removeAll { $0.selectionKey == definition.selectionKey }
-        modelContext.delete(definition)
+        definition.markDeleted()
 
         do {
             try modelContext.save()
@@ -721,6 +723,10 @@ struct EpisodeEditorView: View {
         }
 
         return value.formatted(.number.precision(.fractionLength(fractionDigits)))
+    }
+
+    private var medicationDefinitions: [MedicationDefinition] {
+        storedMedicationDefinitions.filter { !$0.isDeleted }
     }
 }
 

--- a/MigraineTrackerApp/Sources/Features/Export/DataExportView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/DataExportView.swift
@@ -1,0 +1,209 @@
+import SwiftData
+import SwiftUI
+
+struct DataExportView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var startDate = Calendar.current.date(byAdding: .day, value: -30, to: .now) ?? .now
+    @State private var endDate = Date()
+    @State private var exportURL: URL?
+    @State private var exportErrorMessage: String?
+    @State private var dataExportURL: URL?
+    @State private var dataTransferMessage: String?
+    @State private var isImportingData = false
+    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
+    @Query(sort: [SortDescriptor(\MedicationDefinition.sortOrder)]) private var storedMedicationDefinitions: [MedicationDefinition]
+
+    var body: some View {
+        let summary = exportSummary
+
+        Form {
+            Section("Zeitraum") {
+                DatePicker("Von", selection: $startDate, displayedComponents: .date)
+                DatePicker("Bis", selection: $endDate, displayedComponents: .date)
+            }
+
+            Section("Bericht") {
+                Text("Episoden im Zeitraum: \(summary.episodeCount)")
+                    .font(.headline)
+                if summary.episodeCount > 0 {
+                    Text("Durchschnittliche Intensität: \(summary.averageIntensity.formatted(.number.precision(.fractionLength(1))))/10")
+                        .foregroundStyle(.secondary)
+                }
+                Text("Der PDF-Export wird lokal erzeugt und über das iOS-Share-Sheet geteilt.")
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Daten sichern") {
+                Text("JSON5-Export enthält alle Episoden sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.")
+                    .foregroundStyle(.secondary)
+
+                Button("JSON5 erstellen") {
+                    createDataExport()
+                }
+                .disabled(!hasTransferData)
+
+                Button("JSON5 importieren") {
+                    isImportingData = true
+                }
+
+                if let dataExportURL {
+                    ShareLink(item: dataExportURL) {
+                        Label("JSON5 teilen", systemImage: "square.and.arrow.up")
+                    }
+                }
+
+                if let dataTransferMessage {
+                    Text(dataTransferMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(dataTransferMessage.contains("Fehler") ? .red : .secondary)
+                }
+            }
+
+            Section("PDF") {
+                Button("PDF erstellen") {
+                    createPDF()
+                }
+                .disabled(!canExport)
+
+                if let exportURL {
+                    ShareLink(item: exportURL) {
+                        Label("PDF teilen", systemImage: "square.and.arrow.up")
+                    }
+                }
+
+                if let exportErrorMessage {
+                    Text(exportErrorMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            if summary.records.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "Keine Episoden im Zeitraum",
+                        systemImage: "square.and.arrow.up",
+                        description: Text("Passe den Zeitraum an, damit ein PDF-Bericht erstellt werden kann.")
+                    )
+                }
+            } else {
+                Section("Vorschau") {
+                    ForEach(summary.records.prefix(5)) { record in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(record.startedAt, style: .date)
+                                .font(.headline)
+                            Text("\(record.type) · Intensität \(record.intensity)/10")
+                                .foregroundStyle(.secondary)
+                            if !record.medications.isEmpty {
+                                Text(record.medications.map(\.name).joined(separator: ", "))
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                            if let weather = record.weather, !weather.condition.isEmpty {
+                                Text("Wetter: \(weather.condition)")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Datenexport")
+        .fileImporter(
+            isPresented: $isImportingData,
+            allowedContentTypes: [.migraineTrackerJSON5, .json, .plainText]
+        ) { result in
+            importData(from: result)
+        }
+    }
+
+    private var episodes: [Episode] {
+        storedEpisodes.filter { !$0.isDeleted }
+    }
+
+    private var customMedicationDefinitions: [MedicationDefinition] {
+        storedMedicationDefinitions.filter { $0.isCustom }
+    }
+
+    private var canExport: Bool {
+        !exportSummary.records.isEmpty && startDate <= endDate
+    }
+
+    private var hasTransferData: Bool {
+        !storedEpisodes.isEmpty || !customMedicationDefinitions.isEmpty
+    }
+
+    private var exportSummary: ExportPeriodSummary {
+        let endOfDay = Calendar.current.date(bySettingHour: 23, minute: 59, second: 59, of: endDate) ?? endDate
+        let filtered = episodes
+            .filter { $0.startedAt >= startDate && $0.startedAt <= endOfDay }
+            .map(EpisodeExportRecord.init)
+
+        return ExportPeriodSummary(startDate: startDate, endDate: endDate, records: filtered)
+    }
+
+    private func createPDF() {
+        exportErrorMessage = nil
+        exportURL = nil
+
+        guard startDate <= endDate else {
+            exportErrorMessage = "Der Zeitraum ist ungültig."
+            return
+        }
+
+        guard !exportSummary.records.isEmpty else {
+            exportErrorMessage = "Für den gewählten Zeitraum gibt es keine Episoden."
+            return
+        }
+
+        do {
+            exportURL = try PDFExportWriter.write(summary: exportSummary)
+        } catch {
+            exportErrorMessage = "Der PDF-Export konnte nicht erstellt werden."
+        }
+    }
+
+    private func createDataExport() {
+        dataTransferMessage = nil
+        dataExportURL = nil
+
+        guard hasTransferData else {
+            dataTransferMessage = "Es sind noch keine Daten für einen JSON5-Export vorhanden."
+            return
+        }
+
+        do {
+            let snapshot = DataTransferSnapshot(
+                episodes: storedEpisodes,
+                customMedicationDefinitions: customMedicationDefinitions
+            )
+            dataExportURL = try snapshot.writeToTemporaryFile()
+            dataTransferMessage = "JSON5-Datei wurde lokal erstellt."
+        } catch {
+            dataTransferMessage = "Fehler beim Erstellen der JSON5-Datei."
+        }
+    }
+
+    private func importData(from result: Result<URL, Error>) {
+        dataTransferMessage = nil
+
+        do {
+            let url = try result.get()
+            let snapshot = try DataTransferSnapshot.load(from: url)
+            try snapshot.merge(into: modelContext)
+            dataTransferMessage = "JSON5-Daten wurden importiert."
+        } catch CocoaError.userCancelled {
+            return
+        } catch {
+            dataTransferMessage = "Fehler beim Import der JSON5-Datei."
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        DataExportView()
+    }
+}

--- a/MigraineTrackerApp/Sources/Features/Export/DataExportView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/DataExportView.swift
@@ -111,6 +111,7 @@ struct DataExportView: View {
             }
         }
         .navigationTitle("Datenexport")
+        .scrollDismissesKeyboard(.interactively)
         .fileImporter(
             isPresented: $isImportingData,
             allowedContentTypes: [.migraineTrackerJSON5, .json, .plainText]

--- a/MigraineTrackerApp/Sources/Features/Export/DataTransfer.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/DataTransfer.swift
@@ -120,6 +120,8 @@ struct EpisodePayload: Codable {
     let id: UUID
     let startedAt: Date
     let endedAt: Date?
+    let updatedAt: Date
+    let deletedAt: Date?
     let type: EpisodeType
     let intensity: Int
     let painLocation: String
@@ -136,6 +138,8 @@ struct EpisodePayload: Codable {
         self.id = episode.id
         self.startedAt = episode.startedAt
         self.endedAt = episode.endedAt
+        self.updatedAt = episode.updatedAt
+        self.deletedAt = episode.deletedAt
         self.type = episode.type
         self.intensity = episode.intensity
         self.painLocation = episode.painLocation
@@ -154,6 +158,8 @@ struct EpisodePayload: Codable {
             id: id,
             startedAt: startedAt,
             endedAt: endedAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt,
             type: type,
             intensity: intensity,
             painLocation: painLocation,
@@ -173,6 +179,8 @@ struct EpisodePayload: Codable {
     func apply(to episode: Episode, in context: ModelContext) {
         episode.startedAt = startedAt
         episode.endedAt = endedAt
+        episode.updatedAt = updatedAt
+        episode.deletedAt = deletedAt
         episode.type = type
         episode.intensity = intensity
         episode.painLocation = painLocation
@@ -317,6 +325,8 @@ struct MedicationDefinitionPayload: Codable {
     let sortOrder: Int
     let isCustom: Bool
     let createdAt: Date
+    let updatedAt: Date
+    let deletedAt: Date?
 
     init(definition: MedicationDefinition) {
         self.catalogKey = definition.catalogKey
@@ -329,6 +339,8 @@ struct MedicationDefinitionPayload: Codable {
         self.sortOrder = definition.sortOrder
         self.isCustom = definition.isCustom
         self.createdAt = definition.createdAt
+        self.updatedAt = definition.updatedAt
+        self.deletedAt = definition.deletedAt
     }
 
     func makeModel() -> MedicationDefinition {
@@ -342,7 +354,9 @@ struct MedicationDefinitionPayload: Codable {
             suggestedDosage: suggestedDosage,
             sortOrder: sortOrder,
             isCustom: isCustom,
-            createdAt: createdAt
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt
         )
     }
 
@@ -356,5 +370,7 @@ struct MedicationDefinitionPayload: Codable {
         definition.sortOrder = sortOrder
         definition.isCustom = isCustom
         definition.createdAt = createdAt
+        definition.updatedAt = updatedAt
+        definition.deletedAt = deletedAt
     }
 }

--- a/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
@@ -12,15 +12,24 @@ struct ExportView: View {
                 NavigationLink {
                     SyncStatusView()
                 } label: {
-                    HStack {
-                        Text("Status")
-                        Spacer()
-                        Circle()
-                            .fill(statusColor)
-                            .frame(width: 10, height: 10)
-                        Text(syncCoordinator.status.state.displayTitle)
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack {
+                            Text("Status")
+                            Spacer()
+                            statusBadge
+                        }
+
+                        Text(statusSubtitle)
+                            .font(.subheadline)
                             .foregroundStyle(.secondary)
+
+                        HStack(spacing: 16) {
+                            statValue(title: "Ausstehend", value: "\(syncCoordinator.status.queuedUpdates)")
+                            statValue(title: "Ungesynct", value: "\(syncCoordinator.status.unsyncedRecords)")
+                            statValue(title: "Konflikte", value: "\(syncCoordinator.conflicts.count)")
+                        }
                     }
+                    .padding(.vertical, 6)
                 }
 
                 Toggle("Sync aktivieren", isOn: Binding(
@@ -38,10 +47,10 @@ struct ExportView: View {
                 Text("Synchronisation")
             }
             footer: {
-                Text("Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional und kann jederzeit wieder deaktiviert werden.")
+                Text("Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden.")
             }
 
-            Section("Export") {
+            Section("Daten sichern") {
                 NavigationLink {
                     DataExportView()
                 } label: {
@@ -78,6 +87,49 @@ struct ExportView: View {
             .gray
         }
     }
+
+    private var statusSubtitle: String {
+        if let lastError = syncCoordinator.status.lastError, !lastError.isEmpty {
+            return lastError
+        }
+
+        if let lastUploadedAt = syncCoordinator.status.lastUploadedAt {
+            return "Letzter Upload: \(formatted(lastUploadedAt))"
+        }
+
+        if let lastDownloadedAt = syncCoordinator.status.lastDownloadedAt {
+            return "Letzter Download: \(formatted(lastDownloadedAt))"
+        }
+
+        return syncCoordinator.isEnabled
+            ? "Synchronisation ist bereit. Lokale Änderungen bleiben bis zum nächsten Lauf sicher auf dem Gerät."
+            : "Synchronisation ist deaktiviert. Alle Daten bleiben lokal auf diesem Gerät erhalten."
+    }
+
+    private var statusBadge: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 10, height: 10)
+            Text(syncCoordinator.status.state.displayTitle)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func statValue(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value)
+                .font(.headline)
+                .foregroundStyle(.primary)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formatted(_ date: Date) -> String {
+        date.formatted(date: .abbreviated, time: .shortened)
+    }
 }
 
 private struct SyncStatusView: View {
@@ -85,13 +137,13 @@ private struct SyncStatusView: View {
 
     var body: some View {
         List {
-            Section("Status") {
+            Section {
                 statusRow("Status", syncCoordinator.status.state.displayTitle)
-                statusRow("Service", syncCoordinator.status.service)
-                statusRow("Queued Updates", "\(syncCoordinator.status.queuedUpdates)")
-                statusRow("Unsynced Records", "\(syncCoordinator.status.unsyncedRecords)")
-                statusRow("Last Downloaded", formatted(syncCoordinator.status.lastDownloadedAt))
-                statusRow("Last Uploaded", formatted(syncCoordinator.status.lastUploadedAt))
+                statusRow("Dienst", syncCoordinator.status.service)
+                statusRow("Ausstehende Uploads", "\(syncCoordinator.status.queuedUpdates)")
+                statusRow("Ungesyncte Einträge", "\(syncCoordinator.status.unsyncedRecords)")
+                statusRow("Letzter Download", formatted(syncCoordinator.status.lastDownloadedAt))
+                statusRow("Letzter Upload", formatted(syncCoordinator.status.lastUploadedAt))
 
                 if let lastError = syncCoordinator.status.lastError {
                     VStack(alignment: .leading, spacing: 6) {
@@ -102,6 +154,11 @@ private struct SyncStatusView: View {
                     }
                     .padding(.vertical, 4)
                 }
+            } header: {
+                Text("Status")
+            }
+            footer: {
+                Text(statusFooter)
             }
         }
         .navigationTitle("Status")
@@ -126,6 +183,25 @@ private struct SyncStatusView: View {
 
         return date.formatted(date: .numeric, time: .shortened)
     }
+
+    private var statusFooter: String {
+        switch syncCoordinator.status.state {
+        case .disabled:
+            "Der Cloud-Sync ist ausgeschaltet. Lokale Daten bleiben unverändert verfügbar."
+        case .ready:
+            "Der Sync-Dienst ist bereit. Änderungen werden beim nächsten Lauf in die private iCloud-Datenbank übertragen."
+        case .syncing:
+            "Es läuft gerade ein Abgleich zwischen lokalem Speicher und iCloud."
+        case .needsAttention:
+            "Der Sync braucht Aufmerksamkeit. Prüfe die Fehlermeldung und versuche den Abgleich erneut."
+        case .conflict:
+            "Mindestens ein Eintrag wurde auf mehreren Geräten unterschiedlich verändert. Erst nach einer Entscheidung gilt der Datensatz wieder als sauber synchronisiert."
+        case .noICloudAccount:
+            "Für iCloud-Sync muss auf dem Gerät ein iCloud-Account angemeldet sein."
+        case .offline:
+            "Ohne Netzwerk bleiben alle Daten lokal erhalten und werden später erneut versucht."
+        }
+    }
 }
 
 private struct ManageCloudDataView: View {
@@ -136,6 +212,17 @@ private struct ManageCloudDataView: View {
 
     var body: some View {
         List {
+            Section {
+                statusRow("Sync", syncCoordinator.isEnabled ? "Aktiviert" : "Deaktiviert")
+                statusRow("Offene Konflikte", "\(syncCoordinator.conflicts.count)")
+                statusRow("Papierkorb", "\(deletedEpisodes.count + deletedDefinitions.count)")
+            } header: {
+                Text("Übersicht")
+            }
+            footer: {
+                Text("Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst.")
+            }
+
             Section {
                 Button("Jetzt synchronisieren") {
                     Task {
@@ -162,6 +249,8 @@ private struct ManageCloudDataView: View {
             footer: {
                 if !syncCoordinator.isEnabled {
                     Text("Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden.")
+                } else {
+                    Text("Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht.")
                 }
             }
 
@@ -172,9 +261,9 @@ private struct ManageCloudDataView: View {
                 } else {
                     ForEach(syncCoordinator.conflicts) { conflict in
                         VStack(alignment: .leading, spacing: 8) {
-                            Text(conflict.documentID)
+                            Text(conflictTitle(for: conflict))
                                 .font(.headline)
-                            Text(conflict.conflictingFields.joined(separator: ", "))
+                            Text("Abweichende Felder: \(conflict.conflictingFields.joined(separator: ", "))")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
 
@@ -252,6 +341,24 @@ private struct ManageCloudDataView: View {
         definition.restore()
         try? modelContext.save()
         syncCoordinator.refreshStatus()
+    }
+
+    private func conflictTitle(for conflict: SyncConflict) -> String {
+        switch conflict.entityType {
+        case .episode:
+            "Episode"
+        case .medicationDefinition:
+            "Medikamentenvorlage"
+        }
+    }
+
+    private func statusRow(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
     }
 }
 

--- a/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
@@ -2,222 +2,233 @@ import SwiftData
 import SwiftUI
 
 struct ExportView: View {
-    @Environment(\.modelContext) private var modelContext
-    @State private var startDate = Calendar.current.date(byAdding: .day, value: -30, to: .now) ?? .now
-    @State private var endDate = Date()
-    @State private var exportURL: URL?
-    @State private var exportErrorMessage: String?
-    @State private var dataExportURL: URL?
-    @State private var dataTransferMessage: String?
-    @State private var isImportingData = false
-    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var episodes: [Episode]
-    @Query(filter: #Predicate<MedicationDefinition> { $0.isCustom }, sort: [SortDescriptor(\MedicationDefinition.sortOrder)]) private var customMedicationDefinitions: [MedicationDefinition]
+    @EnvironmentObject private var syncCoordinator: SyncCoordinator
+    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
+    @Query(sort: [SortDescriptor(\MedicationDefinition.name)]) private var storedDefinitions: [MedicationDefinition]
 
     var body: some View {
-        let summary = exportSummary
-
-        Form {
-            Section("Zeitraum") {
-                DatePicker("Von", selection: $startDate, displayedComponents: .date)
-                DatePicker("Bis", selection: $endDate, displayedComponents: .date)
-            }
-
-            Section("Bericht") {
-                Text("Episoden im Zeitraum: \(summary.episodeCount)")
-                    .font(.headline)
-                if summary.episodeCount > 0 {
-                    Text("Durchschnittliche Intensität: \(summary.averageIntensity.formatted(.number.precision(.fractionLength(1))))/10")
-                        .foregroundStyle(.secondary)
-                }
-                Text("Der PDF-Export wird lokal erzeugt und über das iOS-Share-Sheet geteilt.")
-                    .foregroundStyle(.secondary)
-            }
-
-            Section("Daten sichern") {
-                Text("JSON5-Export enthält alle Episoden sowie eigene Medikamentenvorlagen.")
-                    .foregroundStyle(.secondary)
-
-                Button("JSON5 erstellen") {
-                    createDataExport()
-                }
-                .disabled(!hasTransferData)
-                .accessibilityHint(hasTransferData ? "Erstellt eine lokale JSON5-Sicherungsdatei mit allen Episoden." : "Lege zuerst Episoden oder eigene Medikamentenvorlagen an, damit ein JSON5-Export erstellt werden kann.")
-
-                Button("JSON5 importieren") {
-                    isImportingData = true
-                }
-                .accessibilityHint("Importiert eine zuvor exportierte JSON5-Datei und ergänzt oder aktualisiert vorhandene Daten.")
-
-                if let dataExportURL {
-                    ShareLink(item: dataExportURL) {
-                        Label("JSON5 teilen", systemImage: "square.and.arrow.up")
+        List {
+            Section("Synchronisation") {
+                NavigationLink {
+                    SyncStatusView()
+                } label: {
+                    HStack {
+                        Text("Status")
+                        Spacer()
+                        Circle()
+                            .fill(statusColor)
+                            .frame(width: 10, height: 10)
+                        Text(syncCoordinator.status.state.displayTitle)
+                            .foregroundStyle(.secondary)
                     }
-                    .accessibilityHint("Öffnet das Teilen-Menü für die bereits erzeugte JSON5-Datei.")
                 }
 
-                if let dataTransferMessage {
-                    Text(dataTransferMessage)
-                        .font(.subheadline)
-                        .foregroundStyle(dataTransferMessage.contains("Fehler") ? .red : .secondary)
-                        .accessibilityLabel(dataTransferMessage)
+                Toggle("Sync aktivieren", isOn: Binding(
+                    get: { syncCoordinator.isEnabled },
+                    set: { syncCoordinator.setSyncEnabled($0) }
+                ))
+
+                NavigationLink {
+                    ManageCloudDataView()
+                } label: {
+                    Label("Cloud-Daten verwalten", systemImage: "icloud")
                 }
             }
 
+            Section("Export") {
+                NavigationLink {
+                    DataExportView()
+                } label: {
+                    Label("Datenexport", systemImage: "square.and.arrow.up")
+                }
+            }
+
+            Section("Übersicht") {
+                LabeledContent("Aktive Episoden", value: "\(storedEpisodes.filter { !$0.isDeleted }.count)")
+                LabeledContent("Papierkorb", value: "\(storedEpisodes.filter(\.isDeleted).count + storedDefinitions.filter(\.isDeleted).count)")
+                LabeledContent("Konflikte", value: "\(syncCoordinator.conflicts.count)")
+            }
+        }
+        .navigationTitle("Sync & Datenexport")
+        .task {
+            syncCoordinator.refreshStatus()
+        }
+    }
+
+    private var statusColor: Color {
+        switch syncCoordinator.status.state {
+        case .ready:
+            .green
+        case .syncing:
+            .blue
+        case .conflict, .needsAttention:
+            .orange
+        case .noICloudAccount, .offline:
+            .red
+        case .disabled:
+            .gray
+        }
+    }
+}
+
+private struct SyncStatusView: View {
+    @EnvironmentObject private var syncCoordinator: SyncCoordinator
+
+    var body: some View {
+        List {
+            Section("Status") {
+                statusRow("Status", syncCoordinator.status.state.displayTitle)
+                statusRow("Service", syncCoordinator.status.service)
+                statusRow("Queued Updates", "\(syncCoordinator.status.queuedUpdates)")
+                statusRow("Unsynced Records", "\(syncCoordinator.status.unsyncedRecords)")
+                statusRow("Last Downloaded", formatted(syncCoordinator.status.lastDownloadedAt))
+                statusRow("Last Uploaded", formatted(syncCoordinator.status.lastUploadedAt))
+
+                if let lastError = syncCoordinator.status.lastError {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Letzter Fehler")
+                        Text(lastError)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+        .navigationTitle("Status")
+    }
+
+    private func statusRow(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formatted(_ date: Date?) -> String {
+        guard let date else {
+            return "Noch nie"
+        }
+
+        return date.formatted(date: .numeric, time: .shortened)
+    }
+}
+
+private struct ManageCloudDataView: View {
+    @Environment(\.modelContext) private var modelContext
+    @EnvironmentObject private var syncCoordinator: SyncCoordinator
+    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
+    @Query(sort: [SortDescriptor(\MedicationDefinition.updatedAt, order: .reverse)]) private var storedDefinitions: [MedicationDefinition]
+
+    var body: some View {
+        List {
             Section("Aktionen") {
-                Button("PDF erstellen") {
-                    createPDF()
-                }
-                .disabled(!canExport)
-                .accessibilityHint(canExport ? "Erstellt einen lokalen PDF-Bericht für den gewählten Zeitraum." : "Wähle zuerst einen gültigen Zeitraum mit mindestens einer Episode.")
-
-                if let exportURL {
-                    ShareLink(item: exportURL) {
-                        Label("PDF teilen", systemImage: "square.and.arrow.up")
+                Button("Jetzt synchronisieren") {
+                    Task {
+                        await syncCoordinator.syncNow()
                     }
-                    .accessibilityHint("Öffnet das Teilen-Menü für den bereits erzeugten PDF-Bericht.")
                 }
 
-                if let exportErrorMessage {
-                    Text(exportErrorMessage)
-                        .font(.subheadline)
-                        .foregroundStyle(.red)
-                        .accessibilityLabel("Fehler: \(exportErrorMessage)")
+                Button("Fehler erneut versuchen") {
+                    Task {
+                        await syncCoordinator.retryLastError()
+                    }
+                }
+                .disabled(syncCoordinator.status.lastError == nil)
+
+                NavigationLink {
+                    DataExportView()
+                } label: {
+                    Text("Lokales JSON5-Backup erstellen")
                 }
             }
 
-            if summary.records.isEmpty {
-                Section {
-                    ContentUnavailableView(
-                        "Keine Episoden im Zeitraum",
-                        systemImage: "square.and.arrow.up",
-                        description: Text("Passe den Zeitraum an, damit ein PDF-Bericht erstellt werden kann.")
-                    )
-                }
-            } else {
-                Section("Vorschau") {
-                    ForEach(summary.records.prefix(5)) { record in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(record.startedAt, style: .date)
+            Section("Konflikte") {
+                if syncCoordinator.conflicts.isEmpty {
+                    Text("Keine offenen Konflikte.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(syncCoordinator.conflicts) { conflict in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(conflict.documentID)
                                 .font(.headline)
-                            Text("\(record.type) · Intensität \(record.intensity)/10")
+                            Text(conflict.conflictingFields.joined(separator: ", "))
+                                .font(.subheadline)
                                 .foregroundStyle(.secondary)
-                            if !record.medications.isEmpty {
-                                Text(record.medications.map(\.name).joined(separator: ", "))
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+
+                            Button("Lokale Version behalten") {
+                                syncCoordinator.resolveConflictKeepingLocal(conflict)
                             }
-                            if let weather = record.weather, !weather.condition.isEmpty {
-                                Text("Wetter: \(weather.condition)")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+
+                            Button("Cloud-Version übernehmen") {
+                                syncCoordinator.resolveConflictUsingRemote(conflict)
                             }
                         }
-                        .padding(.vertical, 2)
-                        .accessibilityElement(children: .ignore)
-                        .accessibilityLabel(previewAccessibilityLabel(for: record))
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+
+            Section("Papierkorb") {
+                if deletedEpisodes.isEmpty && deletedDefinitions.isEmpty {
+                    Text("Keine gelöschten Einträge.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(deletedEpisodes, id: \.id) { episode in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(episode.startedAt.formatted(date: .abbreviated, time: .shortened))
+                                Text(episode.type.rawValue)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Button("Wiederherstellen") {
+                                restore(episode)
+                            }
+                        }
+                    }
+
+                    ForEach(deletedDefinitions, id: \.catalogKey) { definition in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(definition.name)
+                                Text(definition.category.rawValue)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Button("Wiederherstellen") {
+                                restore(definition)
+                            }
+                        }
                     }
                 }
             }
         }
-        .navigationTitle("Export")
-        .fileImporter(
-            isPresented: $isImportingData,
-            allowedContentTypes: [.migraineTrackerJSON5, .json, .plainText]
-        ) { result in
-            importData(from: result)
-        }
+        .navigationTitle("Cloud-Daten")
     }
 
-    private var canExport: Bool {
-        !exportSummary.records.isEmpty && startDate <= endDate
+    private var deletedEpisodes: [Episode] {
+        storedEpisodes.filter(\.isDeleted)
     }
 
-    private var hasTransferData: Bool {
-        !episodes.isEmpty || !customMedicationDefinitions.isEmpty
+    private var deletedDefinitions: [MedicationDefinition] {
+        storedDefinitions.filter(\.isDeleted)
     }
 
-    private var exportSummary: ExportPeriodSummary {
-        let endOfDay = Calendar.current.date(bySettingHour: 23, minute: 59, second: 59, of: endDate) ?? endDate
-        let filtered = episodes
-            .filter { $0.startedAt >= startDate && $0.startedAt <= endOfDay }
-            .map(EpisodeExportRecord.init)
-
-        return ExportPeriodSummary(startDate: startDate, endDate: endDate, records: filtered)
+    private func restore(_ episode: Episode) {
+        episode.restore()
+        try? modelContext.save()
+        syncCoordinator.refreshStatus()
     }
 
-    private func createPDF() {
-        exportErrorMessage = nil
-        exportURL = nil
-
-        guard startDate <= endDate else {
-            exportErrorMessage = "Der Zeitraum ist ungültig."
-            return
-        }
-
-        guard !exportSummary.records.isEmpty else {
-            exportErrorMessage = "Für den gewählten Zeitraum gibt es keine Episoden."
-            return
-        }
-
-        do {
-            exportURL = try PDFExportWriter.write(summary: exportSummary)
-        } catch {
-            exportErrorMessage = "Der PDF-Export konnte nicht erstellt werden."
-        }
-    }
-
-    private func createDataExport() {
-        dataTransferMessage = nil
-        dataExportURL = nil
-
-        guard hasTransferData else {
-            dataTransferMessage = "Es sind noch keine Daten für einen JSON5-Export vorhanden."
-            return
-        }
-
-        do {
-            let snapshot = DataTransferSnapshot(
-                episodes: episodes,
-                customMedicationDefinitions: customMedicationDefinitions
-            )
-            dataExportURL = try snapshot.writeToTemporaryFile()
-            dataTransferMessage = "JSON5-Datei wurde lokal erstellt."
-        } catch {
-            dataTransferMessage = "Fehler beim Erstellen der JSON5-Datei."
-        }
-    }
-
-    private func importData(from result: Result<URL, Error>) {
-        dataTransferMessage = nil
-
-        do {
-            let url = try result.get()
-            let snapshot = try DataTransferSnapshot.load(from: url)
-            try snapshot.merge(into: modelContext)
-            dataTransferMessage = "JSON5-Daten wurden importiert."
-        } catch CocoaError.userCancelled {
-            return
-        } catch {
-            dataTransferMessage = "Fehler beim Import der JSON5-Datei."
-        }
-    }
-
-    private func previewAccessibilityLabel(for record: EpisodeExportRecord) -> String {
-        var parts = [
-            record.startedAt.formatted(date: .complete, time: .shortened),
-            record.type,
-            "Intensität \(record.intensity) von 10"
-        ]
-
-        if !record.medications.isEmpty {
-            parts.append("Medikamente: \(record.medications.map(\.name).joined(separator: ", "))")
-        }
-
-        if let weather = record.weather, !weather.condition.isEmpty {
-            parts.append("Wetter: \(weather.condition)")
-        }
-
-        return parts.joined(separator: ", ")
+    private func restore(_ definition: MedicationDefinition) {
+        definition.restore()
+        try? modelContext.save()
+        syncCoordinator.refreshStatus()
     }
 }
 

--- a/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
@@ -8,7 +8,7 @@ struct ExportView: View {
 
     var body: some View {
         List {
-            Section("Synchronisation") {
+            Section {
                 NavigationLink {
                     SyncStatusView()
                 } label: {
@@ -27,12 +27,18 @@ struct ExportView: View {
                     get: { syncCoordinator.isEnabled },
                     set: { syncCoordinator.setSyncEnabled($0) }
                 ))
+                .tint(.green)
 
                 NavigationLink {
                     ManageCloudDataView()
                 } label: {
                     Label("Cloud-Daten verwalten", systemImage: "icloud")
                 }
+            } header: {
+                Text("Synchronisation")
+            }
+            footer: {
+                Text("Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional und kann jederzeit wieder deaktiviert werden.")
             }
 
             Section("Export") {
@@ -51,6 +57,9 @@ struct ExportView: View {
         }
         .navigationTitle("Sync & Datenexport")
         .task {
+            syncCoordinator.refreshStatus()
+        }
+        .refreshable {
             syncCoordinator.refreshStatus()
         }
     }
@@ -96,6 +105,9 @@ private struct SyncStatusView: View {
             }
         }
         .navigationTitle("Status")
+        .refreshable {
+            syncCoordinator.refreshStatus()
+        }
     }
 
     private func statusRow(_ title: String, _ value: String) -> some View {
@@ -124,24 +136,32 @@ private struct ManageCloudDataView: View {
 
     var body: some View {
         List {
-            Section("Aktionen") {
+            Section {
                 Button("Jetzt synchronisieren") {
                     Task {
                         await syncCoordinator.syncNow()
                     }
                 }
+                .disabled(!syncCoordinator.isEnabled)
 
                 Button("Fehler erneut versuchen") {
                     Task {
                         await syncCoordinator.retryLastError()
                     }
                 }
-                .disabled(syncCoordinator.status.lastError == nil)
+                .disabled(!syncCoordinator.isEnabled || syncCoordinator.status.lastError == nil)
 
                 NavigationLink {
                     DataExportView()
                 } label: {
                     Text("Lokales JSON5-Backup erstellen")
+                }
+            } header: {
+                Text("Aktionen")
+            }
+            footer: {
+                if !syncCoordinator.isEnabled {
+                    Text("Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden.")
                 }
             }
 
@@ -209,6 +229,9 @@ private struct ManageCloudDataView: View {
             }
         }
         .navigationTitle("Cloud-Daten")
+        .refreshable {
+            syncCoordinator.refreshStatus()
+        }
     }
 
     private var deletedEpisodes: [Episode] {

--- a/MigraineTrackerApp/Sources/Features/History/EpisodeDetailView.swift
+++ b/MigraineTrackerApp/Sources/Features/History/EpisodeDetailView.swift
@@ -149,7 +149,7 @@ struct EpisodeDetailView: View {
 
             Button("Abbrechen", role: .cancel) {}
         } message: {
-            Text("Diese Episode wird dauerhaft gelöscht.")
+            Text("Diese Episode wird in den Papierkorb verschoben.")
         }
     }
 
@@ -173,7 +173,7 @@ struct EpisodeDetailView: View {
     }
 
     private func deleteEpisode() {
-        modelContext.delete(episode)
+        episode.markDeleted()
 
         do {
             try modelContext.save()

--- a/MigraineTrackerApp/Sources/Features/History/HistoryView.swift
+++ b/MigraineTrackerApp/Sources/Features/History/HistoryView.swift
@@ -10,7 +10,7 @@ struct HistoryView: View {
     }
 
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var episodes: [Episode]
+    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
     @State private var mode: HistoryMode = .list
     @State private var selectedDay: Date = .now
     @State private var displayedMonth: Date = Calendar.current.startOfMonth(for: .now)
@@ -111,12 +111,16 @@ struct HistoryView: View {
                 pendingDeletion = nil
             }
         } message: { episode in
-            Text("\(episode.startedAt.formatted(date: .abbreviated, time: .shortened)) wird dauerhaft gelöscht.")
+            Text("\(episode.startedAt.formatted(date: .abbreviated, time: .shortened)) wird in den Papierkorb verschoben.")
         }
     }
 
     private var episodesByDay: [Date: [Episode]] {
         Dictionary(grouping: episodes) { Calendar.current.startOfDay(for: $0.startedAt) }
+    }
+
+    private var episodes: [Episode] {
+        storedEpisodes.filter { !$0.isDeleted }
     }
 
     private var episodesForSelectedDay: [Episode] {
@@ -154,7 +158,7 @@ struct HistoryView: View {
 
     private func deleteEpisodes(at offsets: IndexSet) {
         for index in offsets {
-            modelContext.delete(episodes[index])
+            episodes[index].markDeleted()
         }
 
         do {
@@ -168,7 +172,7 @@ struct HistoryView: View {
         let dayEpisodes = episodesForSelectedDay
 
         for index in offsets {
-            modelContext.delete(dayEpisodes[index])
+            dayEpisodes[index].markDeleted()
         }
 
         do {
@@ -179,7 +183,7 @@ struct HistoryView: View {
     }
 
     private func deleteEpisode(_ episode: Episode) {
-        modelContext.delete(episode)
+        episode.markDeleted()
 
         do {
             try modelContext.save()

--- a/MigraineTrackerApp/Sources/Features/Home/HomeView.swift
+++ b/MigraineTrackerApp/Sources/Features/Home/HomeView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct HomeView: View {
     @Binding var selectedTab: AppTab
-    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var episodes: [Episode]
+    @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
 
     var body: some View {
         List {
@@ -52,7 +52,7 @@ struct HomeView: View {
 
             Section("Version 1") {
                 MetricRow(title: "Gespeicherte Episoden", detail: "\(episodes.count)")
-                MetricRow(title: "Lokale Speicherung", detail: "Keine Anmeldung, kein Backend, keine Synchronisation.")
+                MetricRow(title: "Lokale Speicherung", detail: "Lokale Primärdaten mit optionaler iCloud-Synchronisation.")
                 MetricRow(title: "Wetterkontext", detail: "Kann optional manuell pro Episode ergänzt und lokal gespeichert werden.")
             }
 
@@ -68,6 +68,10 @@ struct HomeView: View {
             }
         }
         .navigationTitle("Migraine Tracker")
+    }
+
+    private var episodes: [Episode] {
+        storedEpisodes.filter { !$0.isDeleted }
     }
 }
 

--- a/MigraineTrackerApp/Sources/Features/Home/HomeView.swift
+++ b/MigraineTrackerApp/Sources/Features/Home/HomeView.swift
@@ -39,9 +39,9 @@ struct HomeView: View {
                 Button {
                     selectedTab = .export
                 } label: {
-                    Label("PDF exportieren", systemImage: "square.and.arrow.up")
+                    Label("Sync & Datenexport", systemImage: "arrow.trianglehead.2.clockwise.icloud")
                 }
-                .accessibilityHint("Öffnet den Exportbereich für Arztberichte als PDF.")
+                .accessibilityHint("Öffnet den Bereich für Sync-Status, Cloud-Daten und Exporte.")
 
                 NavigationLink {
                     ProductInformationView(mode: .standard)

--- a/MigraineTrackerApp/Sources/Features/Home/ProductInformationView.swift
+++ b/MigraineTrackerApp/Sources/Features/Home/ProductInformationView.swift
@@ -26,11 +26,11 @@ struct ProductInformationView: View {
             Section("Datenschutz") {
                 infoRow(
                     title: "Lokale Gesundheitsdaten",
-                    detail: "Episoden, Medikamente, Notizen, Trigger, Symptome und optionale Wetterangaben bleiben auf dem Gerät."
+                    detail: "Episoden, Medikamente, Notizen, Trigger, Symptome und optionale Wetterangaben werden lokal auf dem Gerät gespeichert."
                 )
                 infoRow(
-                    title: "Kein Account, kein Backend",
-                    detail: "Es gibt keine Anmeldung, keine Cloud-Synchronisation und keine Server-Speicherung."
+                    title: "Optionale iCloud-Synchronisation",
+                    detail: "Cloud-Sync ist freiwillig. Ohne Aktivierung bleiben die Daten ausschließlich lokal auf diesem Gerät."
                 )
                 infoRow(
                     title: "PDF-Export nur auf deinen Befehl",

--- a/MigraineTrackerApp/Sources/Features/Sync/CloudKitSyncProvider.swift
+++ b/MigraineTrackerApp/Sources/Features/Sync/CloudKitSyncProvider.swift
@@ -1,0 +1,269 @@
+import CloudKit
+import Foundation
+
+enum SyncProviderEvent: Sendable {
+    case didUpdateState(CKSyncEngine.State.Serialization)
+    case didFetchRecords([CKRecord])
+    case didDeleteRecords([CKRecord.ID])
+    case didSendRecords([CKRecord])
+    case didFailToSend([SyncFailedRecordSave])
+    case didEncounterError(String)
+}
+
+struct SyncFailedRecordSave: Sendable {
+    let recordID: CKRecord.ID
+    let error: CKError
+}
+
+protocol SyncProvider: AnyObject {
+    var queuedChangeCount: Int { get async }
+    var accountAvailability: SyncServiceState { get async }
+
+    func start() async throws
+    func stop() async
+    func queue(recordNames: [String]) async
+    func fetch() async throws
+    func send() async throws
+}
+
+final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
+    private let stateStore: SyncStateStore
+    private let zoneID: CKRecordZone.ID
+    private let recordProvider: @Sendable (CKRecord.ID) async -> CKRecord?
+    private let eventHandler: @Sendable (SyncProviderEvent) async -> Void
+    private var syncEngine: CKSyncEngine?
+    private let container = CKContainer(identifier: SyncConfiguration.containerIdentifier)
+    private var pendingRecordNames = Set<String>()
+
+    init(
+        stateStore: SyncStateStore,
+        zoneID: CKRecordZone.ID,
+        recordProvider: @escaping @Sendable (CKRecord.ID) async -> CKRecord?,
+        eventHandler: @escaping @Sendable (SyncProviderEvent) async -> Void
+    ) {
+        self.stateStore = stateStore
+        self.zoneID = zoneID
+        self.recordProvider = recordProvider
+        self.eventHandler = eventHandler
+    }
+
+    var queuedChangeCount: Int {
+        get async {
+            if let syncEngine {
+                return syncEngine.state.pendingRecordZoneChanges.count + syncEngine.state.pendingDatabaseChanges.count
+            }
+
+            return pendingRecordNames.count
+        }
+    }
+
+    var accountAvailability: SyncServiceState {
+        get async {
+            do {
+                switch try await container.accountStatus() {
+                case .available:
+                    return .ready
+                case .noAccount:
+                    return .noICloudAccount
+                default:
+                    return .needsAttention
+                }
+            } catch {
+                return .needsAttention
+            }
+        }
+    }
+
+    func start() async throws {
+        guard syncEngine == nil else {
+            return
+        }
+
+        let database = container.privateCloudDatabase
+        let configuration = CKSyncEngine.Configuration(
+            database: database,
+            stateSerialization: await stateStore.engineState(),
+            delegate: self
+        )
+
+        let engine = CKSyncEngine(configuration)
+        engine.state.add(
+            pendingDatabaseChanges: [
+                .saveZone(CKRecordZone(zoneID: zoneID))
+            ]
+        )
+        syncEngine = engine
+    }
+
+    func stop() async {
+        await syncEngine?.cancelOperations()
+        syncEngine = nil
+    }
+
+    func queue(recordNames: [String]) async {
+        pendingRecordNames.formUnion(recordNames)
+
+        guard let syncEngine else {
+            return
+        }
+
+        let changes = recordNames.map {
+            CKSyncEngine.PendingRecordZoneChange.saveRecord(
+                CKRecord.ID(recordName: $0, zoneID: zoneID)
+            )
+        }
+        syncEngine.state.add(pendingRecordZoneChanges: changes)
+    }
+
+    func fetch() async throws {
+        guard let syncEngine else {
+            return
+        }
+
+        try await syncEngine.fetchChanges(
+            .init(scope: .zoneIDs([zoneID]))
+        )
+    }
+
+    func send() async throws {
+        guard let syncEngine else {
+            return
+        }
+
+        try await syncEngine.sendChanges(
+            .init(scope: .zoneIDs([zoneID]))
+        )
+    }
+}
+
+extension CloudKitSyncProvider: CKSyncEngineDelegate {
+    func handleEvent(_ event: CKSyncEngine.Event, syncEngine _: CKSyncEngine) async {
+        switch event {
+        case .stateUpdate(let update):
+            await eventHandler(.didUpdateState(update.stateSerialization))
+        case .fetchedRecordZoneChanges(let changes):
+            await eventHandler(.didFetchRecords(changes.modifications.map(\.record)))
+            await eventHandler(.didDeleteRecords(changes.deletions.map(\.recordID)))
+        case .sentRecordZoneChanges(let changes):
+            let failures = changes.failedRecordSaves.map {
+                SyncFailedRecordSave(recordID: $0.record.recordID, error: $0.error)
+            }
+            pendingRecordNames.subtract(changes.savedRecords.map { $0.recordID.recordName })
+            await eventHandler(.didSendRecords(changes.savedRecords))
+            if !failures.isEmpty {
+                await eventHandler(.didFailToSend(failures))
+            }
+        case .sentDatabaseChanges(let changes):
+            if !changes.failedZoneSaves.isEmpty {
+                await eventHandler(.didEncounterError(changes.failedZoneSaves[0].error.localizedDescription))
+            }
+        case .didFetchRecordZoneChanges(let change):
+            if let error = change.error {
+                await eventHandler(.didEncounterError(error.localizedDescription))
+            }
+        case .didSendChanges:
+            break
+        case .didFetchChanges:
+            break
+        case .willFetchChanges:
+            break
+        case .willFetchRecordZoneChanges:
+            break
+        case .willSendChanges:
+            break
+        case .accountChange(let change):
+            switch change.changeType {
+            case .signOut, .switchAccounts:
+                await eventHandler(.didEncounterError("Der iCloud-Account wurde geändert. Bitte prüfe den Sync-Status."))
+            case .signIn:
+                break
+            @unknown default:
+                await eventHandler(.didEncounterError("Unbekannte iCloud-Änderung erkannt."))
+            }
+        case .fetchedDatabaseChanges:
+            break
+        @unknown default:
+            break
+        }
+    }
+
+    func nextRecordZoneChangeBatch(_ context: CKSyncEngine.SendChangesContext, syncEngine: CKSyncEngine) async -> CKSyncEngine.RecordZoneChangeBatch? {
+        let changes = syncEngine.state.pendingRecordZoneChanges.filter { context.options.scope.contains($0) }
+        return await CKSyncEngine.RecordZoneChangeBatch(
+            pendingChanges: changes,
+            recordProvider: recordProvider
+        )
+    }
+}
+
+enum CloudKitRecordCodec {
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    static func record(for envelope: SyncDocumentEnvelope, zoneID: CKRecordZone.ID, existingSystemFields: Data?) -> CKRecord? {
+        let recordID = CKRecord.ID(recordName: envelope.documentID, zoneID: zoneID)
+        let record = existingRecord(for: recordID, systemFields: existingSystemFields) ?? CKRecord(
+            recordType: SyncConfiguration.recordType,
+            recordID: recordID
+        )
+
+        guard let data = try? encoder.encode(envelope), let payloadString = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        record["documentID"] = envelope.documentID as CKRecordValue
+        record["entityType"] = envelope.entityType.rawValue as CKRecordValue
+        record["schemaVersion"] = NSNumber(value: envelope.schemaVersion)
+        record["modifiedAt"] = envelope.modifiedAt as CKRecordValue
+        record["authorDeviceID"] = envelope.authorDeviceID as CKRecordValue
+        record["payloadJSON"] = payloadString as CKRecordValue
+        if let deletedAt = envelope.deletedAt {
+            record["deletedAt"] = deletedAt as CKRecordValue
+        } else {
+            record["deletedAt"] = nil
+        }
+
+        return record
+    }
+
+    static func envelope(from record: CKRecord) -> SyncDocumentEnvelope? {
+        guard let payloadString = record["payloadJSON"] as? String, let data = payloadString.data(using: .utf8) else {
+            return nil
+        }
+
+        return try? decoder.decode(SyncDocumentEnvelope.self, from: data)
+    }
+
+    static func systemFields(for record: CKRecord) -> Data? {
+        let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+        record.encodeSystemFields(with: archiver)
+        archiver.finishEncoding()
+        return archiver.encodedData
+    }
+
+    private static func existingRecord(for recordID: CKRecord.ID, systemFields: Data?) -> CKRecord? {
+        guard let systemFields else {
+            return nil
+        }
+
+        let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: systemFields)
+        unarchiver?.requiresSecureCoding = true
+        let record = CKRecord(coder: unarchiver!)
+        unarchiver?.finishDecoding()
+        guard let record else {
+            return nil
+        }
+
+        return record.recordID == recordID ? record : CKRecord(recordType: SyncConfiguration.recordType, recordID: recordID)
+    }
+}

--- a/MigraineTrackerApp/Sources/Features/Sync/SyncCoordinator.swift
+++ b/MigraineTrackerApp/Sources/Features/Sync/SyncCoordinator.swift
@@ -1,0 +1,564 @@
+import CloudKit
+import Foundation
+import SwiftData
+import SwiftUI
+import UIKit
+
+@MainActor
+final class SyncCoordinator: ObservableObject {
+    @Published private(set) var status = SyncStatusSnapshot()
+    @Published private(set) var conflicts: [SyncConflict] = []
+    @Published private(set) var isEnabled = false
+
+    private let modelContainer: ModelContainer
+    private let stateStore: SyncStateStore
+    private let repository: LocalSyncRepository
+    private let deviceID: String
+    private var provider: (any SyncProvider)?
+    private let zoneID = SyncConfiguration.zoneID
+
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+        self.stateStore = SyncStateStore()
+        self.repository = LocalSyncRepository(modelContainer: modelContainer)
+        self.deviceID = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+
+        Task {
+            await loadPersistedState()
+        }
+    }
+
+    func loadPersistedState() async {
+        isEnabled = await stateStore.syncEnabled()
+        conflicts = await stateStore.conflicts()
+        status = await buildStatusSnapshot(
+            baseState: isEnabled ? .ready : .disabled,
+            isSyncing: false
+        )
+
+        if isEnabled {
+            await ensureStarted()
+        }
+    }
+
+    func setSyncEnabled(_ enabled: Bool) {
+        Task {
+            await stateStore.setSyncEnabled(enabled)
+            isEnabled = enabled
+
+            if enabled {
+                await ensureStarted()
+                await syncNow()
+            } else {
+                await provider?.stop()
+                provider = nil
+                status = await buildStatusSnapshot(baseState: .disabled, isSyncing: false)
+            }
+        }
+    }
+
+    func refreshStatus() {
+        Task {
+            status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+        }
+    }
+
+    func syncNow() async {
+        guard isEnabled else {
+            status = await buildStatusSnapshot(baseState: .disabled, isSyncing: false)
+            return
+        }
+
+        await ensureStarted()
+
+        guard let provider else {
+            status = await buildStatusSnapshot(baseState: .needsAttention, isSyncing: false)
+            return
+        }
+
+        status = await buildStatusSnapshot(baseState: .syncing, isSyncing: true)
+
+        do {
+            try await provider.fetch()
+            try await queueUnsyncedDocuments()
+            try await provider.send()
+            await stateStore.clearLastError()
+        } catch {
+            await stateStore.setLastError(error.localizedDescription)
+        }
+
+        conflicts = await stateStore.conflicts()
+        status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+    }
+
+    func retryLastError() async {
+        await syncNow()
+    }
+
+    func backupNow() async {
+        await syncNow()
+    }
+
+    func resolveConflictKeepingLocal(_ conflict: SyncConflict) {
+        Task {
+            await stateStore.removeConflict(documentID: conflict.documentID)
+            conflicts = await stateStore.conflicts()
+            status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+        }
+    }
+
+    func resolveConflictUsingRemote(_ conflict: SyncConflict) {
+        Task {
+            do {
+                try repository.apply(remote: conflict.remote)
+                await stateStore.saveShadow(SyncShadow(envelope: conflict.remote), for: conflict.documentID)
+                await stateStore.removeConflict(documentID: conflict.documentID)
+                conflicts = await stateStore.conflicts()
+                status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+            } catch {
+                await stateStore.setLastError(error.localizedDescription)
+                status = await buildStatusSnapshot(baseState: .needsAttention, isSyncing: false)
+            }
+        }
+    }
+
+    private func ensureStarted() async {
+        guard provider == nil else {
+            return
+        }
+
+        let cloudProvider = CloudKitSyncProvider(
+            stateStore: stateStore,
+            zoneID: zoneID,
+            recordProvider: { [weak self] recordID in
+                await self?.recordForUpload(recordID: recordID)
+            },
+            eventHandler: { [weak self] event in
+                await self?.handleProviderEvent(event)
+            }
+        )
+
+        provider = cloudProvider
+
+        do {
+            try await cloudProvider.start()
+        } catch {
+            await stateStore.setLastError(error.localizedDescription)
+        }
+    }
+
+    private func recordForUpload(recordID: CKRecord.ID) async -> CKRecord? {
+        guard let envelope = try? repository.envelope(documentID: recordID.recordName, deviceID: deviceID) else {
+            return nil
+        }
+
+        let shadow = await stateStore.shadow(for: envelope.documentID)
+        return CloudKitRecordCodec.record(
+            for: envelope,
+            zoneID: zoneID,
+            existingSystemFields: shadow?.recordSystemFields
+        )
+    }
+
+    private func handleProviderEvent(_ event: SyncProviderEvent) async {
+        switch event {
+        case .didUpdateState(let serialization):
+            await stateStore.saveEngineState(serialization)
+        case .didFetchRecords(let records):
+            for record in records {
+                await applyRemoteRecord(record)
+            }
+            await stateStore.setLastDownloadedAt(.now)
+        case .didDeleteRecords(let recordIDs):
+            for recordID in recordIDs {
+                await handleRemoteDeletion(recordID: recordID)
+            }
+            await stateStore.setLastDownloadedAt(.now)
+        case .didSendRecords(let records):
+            for record in records {
+                if let envelope = CloudKitRecordCodec.envelope(from: record) {
+                    let systemFields = CloudKitRecordCodec.systemFields(for: record)
+                    await stateStore.saveShadow(
+                        SyncShadow(envelope: envelope, recordSystemFields: systemFields),
+                        for: envelope.documentID
+                    )
+                    await stateStore.removeConflict(documentID: envelope.documentID)
+                }
+            }
+            conflicts = await stateStore.conflicts()
+            await stateStore.setLastUploadedAt(.now)
+        case .didFailToSend(let failures):
+            for failure in failures {
+                await handleFailedSave(failure)
+            }
+        case .didEncounterError(let message):
+            await stateStore.setLastError(message)
+        }
+
+        status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+    }
+
+    private func applyRemoteRecord(_ record: CKRecord) async {
+        guard let remoteEnvelope = CloudKitRecordCodec.envelope(from: record) else {
+            return
+        }
+
+        let shadow = await stateStore.shadow(for: remoteEnvelope.documentID)
+        let localEnvelope = try? repository.envelope(documentID: remoteEnvelope.documentID, deviceID: deviceID)
+
+        do {
+            if let localEnvelope {
+                if localEnvelope == remoteEnvelope {
+                    await stateStore.saveShadow(
+                        SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
+                        for: remoteEnvelope.documentID
+                    )
+                    return
+                }
+
+                let merge = SyncMergeEngine.merge(
+                    base: shadow?.envelope,
+                    local: localEnvelope,
+                    remote: remoteEnvelope
+                )
+
+                try repository.apply(remote: merge.merged)
+                await stateStore.saveShadow(
+                    SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
+                    for: remoteEnvelope.documentID
+                )
+
+                if merge.conflicts.isEmpty {
+                    await stateStore.removeConflict(documentID: remoteEnvelope.documentID)
+                } else {
+                    await stateStore.saveConflict(
+                        SyncConflict(
+                            documentID: remoteEnvelope.documentID,
+                            entityType: remoteEnvelope.entityType,
+                            base: shadow?.envelope,
+                            local: localEnvelope,
+                            remote: remoteEnvelope,
+                            conflictingFields: merge.conflicts
+                        )
+                    )
+                }
+            } else {
+                try repository.apply(remote: remoteEnvelope)
+                await stateStore.saveShadow(
+                    SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
+                    for: remoteEnvelope.documentID
+                )
+            }
+        } catch {
+            await stateStore.setLastError(error.localizedDescription)
+        }
+
+        conflicts = await stateStore.conflicts()
+    }
+
+    private func handleRemoteDeletion(recordID: CKRecord.ID) async {
+        guard let localEnvelope = try? repository.envelope(documentID: recordID.recordName, deviceID: deviceID) else {
+            return
+        }
+
+        let tombstone = SyncDocumentEnvelope(
+            documentID: localEnvelope.documentID,
+            entityType: localEnvelope.entityType,
+            modifiedAt: .now,
+            authorDeviceID: localEnvelope.authorDeviceID,
+            deletedAt: .now,
+            payload: localEnvelope.payload
+        )
+
+        do {
+            try repository.apply(remote: tombstone)
+            await stateStore.saveShadow(SyncShadow(envelope: tombstone), for: tombstone.documentID)
+        } catch {
+            await stateStore.setLastError(error.localizedDescription)
+        }
+    }
+
+    private func handleFailedSave(_ failure: SyncFailedRecordSave) async {
+        switch failure.error.code {
+        case .serverRecordChanged:
+            guard let serverRecord = failure.error.serverRecord else {
+                await stateStore.setLastError(failure.error.localizedDescription)
+                return
+            }
+
+            await applyRemoteRecord(serverRecord)
+        default:
+            await stateStore.setLastError(failure.error.localizedDescription)
+        }
+    }
+
+    private func queueUnsyncedDocuments() async throws {
+        guard let provider else {
+            return
+        }
+
+        let shadows = await stateStore.shadows()
+        let conflicts = Set(await stateStore.conflicts().map(\.documentID))
+        let envelopes = try repository.allEnvelopes(deviceID: deviceID)
+
+        let pendingRecordNames = envelopes
+            .filter { !conflicts.contains($0.documentID) }
+            .filter { shadows[$0.documentID]?.envelope != $0 }
+            .map(\.documentID)
+
+        await provider.queue(recordNames: pendingRecordNames)
+    }
+
+    private func currentBaseState() -> SyncServiceState {
+        if !isEnabled {
+            return .disabled
+        }
+
+        if !conflicts.isEmpty {
+            return .conflict
+        }
+
+        return .ready
+    }
+
+    private func buildStatusSnapshot(baseState: SyncServiceState, isSyncing: Bool) async -> SyncStatusSnapshot {
+        let shadows = await stateStore.shadows()
+        let conflictList = await stateStore.conflicts()
+        let lastError = await stateStore.lastError()
+        let pendingRecordCount = await provider?.queuedChangeCount ?? 0
+        let accountState = await provider?.accountAvailability ?? (isEnabled ? .needsAttention : .disabled)
+
+        let effectiveState: SyncServiceState
+        if !isEnabled {
+            effectiveState = .disabled
+        } else if accountState == .noICloudAccount {
+            effectiveState = .noICloudAccount
+        } else if isSyncing {
+            effectiveState = .syncing
+        } else if !conflictList.isEmpty {
+            effectiveState = .conflict
+        } else if let lastError, !lastError.isEmpty {
+            effectiveState = lastError.localizedCaseInsensitiveContains("internet") ? .offline : .needsAttention
+        } else {
+            effectiveState = baseState
+        }
+
+        let localCount = (try? repository.allEnvelopes(deviceID: deviceID).count) ?? 0
+        let unsyncedCount = max(localCount - shadows.count, 0) + conflictList.count
+
+        return SyncStatusSnapshot(
+            state: effectiveState,
+            service: "iCloud",
+            queuedUpdates: pendingRecordCount,
+            unsyncedRecords: unsyncedCount,
+            lastDownloadedAt: await stateStore.lastDownloadedAt(),
+            lastUploadedAt: await stateStore.lastUploadedAt(),
+            lastError: lastError
+        )
+    }
+}
+
+@MainActor
+struct LocalSyncRepository {
+    let modelContainer: ModelContainer
+
+    func allEnvelopes(deviceID: String) throws -> [SyncDocumentEnvelope] {
+        let context = ModelContext(modelContainer)
+        let episodes = try context.fetch(FetchDescriptor<Episode>())
+        let customDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
+            .filter(\.isCustom)
+
+        return episodes.map { $0.syncEnvelope(deviceID: deviceID) } +
+            customDefinitions.map { $0.syncEnvelope(deviceID: deviceID) }
+    }
+
+    func envelope(documentID: String, deviceID: String) throws -> SyncDocumentEnvelope? {
+        let envelopes = try allEnvelopes(deviceID: deviceID)
+        return envelopes.first { $0.documentID == documentID }
+    }
+
+    func apply(remote envelope: SyncDocumentEnvelope) throws {
+        let context = ModelContext(modelContainer)
+
+        switch envelope.payload {
+        case .episode(let payload):
+            let episodeID = UUID(uuidString: payload.id) ?? UUID()
+            let existing = try context.fetch(FetchDescriptor<Episode>()).first { $0.id == episodeID }
+            let target = existing ?? Episode(
+                id: episodeID,
+                startedAt: payload.startedAt,
+                endedAt: payload.endedAt,
+                updatedAt: envelope.modifiedAt,
+                deletedAt: envelope.deletedAt,
+                type: EpisodeType(rawValue: payload.type) ?? .unclear,
+                intensity: payload.intensity
+            )
+
+            target.startedAt = payload.startedAt
+            target.endedAt = payload.endedAt
+            target.updatedAt = envelope.modifiedAt
+            target.deletedAt = envelope.deletedAt
+            target.type = EpisodeType(rawValue: payload.type) ?? .unclear
+            target.intensity = payload.intensity
+            target.painLocation = payload.painLocation
+            target.painCharacter = payload.painCharacter
+            target.notes = payload.notes
+            target.symptoms = payload.symptoms
+            target.triggers = payload.triggers
+            target.functionalImpact = payload.functionalImpact
+            target.menstruationStatus = MenstruationStatus(rawValue: payload.menstruationStatus) ?? .unknown
+
+            for medication in target.medications {
+                context.delete(medication)
+            }
+
+            if let weatherSnapshot = target.weatherSnapshot {
+                context.delete(weatherSnapshot)
+                target.weatherSnapshot = nil
+            }
+
+            target.medications = payload.medications.map { medication in
+                MedicationEntry(
+                    id: UUID(uuidString: medication.id) ?? UUID(),
+                    name: medication.name,
+                    category: MedicationCategory(rawValue: medication.category) ?? .other,
+                    dosage: medication.dosage,
+                    quantity: medication.quantity,
+                    takenAt: medication.takenAt,
+                    effectiveness: MedicationEffectiveness(rawValue: medication.effectiveness) ?? .partial,
+                    reliefStartedAt: medication.reliefStartedAt,
+                    isRepeatDose: medication.isRepeatDose,
+                    episode: target
+                )
+            }
+            target.weatherSnapshot = payload.weatherSnapshot.map { weather in
+                WeatherSnapshot(
+                    id: UUID(uuidString: weather.id) ?? UUID(),
+                    recordedAt: weather.recordedAt,
+                    temperature: weather.temperature,
+                    condition: weather.condition,
+                    humidity: weather.humidity,
+                    pressure: weather.pressure,
+                    source: weather.source,
+                    episode: target
+                )
+            }
+
+            if existing == nil {
+                context.insert(target)
+            }
+        case .medicationDefinition(let payload):
+            let existing = try context.fetch(FetchDescriptor<MedicationDefinition>()).first { $0.catalogKey == payload.catalogKey }
+            let target = existing ?? MedicationDefinition(
+                catalogKey: payload.catalogKey,
+                groupID: payload.groupID,
+                groupTitle: payload.groupTitle,
+                groupFooter: payload.groupFooter,
+                name: payload.name,
+                category: MedicationCategory(rawValue: payload.category) ?? .other,
+                suggestedDosage: payload.suggestedDosage,
+                sortOrder: payload.sortOrder,
+                isCustom: payload.isCustom,
+                createdAt: payload.createdAt,
+                updatedAt: envelope.modifiedAt,
+                deletedAt: envelope.deletedAt
+            )
+
+            target.groupID = payload.groupID
+            target.groupTitle = payload.groupTitle
+            target.groupFooter = payload.groupFooter
+            target.name = payload.name
+            target.category = MedicationCategory(rawValue: payload.category) ?? .other
+            target.suggestedDosage = payload.suggestedDosage
+            target.sortOrder = payload.sortOrder
+            target.isCustom = payload.isCustom
+            target.createdAt = payload.createdAt
+            target.updatedAt = envelope.modifiedAt
+            target.deletedAt = envelope.deletedAt
+
+            if existing == nil {
+                context.insert(target)
+            }
+        }
+
+        try context.save()
+    }
+}
+
+extension Episode {
+    func syncEnvelope(deviceID: String) -> SyncDocumentEnvelope {
+        SyncDocumentEnvelope(
+            documentID: "episode:\(id.uuidString)",
+            entityType: .episode,
+            modifiedAt: updatedAt,
+            authorDeviceID: deviceID,
+            deletedAt: deletedAt,
+            payload: .episode(
+                SyncEpisodePayload(
+                    id: id.uuidString,
+                    startedAt: startedAt,
+                    endedAt: endedAt,
+                    type: type.rawValue,
+                    intensity: intensity,
+                    painLocation: painLocation,
+                    painCharacter: painCharacter,
+                    notes: notes,
+                    symptoms: symptoms,
+                    triggers: triggers,
+                    functionalImpact: functionalImpact,
+                    menstruationStatus: menstruationStatus.rawValue,
+                    medications: medications.map {
+                        SyncMedicationEntryPayload(
+                            id: $0.id.uuidString,
+                            name: $0.name,
+                            category: $0.category.rawValue,
+                            dosage: $0.dosage,
+                            quantity: $0.quantity,
+                            takenAt: $0.takenAt,
+                            effectiveness: $0.effectiveness.rawValue,
+                            reliefStartedAt: $0.reliefStartedAt,
+                            isRepeatDose: $0.isRepeatDose
+                        )
+                    },
+                    weatherSnapshot: weatherSnapshot.map {
+                        SyncWeatherSnapshotPayload(
+                            id: $0.id.uuidString,
+                            recordedAt: $0.recordedAt,
+                            temperature: $0.temperature,
+                            condition: $0.condition,
+                            humidity: $0.humidity,
+                            pressure: $0.pressure,
+                            source: $0.source
+                        )
+                    }
+                )
+            )
+        )
+    }
+}
+
+extension MedicationDefinition {
+    func syncEnvelope(deviceID: String) -> SyncDocumentEnvelope {
+        SyncDocumentEnvelope(
+            documentID: "medicationDefinition:\(catalogKey)",
+            entityType: .medicationDefinition,
+            modifiedAt: updatedAt,
+            authorDeviceID: deviceID,
+            deletedAt: deletedAt,
+            payload: .medicationDefinition(
+                SyncMedicationDefinitionPayload(
+                    catalogKey: catalogKey,
+                    groupID: groupID,
+                    groupTitle: groupTitle,
+                    groupFooter: groupFooter,
+                    name: name,
+                    category: category.rawValue,
+                    suggestedDosage: suggestedDosage,
+                    sortOrder: sortOrder,
+                    isCustom: isCustom,
+                    createdAt: createdAt
+                )
+            )
+        )
+    }
+}

--- a/MigraineTrackerApp/Sources/Features/Sync/SyncStateStore.swift
+++ b/MigraineTrackerApp/Sources/Features/Sync/SyncStateStore.swift
@@ -1,0 +1,146 @@
+import CloudKit
+import Foundation
+
+enum SyncConfiguration {
+    static let containerIdentifier = "iCloud.eu.mpwg.MigraineTracker"
+    static let zoneName = "MigraineTrackerSync"
+    static let subscriptionID = "MigraineTrackerSyncSubscription"
+    static let recordType = "SyncDocument"
+
+    static let zoneID = CKRecordZone.ID(
+        zoneName: zoneName,
+        ownerName: CKCurrentUserDefaultName
+    )
+}
+
+actor SyncStateStore {
+    private struct PersistedSyncState: Codable {
+        var syncEnabled = false
+        var engineStateData: Data?
+        var shadows: [String: SyncShadow] = [:]
+        var conflicts: [String: SyncConflict] = [:]
+        var lastUploadedAt: Date?
+        var lastDownloadedAt: Date?
+        var lastError: String?
+    }
+
+    private let url: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private var state: PersistedSyncState
+
+    init(fileManager: FileManager = .default) {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        decoder.dateDecodingStrategy = .iso8601
+        encoder.dateEncodingStrategy = .iso8601
+
+        let baseURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        let directory = baseURL.appendingPathComponent("MigraineTracker", isDirectory: true)
+        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        self.url = directory.appendingPathComponent("sync-state.json")
+
+        if
+            let data = try? Data(contentsOf: url),
+            let persisted = try? decoder.decode(PersistedSyncState.self, from: data)
+        {
+            self.state = persisted
+        } else {
+            self.state = PersistedSyncState()
+        }
+    }
+
+    func syncEnabled() -> Bool {
+        state.syncEnabled
+    }
+
+    func setSyncEnabled(_ enabled: Bool) {
+        state.syncEnabled = enabled
+        persist()
+    }
+
+    func engineState() -> CKSyncEngine.State.Serialization? {
+        guard let data = state.engineStateData else {
+            return nil
+        }
+
+        return try? decoder.decode(CKSyncEngine.State.Serialization.self, from: data)
+    }
+
+    func saveEngineState(_ serialization: CKSyncEngine.State.Serialization) {
+        state.engineStateData = try? encoder.encode(serialization)
+        persist()
+    }
+
+    func shadows() -> [String: SyncShadow] {
+        state.shadows
+    }
+
+    func shadow(for documentID: String) -> SyncShadow? {
+        state.shadows[documentID]
+    }
+
+    func saveShadow(_ shadow: SyncShadow, for documentID: String) {
+        state.shadows[documentID] = shadow
+        persist()
+    }
+
+    func removeShadow(documentID: String) {
+        state.shadows.removeValue(forKey: documentID)
+        persist()
+    }
+
+    func conflicts() -> [SyncConflict] {
+        state.conflicts.values.sorted { $0.detectedAt > $1.detectedAt }
+    }
+
+    func saveConflict(_ conflict: SyncConflict) {
+        state.conflicts[conflict.documentID] = conflict
+        persist()
+    }
+
+    func removeConflict(documentID: String) {
+        state.conflicts.removeValue(forKey: documentID)
+        persist()
+    }
+
+    func lastUploadedAt() -> Date? {
+        state.lastUploadedAt
+    }
+
+    func setLastUploadedAt(_ date: Date?) {
+        state.lastUploadedAt = date
+        persist()
+    }
+
+    func lastDownloadedAt() -> Date? {
+        state.lastDownloadedAt
+    }
+
+    func setLastDownloadedAt(_ date: Date?) {
+        state.lastDownloadedAt = date
+        persist()
+    }
+
+    func lastError() -> String? {
+        state.lastError
+    }
+
+    func setLastError(_ error: String?) {
+        state.lastError = error
+        persist()
+    }
+
+    func clearLastError() {
+        state.lastError = nil
+        persist()
+    }
+
+    private func persist() {
+        guard let data = try? encoder.encode(state) else {
+            return
+        }
+
+        try? data.write(to: url, options: .atomic)
+    }
+}

--- a/MigraineTrackerApp/Sources/Models/EpisodeModels.swift
+++ b/MigraineTrackerApp/Sources/Models/EpisodeModels.swift
@@ -41,6 +41,8 @@ final class Episode {
     @Attribute(.unique) var id: UUID
     var startedAt: Date
     var endedAt: Date?
+    var updatedAt: Date
+    var deletedAt: Date?
     var typeRaw: String
     var intensity: Int
     var painLocation: String
@@ -61,6 +63,8 @@ final class Episode {
         id: UUID = UUID(),
         startedAt: Date,
         endedAt: Date? = nil,
+        updatedAt: Date = .now,
+        deletedAt: Date? = nil,
         type: EpisodeType = .unclear,
         intensity: Int,
         painLocation: String = "",
@@ -75,6 +79,8 @@ final class Episode {
         self.id = id
         self.startedAt = startedAt
         self.endedAt = endedAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
         self.typeRaw = type.rawValue
         self.intensity = intensity
         self.painLocation = painLocation
@@ -109,6 +115,25 @@ final class Episode {
 
     var hasWeatherSnapshot: Bool {
         weatherSnapshot != nil
+    }
+
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
+    func markUpdated(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = nil
+    }
+
+    func markDeleted(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = date
+    }
+
+    func restore(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = nil
     }
 
     private static func decodeList(_ storage: String) -> [String] {
@@ -180,6 +205,8 @@ final class MedicationDefinition {
     var sortOrder: Int
     var isCustom: Bool
     var createdAt: Date
+    var updatedAt: Date
+    var deletedAt: Date?
 
     init(
         catalogKey: String,
@@ -191,7 +218,9 @@ final class MedicationDefinition {
         suggestedDosage: String,
         sortOrder: Int,
         isCustom: Bool,
-        createdAt: Date = .now
+        createdAt: Date = .now,
+        updatedAt: Date = .now,
+        deletedAt: Date? = nil
     ) {
         self.catalogKey = catalogKey
         self.groupID = groupID
@@ -203,6 +232,8 @@ final class MedicationDefinition {
         self.sortOrder = sortOrder
         self.isCustom = isCustom
         self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
     }
 
     var category: MedicationCategory {
@@ -216,6 +247,25 @@ final class MedicationDefinition {
             category.rawValue,
             suggestedDosage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         ].joined(separator: "|")
+    }
+
+    var isDeleted: Bool {
+        deletedAt != nil
+    }
+
+    func markUpdated(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = nil
+    }
+
+    func markDeleted(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = date
+    }
+
+    func restore(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = nil
     }
 }
 

--- a/MigraineTrackerApp/Sources/Models/EpisodeModels.swift
+++ b/MigraineTrackerApp/Sources/Models/EpisodeModels.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftData
 
 enum EpisodeType: String, CaseIterable, Codable, Identifiable {
     case migraine = "Migräne"
@@ -36,30 +35,8 @@ enum MedicationEffectiveness: String, CaseIterable, Codable, Identifiable {
     var id: String { rawValue }
 }
 
-@Model
-final class Episode {
-    @Attribute(.unique) var id: UUID
-    var startedAt: Date
-    var endedAt: Date?
-    var updatedAt: Date
-    var deletedAt: Date?
-    var typeRaw: String
-    var intensity: Int
-    var painLocation: String
-    var painCharacter: String
-    var notes: String
-    var symptomsStorage: String
-    var triggersStorage: String
-    var functionalImpact: String
-    var menstruationStatusRaw: String
-
-    @Relationship(deleteRule: .cascade, inverse: \MedicationEntry.episode)
-    var medications: [MedicationEntry]
-
-    @Relationship(deleteRule: .cascade, inverse: \WeatherSnapshot.episode)
-    var weatherSnapshot: WeatherSnapshot?
-
-    init(
+extension Episode {
+    convenience init(
         id: UUID = UUID(),
         startedAt: Date,
         endedAt: Date? = nil,
@@ -76,21 +53,23 @@ final class Episode {
         menstruationStatus: MenstruationStatus = .unknown,
         medications: [MedicationEntry] = []
     ) {
-        self.id = id
-        self.startedAt = startedAt
-        self.endedAt = endedAt
-        self.updatedAt = updatedAt
-        self.deletedAt = deletedAt
-        self.typeRaw = type.rawValue
-        self.intensity = intensity
-        self.painLocation = painLocation
-        self.painCharacter = painCharacter
-        self.notes = notes
-        self.symptomsStorage = symptoms.joined(separator: "|")
-        self.triggersStorage = triggers.joined(separator: "|")
-        self.functionalImpact = functionalImpact
-        self.menstruationStatusRaw = menstruationStatus.rawValue
-        self.medications = medications
+        self.init(
+            id: id,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt,
+            typeRaw: type.rawValue,
+            intensity: intensity,
+            painLocation: painLocation,
+            painCharacter: painCharacter,
+            notes: notes,
+            symptomsStorage: symptoms.joined(separator: "|"),
+            triggersStorage: triggers.joined(separator: "|"),
+            functionalImpact: functionalImpact,
+            menstruationStatusRaw: menstruationStatus.rawValue,
+            medications: medications
+        )
     }
 
     var type: EpisodeType {
@@ -144,21 +123,8 @@ final class Episode {
     }
 }
 
-@Model
-final class MedicationEntry {
-    @Attribute(.unique) var id: UUID
-    var name: String
-    var categoryRaw: String
-    var dosage: String
-    var quantity: Int
-    var takenAt: Date
-    var effectivenessRaw: String
-    var reliefStartedAt: Date?
-    var isRepeatDose: Bool
-
-    var episode: Episode?
-
-    init(
+extension MedicationEntry {
+    convenience init(
         id: UUID = UUID(),
         name: String,
         category: MedicationCategory,
@@ -170,16 +136,18 @@ final class MedicationEntry {
         isRepeatDose: Bool = false,
         episode: Episode? = nil
     ) {
-        self.id = id
-        self.name = name
-        self.categoryRaw = category.rawValue
-        self.dosage = dosage
-        self.quantity = quantity
-        self.takenAt = takenAt
-        self.effectivenessRaw = effectiveness.rawValue
-        self.reliefStartedAt = reliefStartedAt
-        self.isRepeatDose = isRepeatDose
-        self.episode = episode
+        self.init(
+            id: id,
+            name: name,
+            categoryRaw: category.rawValue,
+            dosage: dosage,
+            quantity: quantity,
+            takenAt: takenAt,
+            effectivenessRaw: effectiveness.rawValue,
+            reliefStartedAt: reliefStartedAt,
+            isRepeatDose: isRepeatDose,
+            episode: episode
+        )
     }
 
     var category: MedicationCategory {
@@ -193,22 +161,8 @@ final class MedicationEntry {
     }
 }
 
-@Model
-final class MedicationDefinition {
-    @Attribute(.unique) var catalogKey: String
-    var groupID: String
-    var groupTitle: String
-    var groupFooter: String?
-    var name: String
-    var categoryRaw: String
-    var suggestedDosage: String
-    var sortOrder: Int
-    var isCustom: Bool
-    var createdAt: Date
-    var updatedAt: Date
-    var deletedAt: Date?
-
-    init(
+extension MedicationDefinition {
+    convenience init(
         catalogKey: String,
         groupID: String,
         groupTitle: String,
@@ -222,18 +176,20 @@ final class MedicationDefinition {
         updatedAt: Date = .now,
         deletedAt: Date? = nil
     ) {
-        self.catalogKey = catalogKey
-        self.groupID = groupID
-        self.groupTitle = groupTitle
-        self.groupFooter = groupFooter
-        self.name = name
-        self.categoryRaw = category.rawValue
-        self.suggestedDosage = suggestedDosage
-        self.sortOrder = sortOrder
-        self.isCustom = isCustom
-        self.createdAt = createdAt
-        self.updatedAt = updatedAt
-        self.deletedAt = deletedAt
+        self.init(
+            catalogKey: catalogKey,
+            groupID: groupID,
+            groupTitle: groupTitle,
+            groupFooter: groupFooter,
+            name: name,
+            categoryRaw: category.rawValue,
+            suggestedDosage: suggestedDosage,
+            sortOrder: sortOrder,
+            isCustom: isCustom,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt
+        )
     }
 
     var category: MedicationCategory {
@@ -266,38 +222,5 @@ final class MedicationDefinition {
     func restore(at date: Date = .now) {
         updatedAt = date
         deletedAt = nil
-    }
-}
-
-@Model
-final class WeatherSnapshot {
-    @Attribute(.unique) var id: UUID
-    var recordedAt: Date
-    var temperature: Double?
-    var condition: String
-    var humidity: Double?
-    var pressure: Double?
-    var source: String
-
-    var episode: Episode?
-
-    init(
-        id: UUID = UUID(),
-        recordedAt: Date,
-        temperature: Double? = nil,
-        condition: String = "",
-        humidity: Double? = nil,
-        pressure: Double? = nil,
-        source: String = "",
-        episode: Episode? = nil
-    ) {
-        self.id = id
-        self.recordedAt = recordedAt
-        self.temperature = temperature
-        self.condition = condition
-        self.humidity = humidity
-        self.pressure = pressure
-        self.source = source
-        self.episode = episode
     }
 }

--- a/MigraineTrackerApp/Sources/Models/ModelSchema.swift
+++ b/MigraineTrackerApp/Sources/Models/ModelSchema.swift
@@ -1,0 +1,399 @@
+import Foundation
+import SwiftData
+
+enum MigraineTrackerSchemaV1: VersionedSchema {
+    static let versionIdentifier = Schema.Version(1, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Episode.self,
+            MedicationEntry.self,
+            MedicationDefinition.self,
+            WeatherSnapshot.self,
+        ]
+    }
+
+    @Model
+    final class Episode {
+        @Attribute(.unique) var id: UUID
+        var startedAt: Date
+        var endedAt: Date?
+        var typeRaw: String
+        var intensity: Int
+        var painLocation: String
+        var painCharacter: String
+        var notes: String
+        var symptomsStorage: String
+        var triggersStorage: String
+        var functionalImpact: String
+        var menstruationStatusRaw: String
+
+        @Relationship(deleteRule: .cascade, inverse: \MedicationEntry.episode)
+        var medications: [MedicationEntry]
+
+        @Relationship(deleteRule: .cascade, inverse: \WeatherSnapshot.episode)
+        var weatherSnapshot: WeatherSnapshot?
+
+        init(
+            id: UUID = UUID(),
+            startedAt: Date,
+            endedAt: Date? = nil,
+            typeRaw: String,
+            intensity: Int,
+            painLocation: String = "",
+            painCharacter: String = "",
+            notes: String = "",
+            symptomsStorage: String = "",
+            triggersStorage: String = "",
+            functionalImpact: String = "",
+            menstruationStatusRaw: String = MenstruationStatus.unknown.rawValue,
+            medications: [MedicationEntry] = []
+        ) {
+            self.id = id
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.typeRaw = typeRaw
+            self.intensity = intensity
+            self.painLocation = painLocation
+            self.painCharacter = painCharacter
+            self.notes = notes
+            self.symptomsStorage = symptomsStorage
+            self.triggersStorage = triggersStorage
+            self.functionalImpact = functionalImpact
+            self.menstruationStatusRaw = menstruationStatusRaw
+            self.medications = medications
+        }
+    }
+
+    @Model
+    final class MedicationEntry {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var categoryRaw: String
+        var dosage: String
+        var quantity: Int
+        var takenAt: Date
+        var effectivenessRaw: String
+        var reliefStartedAt: Date?
+        var isRepeatDose: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            categoryRaw: String,
+            dosage: String,
+            quantity: Int = 1,
+            takenAt: Date,
+            effectivenessRaw: String,
+            reliefStartedAt: Date? = nil,
+            isRepeatDose: Bool = false,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.dosage = dosage
+            self.quantity = quantity
+            self.takenAt = takenAt
+            self.effectivenessRaw = effectivenessRaw
+            self.reliefStartedAt = reliefStartedAt
+            self.isRepeatDose = isRepeatDose
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class MedicationDefinition {
+        @Attribute(.unique) var catalogKey: String
+        var groupID: String
+        var groupTitle: String
+        var groupFooter: String?
+        var name: String
+        var categoryRaw: String
+        var suggestedDosage: String
+        var sortOrder: Int
+        var isCustom: Bool
+        var createdAt: Date
+
+        init(
+            catalogKey: String,
+            groupID: String,
+            groupTitle: String,
+            groupFooter: String? = nil,
+            name: String,
+            categoryRaw: String,
+            suggestedDosage: String,
+            sortOrder: Int,
+            isCustom: Bool,
+            createdAt: Date = .now
+        ) {
+            self.catalogKey = catalogKey
+            self.groupID = groupID
+            self.groupTitle = groupTitle
+            self.groupFooter = groupFooter
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.suggestedDosage = suggestedDosage
+            self.sortOrder = sortOrder
+            self.isCustom = isCustom
+            self.createdAt = createdAt
+        }
+    }
+
+    @Model
+    final class WeatherSnapshot {
+        @Attribute(.unique) var id: UUID
+        var recordedAt: Date
+        var temperature: Double?
+        var condition: String
+        var humidity: Double?
+        var pressure: Double?
+        var source: String
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            recordedAt: Date,
+            temperature: Double? = nil,
+            condition: String = "",
+            humidity: Double? = nil,
+            pressure: Double? = nil,
+            source: String = "",
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.recordedAt = recordedAt
+            self.temperature = temperature
+            self.condition = condition
+            self.humidity = humidity
+            self.pressure = pressure
+            self.source = source
+            self.episode = episode
+        }
+    }
+}
+
+enum MigraineTrackerSchemaV2: VersionedSchema {
+    static let versionIdentifier = Schema.Version(2, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Episode.self,
+            MedicationEntry.self,
+            MedicationDefinition.self,
+            WeatherSnapshot.self,
+        ]
+    }
+
+    @Model
+    final class Episode {
+        @Attribute(.unique) var id: UUID
+        var startedAt: Date
+        var endedAt: Date?
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+        var typeRaw: String
+        var intensity: Int
+        var painLocation: String
+        var painCharacter: String
+        var notes: String
+        var symptomsStorage: String
+        var triggersStorage: String
+        var functionalImpact: String
+        var menstruationStatusRaw: String
+
+        @Relationship(deleteRule: .cascade, inverse: \MedicationEntry.episode)
+        var medications: [MedicationEntry]
+
+        @Relationship(deleteRule: .cascade, inverse: \WeatherSnapshot.episode)
+        var weatherSnapshot: WeatherSnapshot?
+
+        init(
+            id: UUID = UUID(),
+            startedAt: Date,
+            endedAt: Date? = nil,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil,
+            typeRaw: String,
+            intensity: Int,
+            painLocation: String = "",
+            painCharacter: String = "",
+            notes: String = "",
+            symptomsStorage: String = "",
+            triggersStorage: String = "",
+            functionalImpact: String = "",
+            menstruationStatusRaw: String = MenstruationStatus.unknown.rawValue,
+            medications: [MedicationEntry] = []
+        ) {
+            self.id = id
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+            self.typeRaw = typeRaw
+            self.intensity = intensity
+            self.painLocation = painLocation
+            self.painCharacter = painCharacter
+            self.notes = notes
+            self.symptomsStorage = symptomsStorage
+            self.triggersStorage = triggersStorage
+            self.functionalImpact = functionalImpact
+            self.menstruationStatusRaw = menstruationStatusRaw
+            self.medications = medications
+        }
+    }
+
+    @Model
+    final class MedicationEntry {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var categoryRaw: String
+        var dosage: String
+        var quantity: Int
+        var takenAt: Date
+        var effectivenessRaw: String
+        var reliefStartedAt: Date?
+        var isRepeatDose: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            categoryRaw: String,
+            dosage: String,
+            quantity: Int = 1,
+            takenAt: Date,
+            effectivenessRaw: String,
+            reliefStartedAt: Date? = nil,
+            isRepeatDose: Bool = false,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.dosage = dosage
+            self.quantity = quantity
+            self.takenAt = takenAt
+            self.effectivenessRaw = effectivenessRaw
+            self.reliefStartedAt = reliefStartedAt
+            self.isRepeatDose = isRepeatDose
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class MedicationDefinition {
+        @Attribute(.unique) var catalogKey: String
+        var groupID: String
+        var groupTitle: String
+        var groupFooter: String?
+        var name: String
+        var categoryRaw: String
+        var suggestedDosage: String
+        var sortOrder: Int
+        var isCustom: Bool
+        var createdAt: Date
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+
+        init(
+            catalogKey: String,
+            groupID: String,
+            groupTitle: String,
+            groupFooter: String? = nil,
+            name: String,
+            categoryRaw: String,
+            suggestedDosage: String,
+            sortOrder: Int,
+            isCustom: Bool,
+            createdAt: Date = .now,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil
+        ) {
+            self.catalogKey = catalogKey
+            self.groupID = groupID
+            self.groupTitle = groupTitle
+            self.groupFooter = groupFooter
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.suggestedDosage = suggestedDosage
+            self.sortOrder = sortOrder
+            self.isCustom = isCustom
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+        }
+    }
+
+    @Model
+    final class WeatherSnapshot {
+        @Attribute(.unique) var id: UUID
+        var recordedAt: Date
+        var temperature: Double?
+        var condition: String
+        var humidity: Double?
+        var pressure: Double?
+        var source: String
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            recordedAt: Date,
+            temperature: Double? = nil,
+            condition: String = "",
+            humidity: Double? = nil,
+            pressure: Double? = nil,
+            source: String = "",
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.recordedAt = recordedAt
+            self.temperature = temperature
+            self.condition = condition
+            self.humidity = humidity
+            self.pressure = pressure
+            self.source = source
+            self.episode = episode
+        }
+    }
+}
+
+enum MigraineTrackerMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [
+            MigraineTrackerSchemaV1.self,
+            MigraineTrackerSchemaV2.self,
+        ]
+    }
+
+    static var stages: [MigrationStage] {
+        [
+            .custom(
+                fromVersion: MigraineTrackerSchemaV1.self,
+                toVersion: MigraineTrackerSchemaV2.self,
+                willMigrate: nil,
+                didMigrate: { context in
+                    let episodes = try context.fetch(FetchDescriptor<MigraineTrackerSchemaV2.Episode>())
+                    for episode in episodes {
+                        episode.updatedAt = episode.startedAt
+                        episode.deletedAt = nil
+                    }
+
+                    let definitions = try context.fetch(FetchDescriptor<MigraineTrackerSchemaV2.MedicationDefinition>())
+                    for definition in definitions {
+                        definition.updatedAt = definition.createdAt
+                        definition.deletedAt = nil
+                    }
+
+                    try context.save()
+                }
+            )
+        ]
+    }
+}
+
+typealias Episode = MigraineTrackerSchemaV2.Episode
+typealias MedicationEntry = MigraineTrackerSchemaV2.MedicationEntry
+typealias MedicationDefinition = MigraineTrackerSchemaV2.MedicationDefinition
+typealias WeatherSnapshot = MigraineTrackerSchemaV2.WeatherSnapshot

--- a/MigraineTrackerApp/Sources/Shared/SyncCore.swift
+++ b/MigraineTrackerApp/Sources/Shared/SyncCore.swift
@@ -16,7 +16,7 @@ public enum SyncServiceState: String, Codable, CaseIterable, Sendable {
         case .ready:
             "Bereit"
         case .syncing:
-            "Synchronisiert"
+            "Synchronisiert gerade"
         case .needsAttention:
             "Aktion nötig"
         case .conflict:

--- a/MigraineTrackerApp/Sources/Shared/SyncCore.swift
+++ b/MigraineTrackerApp/Sources/Shared/SyncCore.swift
@@ -1,0 +1,602 @@
+import Foundation
+
+public enum SyncServiceState: String, Codable, CaseIterable, Sendable {
+    case disabled
+    case ready
+    case syncing
+    case needsAttention
+    case conflict
+    case noICloudAccount
+    case offline
+
+    public var displayTitle: String {
+        switch self {
+        case .disabled:
+            "Deaktiviert"
+        case .ready:
+            "Bereit"
+        case .syncing:
+            "Synchronisiert"
+        case .needsAttention:
+            "Aktion nötig"
+        case .conflict:
+            "Konflikt"
+        case .noICloudAccount:
+            "Kein iCloud-Account"
+        case .offline:
+            "Offline"
+        }
+    }
+}
+
+public enum SyncEntityType: String, Codable, CaseIterable, Sendable {
+    case episode
+    case medicationDefinition
+}
+
+public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
+    public var state: SyncServiceState
+    public var service: String
+    public var queuedUpdates: Int
+    public var unsyncedRecords: Int
+    public var lastDownloadedAt: Date?
+    public var lastUploadedAt: Date?
+    public var lastError: String?
+
+    public init(
+        state: SyncServiceState = .disabled,
+        service: String = "iCloud",
+        queuedUpdates: Int = 0,
+        unsyncedRecords: Int = 0,
+        lastDownloadedAt: Date? = nil,
+        lastUploadedAt: Date? = nil,
+        lastError: String? = nil
+    ) {
+        self.state = state
+        self.service = service
+        self.queuedUpdates = queuedUpdates
+        self.unsyncedRecords = unsyncedRecords
+        self.lastDownloadedAt = lastDownloadedAt
+        self.lastUploadedAt = lastUploadedAt
+        self.lastError = lastError
+    }
+}
+
+public struct SyncDocumentEnvelope: Codable, Equatable, Sendable {
+    public var documentID: String
+    public var entityType: SyncEntityType
+    public var schemaVersion: Int
+    public var modifiedAt: Date
+    public var authorDeviceID: String
+    public var deletedAt: Date?
+    public var payload: Payload
+
+    public init(
+        documentID: String,
+        entityType: SyncEntityType,
+        schemaVersion: Int = 1,
+        modifiedAt: Date,
+        authorDeviceID: String,
+        deletedAt: Date? = nil,
+        payload: Payload
+    ) {
+        self.documentID = documentID
+        self.entityType = entityType
+        self.schemaVersion = schemaVersion
+        self.modifiedAt = modifiedAt
+        self.authorDeviceID = authorDeviceID
+        self.deletedAt = deletedAt
+        self.payload = payload
+    }
+
+    public enum Payload: Codable, Equatable, Sendable {
+        case episode(SyncEpisodePayload)
+        case medicationDefinition(SyncMedicationDefinitionPayload)
+
+        private enum CodingKeys: String, CodingKey {
+            case episode
+            case medicationDefinition
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let episode = try container.decodeIfPresent(SyncEpisodePayload.self, forKey: .episode) {
+                self = .episode(episode)
+                return
+            }
+
+            if let definition = try container.decodeIfPresent(SyncMedicationDefinitionPayload.self, forKey: .medicationDefinition) {
+                self = .medicationDefinition(definition)
+                return
+            }
+
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Unbekannte Sync-Payload."
+                )
+            )
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .episode(let payload):
+                try container.encode(payload, forKey: .episode)
+            case .medicationDefinition(let payload):
+                try container.encode(payload, forKey: .medicationDefinition)
+            }
+        }
+    }
+}
+
+public struct SyncEpisodePayload: Codable, Equatable, Sendable {
+    public var id: String
+    public var startedAt: Date
+    public var endedAt: Date?
+    public var type: String
+    public var intensity: Int
+    public var painLocation: String
+    public var painCharacter: String
+    public var notes: String
+    public var symptoms: [String]
+    public var triggers: [String]
+    public var functionalImpact: String
+    public var menstruationStatus: String
+    public var medications: [SyncMedicationEntryPayload]
+    public var weatherSnapshot: SyncWeatherSnapshotPayload?
+
+    public init(
+        id: String,
+        startedAt: Date,
+        endedAt: Date?,
+        type: String,
+        intensity: Int,
+        painLocation: String,
+        painCharacter: String,
+        notes: String,
+        symptoms: [String],
+        triggers: [String],
+        functionalImpact: String,
+        menstruationStatus: String,
+        medications: [SyncMedicationEntryPayload],
+        weatherSnapshot: SyncWeatherSnapshotPayload?
+    ) {
+        self.id = id
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.type = type
+        self.intensity = intensity
+        self.painLocation = painLocation
+        self.painCharacter = painCharacter
+        self.notes = notes
+        self.symptoms = symptoms
+        self.triggers = triggers
+        self.functionalImpact = functionalImpact
+        self.menstruationStatus = menstruationStatus
+        self.medications = medications
+        self.weatherSnapshot = weatherSnapshot
+    }
+}
+
+public struct SyncMedicationEntryPayload: Codable, Equatable, Sendable {
+    public var id: String
+    public var name: String
+    public var category: String
+    public var dosage: String
+    public var quantity: Int
+    public var takenAt: Date
+    public var effectiveness: String
+    public var reliefStartedAt: Date?
+    public var isRepeatDose: Bool
+
+    public init(
+        id: String,
+        name: String,
+        category: String,
+        dosage: String,
+        quantity: Int,
+        takenAt: Date,
+        effectiveness: String,
+        reliefStartedAt: Date?,
+        isRepeatDose: Bool
+    ) {
+        self.id = id
+        self.name = name
+        self.category = category
+        self.dosage = dosage
+        self.quantity = quantity
+        self.takenAt = takenAt
+        self.effectiveness = effectiveness
+        self.reliefStartedAt = reliefStartedAt
+        self.isRepeatDose = isRepeatDose
+    }
+}
+
+public struct SyncWeatherSnapshotPayload: Codable, Equatable, Sendable {
+    public var id: String
+    public var recordedAt: Date
+    public var temperature: Double?
+    public var condition: String
+    public var humidity: Double?
+    public var pressure: Double?
+    public var source: String
+
+    public init(
+        id: String,
+        recordedAt: Date,
+        temperature: Double?,
+        condition: String,
+        humidity: Double?,
+        pressure: Double?,
+        source: String
+    ) {
+        self.id = id
+        self.recordedAt = recordedAt
+        self.temperature = temperature
+        self.condition = condition
+        self.humidity = humidity
+        self.pressure = pressure
+        self.source = source
+    }
+}
+
+public struct SyncMedicationDefinitionPayload: Codable, Equatable, Sendable {
+    public var catalogKey: String
+    public var groupID: String
+    public var groupTitle: String
+    public var groupFooter: String?
+    public var name: String
+    public var category: String
+    public var suggestedDosage: String
+    public var sortOrder: Int
+    public var isCustom: Bool
+    public var createdAt: Date
+
+    public init(
+        catalogKey: String,
+        groupID: String,
+        groupTitle: String,
+        groupFooter: String?,
+        name: String,
+        category: String,
+        suggestedDosage: String,
+        sortOrder: Int,
+        isCustom: Bool,
+        createdAt: Date
+    ) {
+        self.catalogKey = catalogKey
+        self.groupID = groupID
+        self.groupTitle = groupTitle
+        self.groupFooter = groupFooter
+        self.name = name
+        self.category = category
+        self.suggestedDosage = suggestedDosage
+        self.sortOrder = sortOrder
+        self.isCustom = isCustom
+        self.createdAt = createdAt
+    }
+}
+
+public struct SyncShadow: Codable, Equatable, Sendable {
+    public var envelope: SyncDocumentEnvelope
+    public var recordSystemFields: Data?
+
+    public init(envelope: SyncDocumentEnvelope, recordSystemFields: Data? = nil) {
+        self.envelope = envelope
+        self.recordSystemFields = recordSystemFields
+    }
+}
+
+public struct SyncConflict: Codable, Equatable, Identifiable, Sendable {
+    public var id: String { documentID }
+    public var documentID: String
+    public var entityType: SyncEntityType
+    public var base: SyncDocumentEnvelope?
+    public var local: SyncDocumentEnvelope
+    public var remote: SyncDocumentEnvelope
+    public var conflictingFields: [String]
+    public var detectedAt: Date
+
+    public init(
+        documentID: String,
+        entityType: SyncEntityType,
+        base: SyncDocumentEnvelope?,
+        local: SyncDocumentEnvelope,
+        remote: SyncDocumentEnvelope,
+        conflictingFields: [String],
+        detectedAt: Date = .now
+    ) {
+        self.documentID = documentID
+        self.entityType = entityType
+        self.base = base
+        self.local = local
+        self.remote = remote
+        self.conflictingFields = conflictingFields
+        self.detectedAt = detectedAt
+    }
+}
+
+public struct SyncMergeResult: Equatable, Sendable {
+    public var merged: SyncDocumentEnvelope
+    public var conflicts: [String]
+
+    public init(merged: SyncDocumentEnvelope, conflicts: [String]) {
+        self.merged = merged
+        self.conflicts = conflicts
+    }
+}
+
+public enum SyncMergeEngine {
+    public static func merge(
+        base: SyncDocumentEnvelope?,
+        local: SyncDocumentEnvelope,
+        remote: SyncDocumentEnvelope
+    ) -> SyncMergeResult {
+        precondition(local.documentID == remote.documentID, "Dokument-IDs müssen übereinstimmen.")
+        precondition(local.entityType == remote.entityType, "Entitätstypen müssen übereinstimmen.")
+
+        let conflicts: [String]
+        let payload: SyncDocumentEnvelope.Payload
+
+        switch (local.payload, remote.payload) {
+        case (.episode(let localPayload), .episode(let remotePayload)):
+            let basePayload = base?.payload.episodePayload
+            let result = mergeEpisode(base: basePayload, local: localPayload, remote: remotePayload)
+            payload = .episode(result.payload)
+            conflicts = result.conflicts
+        case (.medicationDefinition(let localPayload), .medicationDefinition(let remotePayload)):
+            let basePayload = base?.payload.medicationDefinitionPayload
+            let result = mergeMedicationDefinition(base: basePayload, local: localPayload, remote: remotePayload)
+            payload = .medicationDefinition(result.payload)
+            conflicts = result.conflicts
+        default:
+            payload = local.payload
+            conflicts = ["payload"]
+        }
+
+        let deletedAt = mergedValue(field: "deletedAt", base: base?.deletedAt, local: local.deletedAt, remote: remote.deletedAt).value
+        let modifiedAt = max(local.modifiedAt, remote.modifiedAt)
+
+        return SyncMergeResult(
+            merged: SyncDocumentEnvelope(
+                documentID: local.documentID,
+                entityType: local.entityType,
+                schemaVersion: max(local.schemaVersion, remote.schemaVersion),
+                modifiedAt: modifiedAt,
+                authorDeviceID: local.authorDeviceID,
+                deletedAt: deletedAt,
+                payload: payload
+            ),
+            conflicts: conflicts
+        )
+    }
+
+    private static func mergeEpisode(
+        base: SyncEpisodePayload?,
+        local: SyncEpisodePayload,
+        remote: SyncEpisodePayload
+    ) -> (payload: SyncEpisodePayload, conflicts: [String]) {
+        var conflicts: [String] = []
+
+        let startedAt = mergedValue(field: "startedAt", base: base?.startedAt, local: local.startedAt, remote: remote.startedAt, conflicts: &conflicts).value
+        let endedAt = mergedValue(field: "endedAt", base: base?.endedAt, local: local.endedAt, remote: remote.endedAt, conflicts: &conflicts).value
+        let type = mergedValue(field: "type", base: base?.type, local: local.type, remote: remote.type, conflicts: &conflicts).value
+        let intensity = mergedValue(field: "intensity", base: base?.intensity, local: local.intensity, remote: remote.intensity, conflicts: &conflicts).value
+        let painLocation = mergedValue(field: "painLocation", base: base?.painLocation, local: local.painLocation, remote: remote.painLocation, conflicts: &conflicts).value
+        let painCharacter = mergedValue(field: "painCharacter", base: base?.painCharacter, local: local.painCharacter, remote: remote.painCharacter, conflicts: &conflicts).value
+        let notes = mergedValue(field: "notes", base: base?.notes, local: local.notes, remote: remote.notes, conflicts: &conflicts).value
+        let symptoms = mergedValue(field: "symptoms", base: base?.symptoms, local: local.symptoms, remote: remote.symptoms, conflicts: &conflicts).value
+        let triggers = mergedValue(field: "triggers", base: base?.triggers, local: local.triggers, remote: remote.triggers, conflicts: &conflicts).value
+        let functionalImpact = mergedValue(field: "functionalImpact", base: base?.functionalImpact, local: local.functionalImpact, remote: remote.functionalImpact, conflicts: &conflicts).value
+        let menstruationStatus = mergedValue(field: "menstruationStatus", base: base?.menstruationStatus, local: local.menstruationStatus, remote: remote.menstruationStatus, conflicts: &conflicts).value
+
+        let medications = mergeMedicationEntries(
+            base: index(base?.medications ?? []),
+            local: index(local.medications),
+            remote: index(remote.medications),
+            conflicts: &conflicts
+        )
+
+        let weather = mergeWeather(
+            base: base?.weatherSnapshot,
+            local: local.weatherSnapshot,
+            remote: remote.weatherSnapshot,
+            conflicts: &conflicts
+        )
+
+        return (
+            SyncEpisodePayload(
+                id: local.id,
+                startedAt: startedAt,
+                endedAt: endedAt,
+                type: type,
+                intensity: intensity,
+                painLocation: painLocation,
+                painCharacter: painCharacter,
+                notes: notes,
+                symptoms: symptoms,
+                triggers: triggers,
+                functionalImpact: functionalImpact,
+                menstruationStatus: menstruationStatus,
+                medications: medications.sorted { $0.takenAt < $1.takenAt },
+                weatherSnapshot: weather
+            ),
+            conflicts
+        )
+    }
+
+    private static func mergeMedicationDefinition(
+        base: SyncMedicationDefinitionPayload?,
+        local: SyncMedicationDefinitionPayload,
+        remote: SyncMedicationDefinitionPayload
+    ) -> (payload: SyncMedicationDefinitionPayload, conflicts: [String]) {
+        var conflicts: [String] = []
+
+        return (
+            SyncMedicationDefinitionPayload(
+                catalogKey: local.catalogKey,
+                groupID: mergedValue(field: "groupID", base: base?.groupID, local: local.groupID, remote: remote.groupID, conflicts: &conflicts).value,
+                groupTitle: mergedValue(field: "groupTitle", base: base?.groupTitle, local: local.groupTitle, remote: remote.groupTitle, conflicts: &conflicts).value,
+                groupFooter: mergedValue(field: "groupFooter", base: base?.groupFooter, local: local.groupFooter, remote: remote.groupFooter, conflicts: &conflicts).value,
+                name: mergedValue(field: "name", base: base?.name, local: local.name, remote: remote.name, conflicts: &conflicts).value,
+                category: mergedValue(field: "category", base: base?.category, local: local.category, remote: remote.category, conflicts: &conflicts).value,
+                suggestedDosage: mergedValue(field: "suggestedDosage", base: base?.suggestedDosage, local: local.suggestedDosage, remote: remote.suggestedDosage, conflicts: &conflicts).value,
+                sortOrder: mergedValue(field: "sortOrder", base: base?.sortOrder, local: local.sortOrder, remote: remote.sortOrder, conflicts: &conflicts).value,
+                isCustom: mergedValue(field: "isCustom", base: base?.isCustom, local: local.isCustom, remote: remote.isCustom, conflicts: &conflicts).value,
+                createdAt: mergedValue(field: "createdAt", base: base?.createdAt, local: local.createdAt, remote: remote.createdAt, conflicts: &conflicts).value
+            ),
+            conflicts
+        )
+    }
+
+    private static func mergeMedicationEntries(
+        base: [String: SyncMedicationEntryPayload],
+        local: [String: SyncMedicationEntryPayload],
+        remote: [String: SyncMedicationEntryPayload],
+        conflicts: inout [String]
+    ) -> [SyncMedicationEntryPayload] {
+        let ids = Set(base.keys).union(local.keys).union(remote.keys)
+
+        return ids.compactMap { id in
+            switch (base[id], local[id], remote[id]) {
+            case let (base?, local?, remote?):
+                let merged = SyncMedicationEntryPayload(
+                    id: id,
+                    name: mergedValue(field: "medications.\(id).name", base: base.name, local: local.name, remote: remote.name, conflicts: &conflicts).value,
+                    category: mergedValue(field: "medications.\(id).category", base: base.category, local: local.category, remote: remote.category, conflicts: &conflicts).value,
+                    dosage: mergedValue(field: "medications.\(id).dosage", base: base.dosage, local: local.dosage, remote: remote.dosage, conflicts: &conflicts).value,
+                    quantity: mergedValue(field: "medications.\(id).quantity", base: base.quantity, local: local.quantity, remote: remote.quantity, conflicts: &conflicts).value,
+                    takenAt: mergedValue(field: "medications.\(id).takenAt", base: base.takenAt, local: local.takenAt, remote: remote.takenAt, conflicts: &conflicts).value,
+                    effectiveness: mergedValue(field: "medications.\(id).effectiveness", base: base.effectiveness, local: local.effectiveness, remote: remote.effectiveness, conflicts: &conflicts).value,
+                    reliefStartedAt: mergedValue(field: "medications.\(id).reliefStartedAt", base: base.reliefStartedAt, local: local.reliefStartedAt, remote: remote.reliefStartedAt, conflicts: &conflicts).value,
+                    isRepeatDose: mergedValue(field: "medications.\(id).isRepeatDose", base: base.isRepeatDose, local: local.isRepeatDose, remote: remote.isRepeatDose, conflicts: &conflicts).value
+                )
+                return merged
+            case let (nil, local?, nil):
+                return local
+            case let (nil, nil, remote?):
+                return remote
+            case let (nil, local?, remote?):
+                if local == remote {
+                    return local
+                }
+                conflicts.append("medications.\(id)")
+                return local
+            case let (base?, local?, nil):
+                if local == base {
+                    return nil
+                }
+                return local
+            case let (base?, nil, remote?):
+                if remote == base {
+                    return nil
+                }
+                return remote
+            default:
+                return nil
+            }
+        }
+    }
+
+    private static func mergeWeather(
+        base: SyncWeatherSnapshotPayload?,
+        local: SyncWeatherSnapshotPayload?,
+        remote: SyncWeatherSnapshotPayload?,
+        conflicts: inout [String]
+    ) -> SyncWeatherSnapshotPayload? {
+        switch (base, local, remote) {
+        case let (base?, local?, remote?):
+            return SyncWeatherSnapshotPayload(
+                id: local.id,
+                recordedAt: mergedValue(field: "weather.recordedAt", base: base.recordedAt, local: local.recordedAt, remote: remote.recordedAt, conflicts: &conflicts).value,
+                temperature: mergedValue(field: "weather.temperature", base: base.temperature, local: local.temperature, remote: remote.temperature, conflicts: &conflicts).value,
+                condition: mergedValue(field: "weather.condition", base: base.condition, local: local.condition, remote: remote.condition, conflicts: &conflicts).value,
+                humidity: mergedValue(field: "weather.humidity", base: base.humidity, local: local.humidity, remote: remote.humidity, conflicts: &conflicts).value,
+                pressure: mergedValue(field: "weather.pressure", base: base.pressure, local: local.pressure, remote: remote.pressure, conflicts: &conflicts).value,
+                source: mergedValue(field: "weather.source", base: base.source, local: local.source, remote: remote.source, conflicts: &conflicts).value
+            )
+        case let (nil, local?, nil):
+            return local
+        case let (nil, nil, remote?):
+            return remote
+        case let (nil, local?, remote?):
+            if local == remote {
+                return local
+            }
+            conflicts.append("weather")
+            return local
+        case let (base?, local?, nil):
+            return local == base ? nil : local
+        case let (base?, nil, remote?):
+            return remote == base ? nil : remote
+        default:
+            return nil
+        }
+    }
+
+    private static func index(_ entries: [SyncMedicationEntryPayload]) -> [String: SyncMedicationEntryPayload] {
+        Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+    }
+
+    private static func mergedValue<T: Equatable>(
+        field: String,
+        base: T?,
+        local: T,
+        remote: T,
+        conflicts: inout [String]
+    ) -> (value: T, conflict: Bool) {
+        let result = mergedValue(field: field, base: base, local: local, remote: remote)
+        if result.conflict {
+            conflicts.append(field)
+        }
+        return result
+    }
+
+    private static func mergedValue<T: Equatable>(
+        field _: String,
+        base: T?,
+        local: T,
+        remote: T
+    ) -> (value: T, conflict: Bool) {
+        if local == remote {
+            return (local, false)
+        }
+
+        guard let base else {
+            return (local, true)
+        }
+
+        let localChanged = local != base
+        let remoteChanged = remote != base
+
+        switch (localChanged, remoteChanged) {
+        case (true, false):
+            return (local, false)
+        case (false, true):
+            return (remote, false)
+        case (false, false):
+            return (local, false)
+        case (true, true):
+            return (local, true)
+        }
+    }
+}
+
+private extension SyncDocumentEnvelope.Payload {
+    var episodePayload: SyncEpisodePayload? {
+        guard case .episode(let payload) = self else {
+            return nil
+        }
+
+        return payload
+    }
+
+    var medicationDefinitionPayload: SyncMedicationDefinitionPayload? {
+        guard case .medicationDefinition(let payload) = self else {
+            return nil
+        }
+
+        return payload
+    }
+}

--- a/Tests/MigraineTrackerCoreTests/SyncMergeEngineTests.swift
+++ b/Tests/MigraineTrackerCoreTests/SyncMergeEngineTests.swift
@@ -1,0 +1,184 @@
+import Foundation
+import Testing
+@testable import MigraineTrackerCore
+
+struct SyncMergeEngineTests {
+    @Test
+    func remoteOnlyChangeIsApplied() {
+        let base = episodeEnvelope(notes: "alt", symptoms: ["Aura"])
+        let local = base
+        let remote = episodeEnvelope(notes: "neu", symptoms: ["Aura"])
+
+        let result = SyncMergeEngine.merge(base: base, local: local, remote: remote)
+
+        #expect(result.conflicts.isEmpty)
+        #expect(result.merged.payload.episodePayload?.notes == "neu")
+    }
+
+    @Test
+    func differentFieldsMergeWithoutConflict() {
+        let base = episodeEnvelope(notes: "alt", symptoms: ["Aura"])
+        let local = episodeEnvelope(notes: "lokal", symptoms: ["Aura"])
+        let remote = episodeEnvelope(notes: "alt", symptoms: ["Aura", "Übelkeit"])
+
+        let result = SyncMergeEngine.merge(base: base, local: local, remote: remote)
+
+        #expect(result.conflicts.isEmpty)
+        #expect(result.merged.payload.episodePayload?.notes == "lokal")
+        #expect(result.merged.payload.episodePayload?.symptoms == ["Aura", "Übelkeit"])
+    }
+
+    @Test
+    func sameFieldConflictIsReported() {
+        let base = episodeEnvelope(notes: "alt", symptoms: ["Aura"])
+        let local = episodeEnvelope(notes: "lokal", symptoms: ["Aura"])
+        let remote = episodeEnvelope(notes: "remote", symptoms: ["Aura"])
+
+        let result = SyncMergeEngine.merge(base: base, local: local, remote: remote)
+
+        #expect(result.conflicts == ["notes"])
+        #expect(result.merged.payload.episodePayload?.notes == "lokal")
+    }
+
+    @Test
+    func medicationEntriesMergeByStableIdentifier() {
+        let base = episodeEnvelope(
+            notes: "alt",
+            symptoms: [],
+            medications: [
+                .init(
+                    id: "med-1",
+                    name: "Ibuprofen",
+                    category: "NSAR",
+                    dosage: "400 mg",
+                    quantity: 1,
+                    takenAt: .distantPast,
+                    effectiveness: "Teilweise",
+                    reliefStartedAt: nil,
+                    isRepeatDose: false
+                )
+            ]
+        )
+
+        let local = episodeEnvelope(
+            notes: "alt",
+            symptoms: [],
+            medications: [
+                .init(
+                    id: "med-1",
+                    name: "Ibuprofen",
+                    category: "NSAR",
+                    dosage: "600 mg",
+                    quantity: 1,
+                    takenAt: .distantPast,
+                    effectiveness: "Teilweise",
+                    reliefStartedAt: nil,
+                    isRepeatDose: false
+                )
+            ]
+        )
+
+        let remote = episodeEnvelope(
+            notes: "alt",
+            symptoms: [],
+            medications: [
+                .init(
+                    id: "med-1",
+                    name: "Ibuprofen",
+                    category: "NSAR",
+                    dosage: "400 mg",
+                    quantity: 2,
+                    takenAt: .distantPast,
+                    effectiveness: "Teilweise",
+                    reliefStartedAt: nil,
+                    isRepeatDose: false
+                )
+            ]
+        )
+
+        let result = SyncMergeEngine.merge(base: base, local: local, remote: remote)
+        let medication = result.merged.payload.episodePayload?.medications.first
+
+        #expect(result.conflicts.isEmpty)
+        #expect(medication?.dosage == "600 mg")
+        #expect(medication?.quantity == 2)
+    }
+
+    @Test
+    func deleteMarkerMergesFromRemote() {
+        let base = definitionEnvelope(name: "Sumatriptan", deletedAt: nil)
+        let local = definitionEnvelope(name: "Sumatriptan", deletedAt: nil)
+        let remoteDeletionDate = Date(timeIntervalSince1970: 100)
+        let remote = definitionEnvelope(name: "Sumatriptan", deletedAt: remoteDeletionDate)
+
+        let result = SyncMergeEngine.merge(base: base, local: local, remote: remote)
+
+        #expect(result.conflicts.isEmpty)
+        #expect(result.merged.deletedAt == remoteDeletionDate)
+    }
+}
+
+private func episodeEnvelope(
+    notes: String,
+    symptoms: [String],
+        medications: [SyncMedicationEntryPayload] = []
+) -> SyncDocumentEnvelope {
+    SyncDocumentEnvelope(
+        documentID: "episode-1",
+        entityType: .episode,
+        modifiedAt: .now,
+        authorDeviceID: "device-a",
+        payload: .episode(
+            SyncEpisodePayload(
+                id: "episode-1",
+                startedAt: .distantPast,
+                endedAt: nil,
+                type: "Migräne",
+                intensity: 6,
+                painLocation: "links",
+                painCharacter: "pochend",
+                notes: notes,
+                symptoms: symptoms,
+                triggers: [],
+                functionalImpact: "",
+                menstruationStatus: "Nicht angegeben",
+                medications: medications,
+                weatherSnapshot: nil
+            )
+        )
+    )
+}
+
+private func definitionEnvelope(name: String, deletedAt: Date?) -> SyncDocumentEnvelope {
+    SyncDocumentEnvelope(
+        documentID: "definition-1",
+        entityType: .medicationDefinition,
+        modifiedAt: .now,
+        authorDeviceID: "device-a",
+        deletedAt: deletedAt,
+        payload: .medicationDefinition(
+            SyncMedicationDefinitionPayload(
+                catalogKey: "custom:1",
+                groupID: "custom",
+                groupTitle: "Eigene Medikamente",
+                groupFooter: nil,
+                name: name,
+                category: "Triptan",
+                suggestedDosage: "50 mg",
+                sortOrder: 1,
+                isCustom: true,
+                createdAt: .distantPast
+            )
+        )
+    )
+}
+
+private extension SyncDocumentEnvelope.Payload {
+    var episodePayload: SyncEpisodePayload? {
+        guard case .episode(let payload) = self else {
+            return nil
+        }
+
+        return payload
+    }
+}


### PR DESCRIPTION
## Was geändert wurde
- führt eine getrennte, local-first Sync-Schicht ein, statt SwiftData direkt zu synchronisieren
- ergänzt einen CloudKit-Provider auf Basis von `CKSyncEngine`, persistentem Sync-State, Shadow-Copies und Konflikterfassung
- erweitert die App um `Sync & Datenexport` mit Statusseite, manuellem Toggle, Cloud-Verwaltung, Konfliktauflösung und Papierkorb
- stellt lokale Soft Deletes und JSON5-Backup/Import so um, dass gelöschte und synchronisierte Daten verlustarm erhalten bleiben

## Warum
Für mehrere Geräte braucht die App eine robuste Synchronisation mit klarer Trennung zwischen lokalem Primärspeicher und Cloud-Replikation. Das Ziel hier ist maximale Datenhaltbarkeit: keine stille Überschreibung, keine harte Kopplung an SwiftData-Cloud-Sync und eine Architektur, die später auf andere Sync-Provider erweitert werden kann.

## Auswirkungen
- SwiftData bleibt lokal führend; synchronisiert werden eigene Sync-Dokumente.
- Löschungen landen zuerst im Papierkorb und werden als Tombstones synchronisiert.
- Paralleländerungen werden per Drei-Wege-Merge zusammengeführt; echte Konflikte werden sichtbar gemacht.
- iCloud/CloudKit ist vorbereitet, aber die App bleibt ohne iCloud vollständig lokal benutzbar.

## Validierung
- `swift test`
- `xcodebuild -project MigraineTracker.xcodeproj -scheme MigraineTrackerApp -destination 'platform=iOS Simulator,name=iPhone 17' build`

## Hinweis
Ich mache direkt im Anschluss noch Feinschliff auf demselben Branch/PR.