### PR TITLE
Add detailed sync logging and log viewer

### DIFF
--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -127,8 +127,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_ENTITLEMENTS = MigraineTrackerApp/MigraineTrackerApp.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = PZV43D6HWT;
 				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
@@ -156,8 +156,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_ENTITLEMENTS = MigraineTrackerApp/MigraineTrackerApp.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = PZV43D6HWT;
 				INFOPLIST_FILE = MigraineTrackerApp/Info.plist;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;

--- a/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
+++ b/MigraineTrackerApp/Sources/App/MigraineTrackerApp.swift
@@ -4,7 +4,9 @@ import SwiftData
 @main
 struct MigraineTrackerApp: App {
     private let modelContainer: ModelContainer
+    private let appLogStore: AppLogStore
     @StateObject private var syncCoordinator: SyncCoordinator
+    @StateObject private var appLogViewModel: AppLogViewModel
 
     init() {
         let schema = Schema(versionedSchema: MigraineTrackerSchemaV2.self)
@@ -23,7 +25,10 @@ struct MigraineTrackerApp: App {
             )
             MedicationCatalog.importSeedDataIfNeeded(into: container)
             self.modelContainer = container
-            _syncCoordinator = StateObject(wrappedValue: SyncCoordinator(modelContainer: container))
+            let appLogStore = AppLogStore()
+            self.appLogStore = appLogStore
+            _syncCoordinator = StateObject(wrappedValue: SyncCoordinator(modelContainer: container, appLogStore: appLogStore))
+            _appLogViewModel = StateObject(wrappedValue: AppLogViewModel(store: appLogStore))
         } catch {
             fatalError("ModelContainer konnte nicht erstellt werden: \(error)")
         }
@@ -33,6 +38,7 @@ struct MigraineTrackerApp: App {
         WindowGroup {
             AppShellView()
                 .environmentObject(syncCoordinator)
+                .environmentObject(appLogViewModel)
         }
         .modelContainer(modelContainer)
     }

--- a/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/ExportView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ExportView: View {
     @EnvironmentObject private var syncCoordinator: SyncCoordinator
+    @EnvironmentObject private var appLogViewModel: AppLogViewModel
     @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
     @Query(sort: [SortDescriptor(\MedicationDefinition.name)]) private var storedDefinitions: [MedicationDefinition]
 
@@ -43,6 +44,17 @@ struct ExportView: View {
                 } label: {
                     Label("Cloud-Daten verwalten", systemImage: "icloud")
                 }
+
+                NavigationLink {
+                    SyncLogView()
+                } label: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label("Sync-Protokoll", systemImage: "text.document")
+                        Text(logSubtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
             } header: {
                 Text("Synchronisation")
             }
@@ -67,9 +79,11 @@ struct ExportView: View {
         .navigationTitle("Sync & Datenexport")
         .task {
             syncCoordinator.refreshStatus()
+            appLogViewModel.refresh(limit: 1)
         }
         .refreshable {
             syncCoordinator.refreshStatus()
+            appLogViewModel.refresh(limit: 1)
         }
     }
 
@@ -129,6 +143,14 @@ struct ExportView: View {
 
     private func formatted(_ date: Date) -> String {
         date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    private var logSubtitle: String {
+        if let latest = appLogViewModel.entries.first {
+            return "Letzter Eintrag: \(formatted(latest.timestamp))"
+        }
+
+        return "Ansehen, teilen und bei Bedarf löschen."
     }
 }
 

--- a/MigraineTrackerApp/Sources/Features/Export/SyncLogView.swift
+++ b/MigraineTrackerApp/Sources/Features/Export/SyncLogView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+@MainActor
+final class AppLogViewModel: ObservableObject {
+    @Published private(set) var entries: [AppLogEntry] = []
+    @Published var filter: AppLogFilter = .all
+    @Published private(set) var shareURL: URL?
+
+    private let store: AppLogStore
+
+    init(store: AppLogStore) {
+        self.store = store
+    }
+
+    func refresh(limit: Int = 200) {
+        Task {
+            let entries = await store.recentEntries(filter: filter, limit: limit)
+            let shareURL = await store.exportLogFileURL(filter: filter)
+            await MainActor.run {
+                self.entries = entries
+                self.shareURL = shareURL
+            }
+        }
+    }
+
+    func updateFilter(_ filter: AppLogFilter) {
+        self.filter = filter
+        refresh()
+    }
+
+    func clear() {
+        Task {
+            await store.clear()
+            await MainActor.run {
+                self.entries = []
+                self.shareURL = nil
+            }
+        }
+    }
+}
+
+struct SyncLogView: View {
+    @EnvironmentObject private var appLogViewModel: AppLogViewModel
+
+    var body: some View {
+        List {
+            Section {
+                Text("Das Protokoll bleibt lokal auf diesem Gerät. Es enthält technische Metadaten zu Synchronisation, Konflikten und Fehlern, aber keine sensiblen Freitextinhalte im Klartext.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Filter") {
+                Picker("Ansicht", selection: filterBinding) {
+                    Text("Alle").tag(AppLogFilter.all)
+                    Text("Nur Fehler").tag(AppLogFilter.errors)
+                    Text("Nur Sync").tag(AppLogFilter.sync)
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Section("Aktionen") {
+                Button("Aktualisieren") {
+                    appLogViewModel.refresh()
+                }
+
+                if let shareURL = appLogViewModel.shareURL {
+                    ShareLink(item: shareURL) {
+                        Label("Protokoll teilen", systemImage: "square.and.arrow.up")
+                    }
+                }
+
+                Button("Protokoll löschen", role: .destructive) {
+                    appLogViewModel.clear()
+                }
+                .disabled(appLogViewModel.entries.isEmpty)
+            }
+
+            Section("Einträge") {
+                if appLogViewModel.entries.isEmpty {
+                    ContentUnavailableView(
+                        "Kein Protokoll vorhanden",
+                        systemImage: "text.page.slash",
+                        description: Text("Sobald Sync-Vorgänge oder Fehler auftreten, erscheinen sie hier.")
+                    )
+                } else {
+                    ForEach(appLogViewModel.entries) { entry in
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(alignment: .top, spacing: 10) {
+                                Image(systemName: iconName(for: entry.level))
+                                    .foregroundStyle(color(for: entry.level))
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(entry.operation)
+                                        .font(.headline)
+                                    Text(entry.message)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Text(entry.timestamp.formatted(date: .abbreviated, time: .standard))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if !entry.metadata.isEmpty {
+                                Text(entry.metadata.map { "\($0.key): \($0.value)" }.sorted().joined(separator: " · "))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Sync-Protokoll")
+        .task {
+            appLogViewModel.refresh()
+        }
+        .refreshable {
+            appLogViewModel.refresh()
+        }
+    }
+
+    private var filterBinding: Binding<AppLogFilter> {
+        Binding(
+            get: { appLogViewModel.filter },
+            set: { appLogViewModel.updateFilter($0) }
+        )
+    }
+
+    private func iconName(for level: AppLogLevel) -> String {
+        switch level {
+        case .debug:
+            "ladybug"
+        case .info:
+            "info.circle"
+        case .warning:
+            "exclamationmark.triangle"
+        case .error:
+            "xmark.octagon"
+        }
+    }
+
+    private func color(for level: AppLogLevel) -> Color {
+        switch level {
+        case .debug:
+            .blue
+        case .info:
+            .green
+        case .warning:
+            .orange
+        case .error:
+            .red
+        }
+    }
+}

--- a/MigraineTrackerApp/Sources/Features/Sync/CloudKitSyncProvider.swift
+++ b/MigraineTrackerApp/Sources/Features/Sync/CloudKitSyncProvider.swift
@@ -31,6 +31,7 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
     private let zoneID: CKRecordZone.ID
     private let recordProvider: @Sendable (CKRecord.ID) async -> CKRecord?
     private let eventHandler: @Sendable (SyncProviderEvent) async -> Void
+    private let appLogStore: AppLogStore
     private var syncEngine: CKSyncEngine?
     private let container = CKContainer(identifier: SyncConfiguration.containerIdentifier)
     private var pendingRecordNames = Set<String>()
@@ -38,11 +39,13 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
     init(
         stateStore: SyncStateStore,
         zoneID: CKRecordZone.ID,
+        appLogStore: AppLogStore,
         recordProvider: @escaping @Sendable (CKRecord.ID) async -> CKRecord?,
         eventHandler: @escaping @Sendable (SyncProviderEvent) async -> Void
     ) {
         self.stateStore = stateStore
         self.zoneID = zoneID
+        self.appLogStore = appLogStore
         self.recordProvider = recordProvider
         self.eventHandler = eventHandler
     }
@@ -76,6 +79,7 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
 
     func start() async throws {
         guard syncEngine == nil else {
+            await log(level: .debug, operation: "provider.start.skip", message: "Sync-Engine läuft bereits.")
             return
         }
 
@@ -93,17 +97,26 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
             ]
         )
         syncEngine = engine
+        await log(level: .info, operation: "provider.start", message: "CloudKit-Sync-Engine gestartet.", metadata: [
+            "zone": zoneID.zoneName
+        ])
     }
 
     func stop() async {
         await syncEngine?.cancelOperations()
         syncEngine = nil
+        await log(level: .info, operation: "provider.stop", message: "CloudKit-Sync-Engine gestoppt.")
     }
 
     func queue(recordNames: [String]) async {
         pendingRecordNames.formUnion(recordNames)
+        await log(level: .debug, operation: "provider.queue", message: "Records für Upload markiert.", metadata: [
+            "count": "\(recordNames.count)",
+            "recordNames": recordNames.sorted().joined(separator: ",")
+        ])
 
         guard let syncEngine else {
+            await log(level: .warning, operation: "provider.queue.deferred", message: "Queue wurde vorgemerkt, Engine ist aber noch nicht aktiv.")
             return
         }
 
@@ -117,22 +130,30 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
 
     func fetch() async throws {
         guard let syncEngine else {
+            await log(level: .warning, operation: "provider.fetch.skip", message: "Fetch übersprungen, da keine Sync-Engine aktiv ist.")
             return
         }
 
+        await log(level: .info, operation: "provider.fetch.start", message: "CloudKit-Änderungen werden geladen.")
         try await syncEngine.fetchChanges(
             .init(scope: .zoneIDs([zoneID]))
         )
+        await log(level: .info, operation: "provider.fetch.finish", message: "CloudKit-Änderungen wurden geladen.")
     }
 
     func send() async throws {
         guard let syncEngine else {
+            await log(level: .warning, operation: "provider.send.skip", message: "Upload übersprungen, da keine Sync-Engine aktiv ist.")
             return
         }
 
+        await log(level: .info, operation: "provider.send.start", message: "CloudKit-Änderungen werden gesendet.", metadata: [
+            "pendingRecords": "\(await queuedChangeCount)"
+        ])
         try await syncEngine.sendChanges(
             .init(scope: .zoneIDs([zoneID]))
         )
+        await log(level: .info, operation: "provider.send.finish", message: "CloudKit-Änderungen wurden gesendet.")
     }
 }
 
@@ -140,8 +161,13 @@ extension CloudKitSyncProvider: CKSyncEngineDelegate {
     func handleEvent(_ event: CKSyncEngine.Event, syncEngine _: CKSyncEngine) async {
         switch event {
         case .stateUpdate(let update):
+            await log(level: .debug, operation: "provider.event.stateUpdate", message: "Sync-Statusserialisierung aktualisiert.")
             await eventHandler(.didUpdateState(update.stateSerialization))
         case .fetchedRecordZoneChanges(let changes):
+            await log(level: .info, operation: "provider.event.fetchedRecordZoneChanges", message: "Remote-Änderungen empfangen.", metadata: [
+                "modifications": "\(changes.modifications.count)",
+                "deletions": "\(changes.deletions.count)"
+            ])
             await eventHandler(.didFetchRecords(changes.modifications.map(\.record)))
             await eventHandler(.didDeleteRecords(changes.deletions.map(\.recordID)))
         case .sentRecordZoneChanges(let changes):
@@ -149,40 +175,58 @@ extension CloudKitSyncProvider: CKSyncEngineDelegate {
                 SyncFailedRecordSave(recordID: $0.record.recordID, error: $0.error)
             }
             pendingRecordNames.subtract(changes.savedRecords.map { $0.recordID.recordName })
+            await log(level: failures.isEmpty ? .info : .warning, operation: "provider.event.sentRecordZoneChanges", message: "Upload-Ergebnis erhalten.", metadata: [
+                "savedRecords": "\(changes.savedRecords.count)",
+                "failedRecords": "\(failures.count)"
+            ])
             await eventHandler(.didSendRecords(changes.savedRecords))
             if !failures.isEmpty {
                 await eventHandler(.didFailToSend(failures))
             }
         case .sentDatabaseChanges(let changes):
             if !changes.failedZoneSaves.isEmpty {
+                await log(level: .error, operation: "provider.event.sentDatabaseChanges.error", message: "Zone konnte nicht gespeichert werden.", metadata: [
+                    "failedZoneSaves": "\(changes.failedZoneSaves.count)"
+                ])
                 await eventHandler(.didEncounterError(changes.failedZoneSaves[0].error.localizedDescription))
             }
         case .didFetchRecordZoneChanges(let change):
             if let error = change.error {
+                await log(level: .error, operation: "provider.event.didFetchRecordZoneChanges.error", message: "Fehler beim Laden einer Zone.", metadata: [
+                    "error": error.localizedDescription
+                ])
                 await eventHandler(.didEncounterError(error.localizedDescription))
             }
         case .didSendChanges:
-            break
+            await log(level: .debug, operation: "provider.event.didSendChanges", message: "CKSyncEngine meldet abgeschlossenen Sendelauf.")
         case .didFetchChanges:
-            break
+            await log(level: .debug, operation: "provider.event.didFetchChanges", message: "CKSyncEngine meldet abgeschlossenen Fetch-Lauf.")
         case .willFetchChanges:
-            break
+            await log(level: .debug, operation: "provider.event.willFetchChanges", message: "CKSyncEngine startet einen Fetch-Lauf.")
         case .willFetchRecordZoneChanges:
-            break
+            await log(level: .debug, operation: "provider.event.willFetchRecordZoneChanges", message: "CKSyncEngine lädt Zonendetails.")
         case .willSendChanges:
-            break
+            await log(level: .debug, operation: "provider.event.willSendChanges", message: "CKSyncEngine startet einen Sendelauf.")
         case .accountChange(let change):
             switch change.changeType {
             case .signOut, .switchAccounts:
+                await log(level: .warning, operation: "provider.event.accountChange", message: "iCloud-Account wurde geändert.", metadata: [
+                    "changeType": "\(change.changeType)"
+                ])
                 await eventHandler(.didEncounterError("Der iCloud-Account wurde geändert. Bitte prüfe den Sync-Status."))
             case .signIn:
+                await log(level: .info, operation: "provider.event.accountChange", message: "iCloud-Account ist wieder verfügbar.", metadata: [
+                    "changeType": "\(change.changeType)"
+                ])
                 break
             @unknown default:
+                await log(level: .warning, operation: "provider.event.accountChange.unknown", message: "Unbekannte iCloud-Änderung erkannt.")
                 await eventHandler(.didEncounterError("Unbekannte iCloud-Änderung erkannt."))
             }
         case .fetchedDatabaseChanges:
-            break
+            await log(level: .debug, operation: "provider.event.fetchedDatabaseChanges", message: "Datenbankweite Änderungen wurden verarbeitet.")
         @unknown default:
+            await log(level: .warning, operation: "provider.event.unknown", message: "Unbekanntes CKSyncEngine-Ereignis empfangen.")
             break
         }
     }
@@ -192,6 +236,21 @@ extension CloudKitSyncProvider: CKSyncEngineDelegate {
         return await CKSyncEngine.RecordZoneChangeBatch(
             pendingChanges: changes,
             recordProvider: recordProvider
+        )
+    }
+
+    private func log(
+        level: AppLogLevel,
+        operation: String,
+        message: String,
+        metadata: [String: String] = [:]
+    ) async {
+        await appLogStore.log(
+            level: level,
+            category: .sync,
+            operation: operation,
+            message: message,
+            metadata: metadata
         )
     }
 }

--- a/MigraineTrackerApp/Sources/Features/Sync/SyncCoordinator.swift
+++ b/MigraineTrackerApp/Sources/Features/Sync/SyncCoordinator.swift
@@ -12,14 +12,16 @@ final class SyncCoordinator: ObservableObject {
 
     private let modelContainer: ModelContainer
     private let stateStore: SyncStateStore
+    private let appLogStore: AppLogStore
     private let repository: LocalSyncRepository
     private let deviceID: String
     private var provider: (any SyncProvider)?
     private let zoneID = SyncConfiguration.zoneID
 
-    init(modelContainer: ModelContainer) {
+    init(modelContainer: ModelContainer, appLogStore: AppLogStore) {
         self.modelContainer = modelContainer
         self.stateStore = SyncStateStore()
+        self.appLogStore = appLogStore
         self.repository = LocalSyncRepository(modelContainer: modelContainer)
         self.deviceID = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
 
@@ -31,6 +33,10 @@ final class SyncCoordinator: ObservableObject {
     func loadPersistedState() async {
         isEnabled = await stateStore.syncEnabled()
         conflicts = await stateStore.conflicts()
+        await log(level: .info, operation: "coordinator.loadPersistedState", message: "Persistierter Sync-Status geladen.", metadata: [
+            "enabled": "\(isEnabled)",
+            "conflicts": "\(conflicts.count)"
+        ])
         status = await buildStatusSnapshot(
             baseState: isEnabled ? .ready : .disabled,
             isSyncing: false
@@ -45,6 +51,7 @@ final class SyncCoordinator: ObservableObject {
         Task {
             await stateStore.setSyncEnabled(enabled)
             isEnabled = enabled
+            await log(level: .info, operation: "coordinator.setSyncEnabled", message: enabled ? "Sync wurde aktiviert." : "Sync wurde deaktiviert.")
 
             if enabled {
                 await ensureStarted()
@@ -65,6 +72,7 @@ final class SyncCoordinator: ObservableObject {
 
     func syncNow() async {
         guard isEnabled else {
+            await log(level: .warning, operation: "coordinator.syncNow.skip", message: "Sync wurde angefordert, ist aber deaktiviert.")
             status = await buildStatusSnapshot(baseState: .disabled, isSyncing: false)
             return
         }
@@ -72,10 +80,12 @@ final class SyncCoordinator: ObservableObject {
         await ensureStarted()
 
         guard let provider else {
+            await log(level: .error, operation: "coordinator.syncNow.missingProvider", message: "Sync konnte nicht starten, da kein Provider verfügbar ist.")
             status = await buildStatusSnapshot(baseState: .needsAttention, isSyncing: false)
             return
         }
 
+        await log(level: .info, operation: "coordinator.syncNow.start", message: "Manueller Sync-Lauf gestartet.")
         status = await buildStatusSnapshot(baseState: .syncing, isSyncing: true)
 
         do {
@@ -83,8 +93,14 @@ final class SyncCoordinator: ObservableObject {
             try await queueUnsyncedDocuments()
             try await provider.send()
             await stateStore.clearLastError()
+            await log(level: .info, operation: "coordinator.syncNow.finish", message: "Sync-Lauf erfolgreich abgeschlossen.", metadata: [
+                "conflicts": "\(await stateStore.conflicts().count)"
+            ])
         } catch {
             await stateStore.setLastError(error.localizedDescription)
+            await log(level: .error, operation: "coordinator.syncNow.error", message: "Sync-Lauf fehlgeschlagen.", metadata: [
+                "error": error.localizedDescription
+            ])
         }
 
         conflicts = await stateStore.conflicts()
@@ -92,6 +108,7 @@ final class SyncCoordinator: ObservableObject {
     }
 
     func retryLastError() async {
+        await log(level: .info, operation: "coordinator.retryLastError", message: "Fehlerhafter Sync-Lauf wird erneut versucht.")
         await syncNow()
     }
 
@@ -103,6 +120,11 @@ final class SyncCoordinator: ObservableObject {
         Task {
             await stateStore.removeConflict(documentID: conflict.documentID)
             conflicts = await stateStore.conflicts()
+            await log(level: .info, operation: "coordinator.resolveConflictKeepingLocal", message: "Lokale Version eines Konflikts wurde beibehalten.", metadata: [
+                "documentID": conflict.documentID,
+                "entityType": conflict.entityType.rawValue,
+                "fields": conflict.conflictingFields.joined(separator: ",")
+            ])
             status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
         }
     }
@@ -114,9 +136,18 @@ final class SyncCoordinator: ObservableObject {
                 await stateStore.saveShadow(SyncShadow(envelope: conflict.remote), for: conflict.documentID)
                 await stateStore.removeConflict(documentID: conflict.documentID)
                 conflicts = await stateStore.conflicts()
+                await log(level: .info, operation: "coordinator.resolveConflictUsingRemote", message: "Cloud-Version eines Konflikts wurde übernommen.", metadata: [
+                    "documentID": conflict.documentID,
+                    "entityType": conflict.entityType.rawValue,
+                    "fields": conflict.conflictingFields.joined(separator: ",")
+                ])
                 status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
             } catch {
                 await stateStore.setLastError(error.localizedDescription)
+                await log(level: .error, operation: "coordinator.resolveConflictUsingRemote.error", message: "Konflikt konnte nicht mit Cloud-Daten aufgelöst werden.", metadata: [
+                    "documentID": conflict.documentID,
+                    "error": error.localizedDescription
+                ])
                 status = await buildStatusSnapshot(baseState: .needsAttention, isSyncing: false)
             }
         }
@@ -130,6 +161,7 @@ final class SyncCoordinator: ObservableObject {
         let cloudProvider = CloudKitSyncProvider(
             stateStore: stateStore,
             zoneID: zoneID,
+            appLogStore: appLogStore,
             recordProvider: { [weak self] recordID in
                 await self?.recordForUpload(recordID: recordID)
             },
@@ -142,17 +174,25 @@ final class SyncCoordinator: ObservableObject {
 
         do {
             try await cloudProvider.start()
+            await log(level: .info, operation: "coordinator.ensureStarted", message: "Sync-Provider wurde initialisiert.")
         } catch {
             await stateStore.setLastError(error.localizedDescription)
+            await log(level: .error, operation: "coordinator.ensureStarted.error", message: "Sync-Provider konnte nicht gestartet werden.", metadata: [
+                "error": error.localizedDescription
+            ])
         }
     }
 
     private func recordForUpload(recordID: CKRecord.ID) async -> CKRecord? {
         guard let envelope = try? repository.envelope(documentID: recordID.recordName, deviceID: deviceID) else {
+            await log(level: .warning, operation: "coordinator.recordForUpload.missingEnvelope", message: "Kein lokales Dokument für Upload gefunden.", metadata: [
+                "recordID": recordID.recordName
+            ])
             return nil
         }
 
         let shadow = await stateStore.shadow(for: envelope.documentID)
+        await log(level: .debug, operation: "coordinator.recordForUpload", message: "Lokales Dokument wird für Upload codiert.", metadata: metadata(for: envelope, shadow: shadow))
         return CloudKitRecordCodec.record(
             for: envelope,
             zoneID: zoneID,
@@ -164,17 +204,28 @@ final class SyncCoordinator: ObservableObject {
         switch event {
         case .didUpdateState(let serialization):
             await stateStore.saveEngineState(serialization)
+            await log(level: .debug, operation: "coordinator.provider.didUpdateState", message: "Engine-Status wurde persistiert.")
         case .didFetchRecords(let records):
+            await log(level: .info, operation: "coordinator.provider.didFetchRecords", message: "Remote-Records empfangen.", metadata: [
+                "count": "\(records.count)"
+            ])
             for record in records {
                 await applyRemoteRecord(record)
             }
             await stateStore.setLastDownloadedAt(.now)
         case .didDeleteRecords(let recordIDs):
+            await log(level: .info, operation: "coordinator.provider.didDeleteRecords", message: "Remote-Löschungen empfangen.", metadata: [
+                "count": "\(recordIDs.count)",
+                "recordIDs": recordIDs.map(\.recordName).sorted().joined(separator: ",")
+            ])
             for recordID in recordIDs {
                 await handleRemoteDeletion(recordID: recordID)
             }
             await stateStore.setLastDownloadedAt(.now)
         case .didSendRecords(let records):
+            await log(level: .info, operation: "coordinator.provider.didSendRecords", message: "Lokale Änderungen wurden hochgeladen.", metadata: [
+                "count": "\(records.count)"
+            ])
             for record in records {
                 if let envelope = CloudKitRecordCodec.envelope(from: record) {
                     let systemFields = CloudKitRecordCodec.systemFields(for: record)
@@ -188,11 +239,17 @@ final class SyncCoordinator: ObservableObject {
             conflicts = await stateStore.conflicts()
             await stateStore.setLastUploadedAt(.now)
         case .didFailToSend(let failures):
+            await log(level: .warning, operation: "coordinator.provider.didFailToSend", message: "Ein Teil des Uploads ist fehlgeschlagen.", metadata: [
+                "count": "\(failures.count)"
+            ])
             for failure in failures {
                 await handleFailedSave(failure)
             }
         case .didEncounterError(let message):
             await stateStore.setLastError(message)
+            await log(level: .error, operation: "coordinator.provider.didEncounterError", message: "Der Provider hat einen Fehler gemeldet.", metadata: [
+                "error": message
+            ])
         }
 
         status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
@@ -200,6 +257,9 @@ final class SyncCoordinator: ObservableObject {
 
     private func applyRemoteRecord(_ record: CKRecord) async {
         guard let remoteEnvelope = CloudKitRecordCodec.envelope(from: record) else {
+            await log(level: .warning, operation: "coordinator.applyRemoteRecord.decodeFailed", message: "Remote-Record konnte nicht decodiert werden.", metadata: [
+                "recordID": record.recordID.recordName
+            ])
             return
         }
 
@@ -213,6 +273,7 @@ final class SyncCoordinator: ObservableObject {
                         SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
                         for: remoteEnvelope.documentID
                     )
+                    await log(level: .debug, operation: "coordinator.applyRemoteRecord.noChange", message: "Remote-Record entspricht bereits dem lokalen Stand.", metadata: metadata(for: remoteEnvelope, shadow: shadow))
                     return
                 }
 
@@ -230,6 +291,7 @@ final class SyncCoordinator: ObservableObject {
 
                 if merge.conflicts.isEmpty {
                     await stateStore.removeConflict(documentID: remoteEnvelope.documentID)
+                    await log(level: .info, operation: "coordinator.applyRemoteRecord.merged", message: "Remote-Record wurde konfliktfrei gemergt.", metadata: metadata(for: remoteEnvelope, shadow: shadow))
                 } else {
                     await stateStore.saveConflict(
                         SyncConflict(
@@ -241,6 +303,11 @@ final class SyncCoordinator: ObservableObject {
                             conflictingFields: merge.conflicts
                         )
                     )
+                    await log(level: .warning, operation: "coordinator.applyRemoteRecord.conflict", message: "Beim Mergen wurde ein Konflikt erkannt.", metadata: [
+                        "documentID": remoteEnvelope.documentID,
+                        "entityType": remoteEnvelope.entityType.rawValue,
+                        "fields": merge.conflicts.joined(separator: ",")
+                    ])
                 }
             } else {
                 try repository.apply(remote: remoteEnvelope)
@@ -248,9 +315,14 @@ final class SyncCoordinator: ObservableObject {
                     SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
                     for: remoteEnvelope.documentID
                 )
+                await log(level: .info, operation: "coordinator.applyRemoteRecord.insert", message: "Remote-Record wurde lokal neu angelegt.", metadata: metadata(for: remoteEnvelope, shadow: shadow))
             }
         } catch {
             await stateStore.setLastError(error.localizedDescription)
+            await log(level: .error, operation: "coordinator.applyRemoteRecord.error", message: "Remote-Record konnte nicht angewendet werden.", metadata: [
+                "documentID": remoteEnvelope.documentID,
+                "error": error.localizedDescription
+            ])
         }
 
         conflicts = await stateStore.conflicts()
@@ -258,6 +330,9 @@ final class SyncCoordinator: ObservableObject {
 
     private func handleRemoteDeletion(recordID: CKRecord.ID) async {
         guard let localEnvelope = try? repository.envelope(documentID: recordID.recordName, deviceID: deviceID) else {
+            await log(level: .debug, operation: "coordinator.handleRemoteDeletion.skip", message: "Remote-Löschung ignoriert, da lokal kein Dokument existiert.", metadata: [
+                "recordID": recordID.recordName
+            ])
             return
         }
 
@@ -273,27 +348,48 @@ final class SyncCoordinator: ObservableObject {
         do {
             try repository.apply(remote: tombstone)
             await stateStore.saveShadow(SyncShadow(envelope: tombstone), for: tombstone.documentID)
+            await log(level: .info, operation: "coordinator.handleRemoteDeletion", message: "Remote-Löschung als Tombstone übernommen.", metadata: [
+                "documentID": tombstone.documentID,
+                "entityType": tombstone.entityType.rawValue
+            ])
         } catch {
             await stateStore.setLastError(error.localizedDescription)
+            await log(level: .error, operation: "coordinator.handleRemoteDeletion.error", message: "Remote-Löschung konnte lokal nicht angewendet werden.", metadata: [
+                "recordID": recordID.recordName,
+                "error": error.localizedDescription
+            ])
         }
     }
 
     private func handleFailedSave(_ failure: SyncFailedRecordSave) async {
         switch failure.error.code {
         case .serverRecordChanged:
+            await log(level: .warning, operation: "coordinator.handleFailedSave.serverRecordChanged", message: "Server meldet geänderten Record. Remote-Stand wird neu angewendet.", metadata: [
+                "recordID": failure.recordID.recordName,
+                "errorCode": "\(failure.error.code.rawValue)"
+            ])
             guard let serverRecord = failure.error.serverRecord else {
                 await stateStore.setLastError(failure.error.localizedDescription)
+                await log(level: .error, operation: "coordinator.handleFailedSave.serverRecordMissing", message: "Server-Record fehlt trotz Konfliktmeldung.", metadata: [
+                    "recordID": failure.recordID.recordName
+                ])
                 return
             }
 
             await applyRemoteRecord(serverRecord)
         default:
             await stateStore.setLastError(failure.error.localizedDescription)
+            await log(level: .error, operation: "coordinator.handleFailedSave.error", message: "Record konnte nicht gespeichert werden.", metadata: [
+                "recordID": failure.recordID.recordName,
+                "errorCode": "\(failure.error.code.rawValue)",
+                "error": failure.error.localizedDescription
+            ])
         }
     }
 
     private func queueUnsyncedDocuments() async throws {
         guard let provider else {
+            await log(level: .warning, operation: "coordinator.queueUnsyncedDocuments.skip", message: "Keine Upload-Queue aufgebaut, da kein Provider aktiv ist.")
             return
         }
 
@@ -306,6 +402,13 @@ final class SyncCoordinator: ObservableObject {
             .filter { shadows[$0.documentID]?.envelope != $0 }
             .map(\.documentID)
 
+        await log(level: .info, operation: "coordinator.queueUnsyncedDocuments", message: "Lokale Änderungen wurden für den Upload ausgewählt.", metadata: [
+            "localEnvelopes": "\(envelopes.count)",
+            "shadows": "\(shadows.count)",
+            "conflicts": "\(conflicts.count)",
+            "pendingRecords": "\(pendingRecordNames.count)",
+            "recordNames": pendingRecordNames.sorted().joined(separator: ",")
+        ])
         await provider.queue(recordNames: pendingRecordNames)
     }
 
@@ -355,6 +458,45 @@ final class SyncCoordinator: ObservableObject {
             lastUploadedAt: await stateStore.lastUploadedAt(),
             lastError: lastError
         )
+    }
+
+    private func log(
+        level: AppLogLevel,
+        operation: String,
+        message: String,
+        metadata: [String: String] = [:]
+    ) async {
+        await appLogStore.log(
+            level: level,
+            category: .sync,
+            operation: operation,
+            message: message,
+            metadata: metadata
+        )
+    }
+
+    private func metadata(for envelope: SyncDocumentEnvelope, shadow: SyncShadow?) -> [String: String] {
+        var values: [String: String] = [
+            "documentID": envelope.documentID,
+            "entityType": envelope.entityType.rawValue,
+            "modifiedAt": envelope.modifiedAt.ISO8601Format(),
+            "hasShadow": "\(shadow != nil)"
+        ]
+
+        switch envelope.payload {
+        case .episode(let payload):
+            values["symptomCount"] = "\(payload.symptoms.count)"
+            values["triggerCount"] = "\(payload.triggers.count)"
+            values["medicationCount"] = "\(payload.medications.count)"
+            values["hasNotes"] = "\(!payload.notes.isEmpty)"
+            values["hasWeather"] = "\(payload.weatherSnapshot != nil)"
+        case .medicationDefinition(let payload):
+            values["isCustom"] = "\(payload.isCustom)"
+            values["category"] = payload.category
+            values["sortOrder"] = "\(payload.sortOrder)"
+        }
+
+        return values
     }
 }
 

--- a/MigraineTrackerApp/Sources/Shared/AppLogging.swift
+++ b/MigraineTrackerApp/Sources/Shared/AppLogging.swift
@@ -1,0 +1,238 @@
+import Foundation
+
+public enum AppLogCategory: String, Codable, CaseIterable, Sendable {
+    case sync
+    case app
+}
+
+public enum AppLogLevel: String, Codable, CaseIterable, Sendable {
+    case debug
+    case info
+    case warning
+    case error
+}
+
+public enum AppLogFilter: String, Codable, CaseIterable, Sendable, Identifiable {
+    case all
+    case errors
+    case sync
+
+    public var id: Self { self }
+}
+
+public struct AppLogEntry: Codable, Equatable, Identifiable, Sendable {
+    public let id: UUID
+    public let timestamp: Date
+    public let category: AppLogCategory
+    public let level: AppLogLevel
+    public let operation: String
+    public let message: String
+    public let metadata: [String: String]
+
+    public init(
+        id: UUID = UUID(),
+        timestamp: Date = .now,
+        category: AppLogCategory,
+        level: AppLogLevel,
+        operation: String,
+        message: String,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.category = category
+        self.level = level
+        self.operation = operation
+        self.message = message
+        self.metadata = metadata
+    }
+}
+
+public actor AppLogStore {
+    private let retentionWindow: TimeInterval
+    private let maxEntryCount: Int
+    private let fileURL: URL
+    private let snapshotDirectoryURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private var entries: [AppLogEntry]
+
+    public init(
+        fileManager: FileManager = .default,
+        baseDirectoryURL: URL? = nil,
+        retentionWindow: TimeInterval = 60 * 60 * 24 * 7,
+        maxEntryCount: Int = 3000
+    ) {
+        self.retentionWindow = retentionWindow
+        self.maxEntryCount = maxEntryCount
+
+        let baseURL = baseDirectoryURL ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        let directoryURL = baseURL.appendingPathComponent("MigraineTracker", isDirectory: true)
+        try? fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        self.fileURL = directoryURL.appendingPathComponent("app-log.ndjson")
+        self.snapshotDirectoryURL = directoryURL.appendingPathComponent("Snapshots", isDirectory: true)
+        try? fileManager.createDirectory(at: snapshotDirectoryURL, withIntermediateDirectories: true)
+        self.entries = []
+
+        self.encoder.dateEncodingStrategy = .iso8601
+        self.decoder.dateDecodingStrategy = .iso8601
+        self.entries = Self.prunedEntries(
+            Self.loadEntries(from: fileURL, using: decoder),
+            retentionWindow: retentionWindow,
+            maxEntryCount: maxEntryCount
+        )
+        Self.persist(entries, to: fileURL, using: encoder, fileManager: fileManager)
+    }
+
+    public func log(
+        level: AppLogLevel,
+        category: AppLogCategory,
+        operation: String,
+        message: String,
+        metadata: [String: String] = [:]
+    ) {
+        entries.append(
+            AppLogEntry(
+                category: category,
+                level: level,
+                operation: operation,
+                message: message,
+                metadata: metadata.sorted { $0.key < $1.key }.reduce(into: [:]) { partialResult, item in
+                    partialResult[item.key] = item.value
+                }
+            )
+        )
+        pruneAndPersist()
+    }
+
+    public func recentEntries(filter: AppLogFilter = .all, limit: Int = 200) -> [AppLogEntry] {
+        Array(filteredEntries(filter).sorted { $0.timestamp > $1.timestamp }.prefix(limit))
+    }
+
+    public func latestEntry(filter: AppLogFilter = .all) -> AppLogEntry? {
+        filteredEntries(filter).max { $0.timestamp < $1.timestamp }
+    }
+
+    public func exportLogFileURL(filter: AppLogFilter = .all) -> URL? {
+        let filtered = filteredEntries(filter).sorted { $0.timestamp < $1.timestamp }
+        guard !filtered.isEmpty else {
+            return nil
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let filename = "sync-log-\(formatter.string(from: .now).replacingOccurrences(of: ":", with: "-")).ndjson"
+        let exportURL = snapshotDirectoryURL.appendingPathComponent(filename)
+
+        let lines = filtered.compactMap { entry -> String? in
+            guard let data = try? encoder.encode(entry) else {
+                return nil
+            }
+
+            return String(data: data, encoding: .utf8)
+        }
+
+        guard !lines.isEmpty else {
+            return nil
+        }
+
+        do {
+            try lines.joined(separator: "\n").appending("\n").write(to: exportURL, atomically: true, encoding: .utf8)
+            return exportURL
+        } catch {
+            return nil
+        }
+    }
+
+    public func clear() {
+        entries.removeAll()
+        do {
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                try FileManager.default.removeItem(at: fileURL)
+            }
+        } catch {
+            // Logging darf den App-Fluss nicht blockieren.
+        }
+    }
+
+    private func filteredEntries(_ filter: AppLogFilter) -> [AppLogEntry] {
+        switch filter {
+        case .all:
+            entries
+        case .errors:
+            entries.filter { $0.level == .error }
+        case .sync:
+            entries.filter { $0.category == .sync }
+        }
+    }
+
+    private func pruneAndPersist() {
+        entries = Self.prunedEntries(entries, retentionWindow: retentionWindow, maxEntryCount: maxEntryCount)
+        Self.persist(entries, to: fileURL, using: encoder, fileManager: .default)
+    }
+
+    private static func loadEntries(from fileURL: URL, using decoder: JSONDecoder) -> [AppLogEntry] {
+        guard
+            let content = try? String(contentsOf: fileURL, encoding: .utf8),
+            !content.isEmpty
+        else {
+            return []
+        }
+
+        return content
+            .split(separator: "\n")
+            .compactMap { line in
+                guard let data = line.data(using: .utf8) else {
+                    return nil
+                }
+
+                return try? decoder.decode(AppLogEntry.self, from: data)
+            }
+    }
+
+    private static func prunedEntries(
+        _ entries: [AppLogEntry],
+        retentionWindow: TimeInterval,
+        maxEntryCount: Int
+    ) -> [AppLogEntry] {
+        let cutoff = Date(timeIntervalSinceNow: -retentionWindow)
+        var pruned = entries
+            .filter { $0.timestamp >= cutoff }
+            .sorted { $0.timestamp < $1.timestamp }
+
+        if pruned.count > maxEntryCount {
+            pruned = Array(pruned.suffix(maxEntryCount))
+        }
+
+        return pruned
+    }
+
+    private static func persist(
+        _ entries: [AppLogEntry],
+        to fileURL: URL,
+        using encoder: JSONEncoder,
+        fileManager: FileManager
+    ) {
+        let lines = entries.compactMap { entry -> String? in
+            guard let data = try? encoder.encode(entry) else {
+                return nil
+            }
+
+            return String(data: data, encoding: .utf8)
+        }
+
+        do {
+            if lines.isEmpty {
+                if fileManager.fileExists(atPath: fileURL.path) {
+                    try fileManager.removeItem(at: fileURL)
+                }
+            } else {
+                try lines.joined(separator: "\n").appending("\n").write(to: fileURL, atomically: true, encoding: .utf8)
+            }
+        } catch {
+            // Logging darf den App-Fluss nicht blockieren.
+        }
+    }
+}

--- a/Tests/MigraineTrackerCoreTests/AppLogStoreTests.swift
+++ b/Tests/MigraineTrackerCoreTests/AppLogStoreTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import MigraineTrackerCore
+
+struct AppLogStoreTests {
+    @Test
+    func persistsAndLoadsEntries() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = AppLogStore(fileManager: .default, baseDirectoryURL: directory, retentionWindow: 60 * 60 * 24 * 7, maxEntryCount: 10)
+
+        await store.log(level: .info, category: .sync, operation: "sync.start", message: "Start", metadata: ["count": "1"])
+        let entries = await store.recentEntries()
+
+        #expect(entries.count == 1)
+        #expect(entries.first?.operation == "sync.start")
+
+        let reloadedStore = AppLogStore(fileManager: .default, baseDirectoryURL: directory, retentionWindow: 60 * 60 * 24 * 7, maxEntryCount: 10)
+        let reloadedEntries = await reloadedStore.recentEntries()
+        #expect(reloadedEntries.count == 1)
+    }
+
+    @Test
+    func retentionRemovesExpiredEntries() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = AppLogStore(fileManager: .default, baseDirectoryURL: directory, retentionWindow: -1, maxEntryCount: 10)
+        await store.log(level: .info, category: .sync, operation: "expired", message: "Alt")
+
+        let entries = await store.recentEntries()
+        #expect(entries.isEmpty)
+    }
+
+    @Test
+    func clearRemovesEntries() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = AppLogStore(fileManager: .default, baseDirectoryURL: directory, retentionWindow: 60 * 60 * 24 * 7, maxEntryCount: 10)
+        await store.log(level: .error, category: .sync, operation: "sync.error", message: "Fehler")
+        await store.clear()
+
+        let entries = await store.recentEntries()
+        #expect(entries.isEmpty)
+    }
+
+    @Test
+    func exportCreatesFileForAvailableEntries() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = AppLogStore(fileManager: .default, baseDirectoryURL: directory, retentionWindow: 60 * 60 * 24 * 7, maxEntryCount: 10)
+        await store.log(level: .warning, category: .sync, operation: "sync.warning", message: "Warnung")
+
+        let url = await store.exportLogFileURL()
+
+        #expect(url != nil)
+        #expect(url.map { FileManager.default.fileExists(atPath: $0.path) } == true)
+    }
+
+    @Test
+    func errorFilterReturnsOnlyErrors() async throws {
+        let directory = try makeTemporaryDirectory()
+        let store = AppLogStore(fileManager: .default, baseDirectoryURL: directory, retentionWindow: 60 * 60 * 24 * 7, maxEntryCount: 10)
+        await store.log(level: .info, category: .sync, operation: "sync.info", message: "Info")
+        await store.log(level: .error, category: .sync, operation: "sync.error", message: "Fehler")
+
+        let entries = await store.recentEntries(filter: .errors)
+
+        #expect(entries.count == 1)
+        #expect(entries.first?.level == .error)
+    }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}


### PR DESCRIPTION
## Zusammenfassung
- fügt ein persistentes lokales App-Log mit 7-Tage-Retention für strukturierte Sync-Ereignisse hinzu
- instrumentiert `SyncCoordinator` und `CloudKitSyncProvider` für Fetch-, Queue-, Send-, Konflikt- und Fehlerpfade
- ergänzt eine neue Ansicht `Sync-Protokoll` zum Ansehen, Filtern, Teilen und Löschen des Logs
- ergänzt Tests für Persistenz, Retention, Filter, Export und Clear des Log-Stores

## Verifikation
- `swift test`
- `xcodebuild -scheme MigraineTrackerApp -project MigraineTracker.xcodeproj -destination 'generic/platform=iOS Simulator' build`