### PR TITLE
[codex] Kalender-Startscreen einführen

### DIFF
--- a/MigraineTracker/Sources/App/AppShellView.swift
+++ b/MigraineTracker/Sources/App/AppShellView.swift
@@ -1,42 +1,11 @@
 import SwiftUI
 
 struct AppShellView: View {
-    @State private var selectedTab: AppTab = .home
     @AppStorage("hasSeenTrustOnboarding") private var hasSeenTrustOnboarding = false
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            NavigationStack {
-                HomeView(selectedTab: $selectedTab)
-            }
-            .tabItem {
-                Label(AppTab.home.title, systemImage: AppTab.home.systemImage)
-            }
-            .tag(AppTab.home)
-
-            NavigationStack {
-                CaptureView()
-            }
-            .tabItem {
-                Label(AppTab.capture.title, systemImage: AppTab.capture.systemImage)
-            }
-            .tag(AppTab.capture)
-
-            NavigationStack {
-                HistoryView()
-            }
-            .tabItem {
-                Label(AppTab.history.title, systemImage: AppTab.history.systemImage)
-            }
-            .tag(AppTab.history)
-
-            NavigationStack {
-                ExportView()
-            }
-            .tabItem {
-                Label(AppTab.export.title, systemImage: AppTab.export.systemImage)
-            }
-            .tag(AppTab.export)
+        NavigationStack {
+            HistoryView()
         }
         .sheet(isPresented: onboardingBinding) {
             NavigationStack {

--- a/MigraineTracker/Sources/App/AppShellView.swift
+++ b/MigraineTracker/Sources/App/AppShellView.swift
@@ -1,32 +1,10 @@
 import SwiftUI
 
 struct AppShellView: View {
-    @AppStorage("hasSeenTrustOnboarding") private var hasSeenTrustOnboarding = false
-
     var body: some View {
         NavigationStack {
             HistoryView()
         }
-        .sheet(isPresented: onboardingBinding) {
-            NavigationStack {
-                ProductInformationView(
-                    mode: .onboarding,
-                    acknowledge: { hasSeenTrustOnboarding = true }
-                )
-            }
-            .interactiveDismissDisabled()
-        }
-    }
-
-    private var onboardingBinding: Binding<Bool> {
-        Binding(
-            get: { !hasSeenTrustOnboarding },
-            set: { isPresented in
-                if !isPresented {
-                    hasSeenTrustOnboarding = true
-                }
-            }
-        )
     }
 }
 

--- a/MigraineTracker/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/MigraineTracker/Sources/Features/Capture/EpisodeEditorView.swift
@@ -54,16 +54,16 @@ struct EpisodeEditorView: View {
     private let customGroupTitle = "Eigene Medikamente"
     private let customGroupFooter = "Eigene Medikamente werden lokal in SwiftData gespeichert und bleiben in deiner persönlichen Auswahlliste verfügbar."
 
-    init(episode: Episode? = nil, onSaved: (() -> Void)? = nil) {
+    init(episode: Episode? = nil, initialStartedAt: Date? = nil, onSaved: (() -> Void)? = nil) {
         self.episode = episode
         self.onSaved = onSaved
         self.mode = episode == nil ? .create : .edit
 
         _type = State(initialValue: episode?.type ?? .unclear)
         _intensity = State(initialValue: Double(episode?.intensity ?? 5))
-        _startedAt = State(initialValue: episode?.startedAt ?? .now)
+        _startedAt = State(initialValue: episode?.startedAt ?? initialStartedAt ?? .now)
         _endedAtEnabled = State(initialValue: episode?.endedAt != nil)
-        _endedAt = State(initialValue: episode?.endedAt ?? .now)
+        _endedAt = State(initialValue: episode?.endedAt ?? initialStartedAt ?? .now)
         _painLocation = State(initialValue: episode?.painLocation ?? "")
         _painCharacter = State(initialValue: episode?.painCharacter ?? "")
         _notes = State(initialValue: episode?.notes ?? "")
@@ -441,7 +441,7 @@ struct EpisodeEditorView: View {
             try modelContext.save()
             validationMessage = nil
 
-            if mode == .create {
+            if mode == .create, onSaved == nil {
                 resetForm()
                 saveMessageVisible = true
             } else {

--- a/MigraineTracker/Sources/Features/Export/ExportView.swift
+++ b/MigraineTracker/Sources/Features/Export/ExportView.swift
@@ -1,7 +1,7 @@
 import SwiftData
 import SwiftUI
 
-struct ExportView: View {
+struct SettingsView: View {
     @Environment(SyncCoordinator.self) private var syncCoordinator
     @Environment(AppLogViewModel.self) private var appLogViewModel
     @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
@@ -62,11 +62,17 @@ struct ExportView: View {
                 Text("Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden.")
             }
 
-            Section("Daten sichern") {
+            Section("Allgemein") {
                 NavigationLink {
                     DataExportView()
                 } label: {
                     Label("Datenexport", systemImage: "square.and.arrow.up")
+                }
+
+                NavigationLink {
+                    ProductInformationView(mode: .standard)
+                } label: {
+                    Label("Datenschutz und Hinweise", systemImage: "hand.raised")
                 }
             }
 
@@ -76,7 +82,7 @@ struct ExportView: View {
                 LabeledContent("Konflikte", value: "\(syncCoordinator.conflicts.count)")
             }
         }
-        .navigationTitle("Sync & Datenexport")
+        .navigationTitle("Einstellungen")
         .task {
             syncCoordinator.refreshStatus()
             appLogViewModel.refresh(limit: 1)
@@ -386,6 +392,6 @@ private struct ManageCloudDataView: View {
 
 #Preview {
     NavigationStack {
-        ExportView()
+        SettingsView()
     }
 }

--- a/MigraineTracker/Sources/Features/Export/ExportView.swift
+++ b/MigraineTracker/Sources/Features/Export/ExportView.swift
@@ -2,6 +2,7 @@ import SwiftData
 import SwiftUI
 
 struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(SyncCoordinator.self) private var syncCoordinator
     @Environment(AppLogViewModel.self) private var appLogViewModel
     @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
@@ -83,6 +84,13 @@ struct SettingsView: View {
             }
         }
         .navigationTitle("Einstellungen")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Schließen") {
+                    dismiss()
+                }
+            }
+        }
         .task {
             syncCoordinator.refreshStatus()
             appLogViewModel.refresh(limit: 1)

--- a/MigraineTracker/Sources/Features/Export/ExportView.swift
+++ b/MigraineTracker/Sources/Features/Export/ExportView.swift
@@ -85,7 +85,7 @@ struct SettingsView: View {
         }
         .navigationTitle("Einstellungen")
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
+            ToolbarItem(placement: closeButtonPlacement) {
                 Button("Schließen") {
                     dismiss()
                 }
@@ -165,6 +165,14 @@ struct SettingsView: View {
         }
 
         return "Ansehen, teilen und bei Bedarf löschen."
+    }
+
+    private var closeButtonPlacement: ToolbarItemPlacement {
+        #if targetEnvironment(macCatalyst)
+        .topBarTrailing
+        #else
+        .topBarLeading
+        #endif
     }
 }
 

--- a/MigraineTracker/Sources/Features/History/HistoryView.swift
+++ b/MigraineTracker/Sources/Features/History/HistoryView.swift
@@ -2,54 +2,32 @@ import SwiftData
 import SwiftUI
 
 struct HistoryView: View {
-    private enum HistoryMode: String, CaseIterable, Identifiable {
-        case list = "Liste"
-        case calendar = "Kalender"
-
-        var id: String { rawValue }
-    }
-
     @Environment(\.modelContext) private var modelContext
     @Query(sort: [SortDescriptor(\Episode.startedAt, order: .reverse)]) private var storedEpisodes: [Episode]
-    @State private var mode: HistoryMode = .list
+
     @State private var selectedDay: Date = .now
     @State private var displayedMonth: Date = Calendar.current.startOfMonth(for: .now)
     @State private var editingEpisode: Episode?
     @State private var pendingDeletion: Episode?
+    @State private var isPresentingNewEpisode = false
+    @State private var isPresentingSettings = false
 
     var body: some View {
-        List {
-            if episodes.isEmpty {
-                Section {
-                    ContentUnavailableView(
-                        "Noch keine Episoden",
-                        systemImage: "calendar.badge.plus",
-                        description: Text("Lege zuerst eine Episode an, um den Verlauf aufzubauen.")
-                    )
-                }
-            } else {
-                Section {
-                    Picker("Ansicht", selection: $mode) {
-                        ForEach(HistoryMode.allCases) { mode in
-                            Text(mode.rawValue).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                }
-
-                if mode == .list {
-                    Section("Letzte Episoden") {
-                        ForEach(episodes) { episode in
-                            episodeLink(for: episode)
-                        }
-                        .onDelete(perform: deleteEpisodes)
-                    }
-                } else {
-                    Section {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                contentSection(
+                    title: "Kalender",
+                    footer: "Wähle einen Tag aus und füge direkt einen Migräneanfall hinzu oder öffne vorhandene Einträge."
+                ) {
+                    VStack(alignment: .leading, spacing: 16) {
                         MonthHeader(
                             month: displayedMonth,
-                            onPrevious: { displayedMonth = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth) ?? displayedMonth },
-                            onNext: { displayedMonth = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth) ?? displayedMonth }
+                            onPrevious: {
+                                displayedMonth = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth) ?? displayedMonth
+                            },
+                            onNext: {
+                                displayedMonth = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth) ?? displayedMonth
+                            }
                         )
 
                         MonthGrid(
@@ -57,13 +35,23 @@ struct HistoryView: View {
                             selectedDay: $selectedDay,
                             episodesByDay: episodesByDay
                         )
-                    } header: {
-                        Text("Kalender")
-                    } footer: {
-                        Text("Wähle einen Tag, um die dokumentierten Episoden direkt darunter zu sehen.")
                     }
+                }
 
-                    Section("Ausgewählter Tag") {
+                Button {
+                    isPresentingNewEpisode = true
+                } label: {
+                    Label("Migräneanfall hinzufügen", systemImage: "plus.circle.fill")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .accessibilityHint("Öffnet die Erfassung mit dem aktuell ausgewählten Kalendertag.")
+
+                contentSection(title: "Ausgewählter Tag") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        daySummary
+
                         if episodesForSelectedDay.isEmpty {
                             ContentUnavailableView(
                                 "Keine Episoden an diesem Tag",
@@ -74,13 +62,62 @@ struct HistoryView: View {
                             ForEach(episodesForSelectedDay) { episode in
                                 episodeLink(for: episode)
                             }
-                            .onDelete(perform: deleteEpisodesForSelectedDay)
                         }
                     }
                 }
+
+                contentSection(title: "Export") {
+                    NavigationLink {
+                        DataExportView()
+                    } label: {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Label("Daten exportieren", systemImage: "square.and.arrow.up")
+                            Text("Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                }
             }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 20)
         }
         .navigationTitle("Verlauf")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    isPresentingSettings = true
+                } label: {
+                    Label("Einstellungen", systemImage: "gearshape")
+                }
+            }
+        }
+        .onAppear {
+            displayedMonth = Calendar.current.startOfMonth(for: selectedDay)
+        }
+        .onChange(of: selectedDay) { _, newDay in
+            let month = Calendar.current.startOfMonth(for: newDay)
+            if !Calendar.current.isDate(month, equalTo: displayedMonth, toGranularity: .month) {
+                displayedMonth = month
+            }
+        }
+        .sheet(isPresented: $isPresentingNewEpisode) {
+            NavigationStack {
+                EpisodeEditorView(
+                    initialStartedAt: defaultStartDate(for: selectedDay),
+                    onSaved: {
+                        isPresentingNewEpisode = false
+                    }
+                )
+            }
+        }
+        .sheet(isPresented: $isPresentingSettings) {
+            NavigationStack {
+                SettingsView()
+            }
+        }
         .sheet(item: $editingEpisode) { episode in
             NavigationStack {
                 EpisodeEditorView(episode: episode)
@@ -113,6 +150,47 @@ struct HistoryView: View {
         } message: { episode in
             Text("\(episode.startedAt.formatted(date: .abbreviated, time: .shortened)) wird in den Papierkorb verschoben.")
         }
+    }
+
+    @ViewBuilder
+    private func contentSection<Content: View>(title: String, footer: String? = nil, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 12) {
+                content()
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+            if let footer {
+                Text(footer)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var daySummary: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(selectedDay.formatted(date: .complete, time: .omitted))
+                .font(.headline)
+
+            if episodesForSelectedDay.isEmpty {
+                Text("Noch kein Eintrag für diesen Tag.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("\(episodesForSelectedDay.count) Eintrag\(episodesForSelectedDay.count == 1 ? "" : "e") · Höchste Intensität \(episodesForSelectedDay.map(\.intensity).max() ?? 0)/10")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
     }
 
     private var episodesByDay: [Date: [Episode]] {
@@ -156,32 +234,6 @@ struct HistoryView: View {
         }
     }
 
-    private func deleteEpisodes(at offsets: IndexSet) {
-        for index in offsets {
-            episodes[index].markDeleted()
-        }
-
-        do {
-            try modelContext.save()
-        } catch {
-            assertionFailure("Löschen fehlgeschlagen: \(error)")
-        }
-    }
-
-    private func deleteEpisodesForSelectedDay(at offsets: IndexSet) {
-        let dayEpisodes = episodesForSelectedDay
-
-        for index in offsets {
-            dayEpisodes[index].markDeleted()
-        }
-
-        do {
-            try modelContext.save()
-        } catch {
-            assertionFailure("Löschen fehlgeschlagen: \(error)")
-        }
-    }
-
     private func deleteEpisode(_ episode: Episode) {
         episode.markDeleted()
 
@@ -191,6 +243,18 @@ struct HistoryView: View {
         } catch {
             assertionFailure("Löschen fehlgeschlagen: \(error)")
         }
+    }
+
+    private func defaultStartDate(for selectedDay: Date) -> Date {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: .now)
+        let day = calendar.startOfDay(for: selectedDay)
+
+        if day == today {
+            return .now
+        }
+
+        return calendar.date(bySettingHour: 12, minute: 0, second: 0, of: day) ?? day
     }
 }
 


### PR DESCRIPTION
## Was sich geändert hat
- die App startet jetzt direkt in einer einzelnen `NavigationStack` mit dem Kalender als Hauptscreen
- `HistoryView` wurde zum neuen Ein-Screen-Workflow umgebaut: Kalender oben, großer CTA für neue Migräneanfälle, Tageseinträge darunter und Export im selben Screen
- `Sync` wurde in `Einstellungen` verschoben; dort liegen jetzt Synchronisation, Cloud-Daten, Sync-Protokoll sowie Datenschutz und Hinweise
- `EpisodeEditorView` kann neue Einträge mit einem vorgegebenen Startdatum öffnen und schließt nach modalem Speichern sauber zurück in den Kalender

## Warum
Die App sollte für den App-Review und für Erstnutzer sofort verständlich sein. Statt mehrerer Tabs führt sie jetzt direkt in den eigentlichen Produktkern: den Migräne-Kalender mit direkter Erfassung.

## Auswirkung
- der Startscreen ist klarer und zeigt sofort den Verlauf im Kalender
- neue Einträge lassen sich direkt aus dem ausgewählten Tag heraus anlegen
- Export bleibt sichtbar im Hauptscreen
- sekundäre technische Funktionen sind aus dem Primärfluss entfernt und in `Einstellungen` gebündelt

## Root Cause beim Fix
Der erste Umbau des Startscreens hat im Simulator einen rekursiven UIKit-/SwiftUI-Layout-Loop in einer `List` ausgelöst. Der Hauptscreen wurde deshalb auf einen `ScrollView`-basierten Aufbau umgestellt, um die Kalenderdarstellung stabil zu halten.

## Verifikation
- `xcodebuild -project MigraineTracker.xcodeproj -scheme MigraineTracker -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`
- ein früherer `xcodebuild test`-Lauf ist an dem App-Start-Crash des alten `List`-Layouts gescheitert; nach dem Fix wurde der Build erneut erfolgreich verifiziert
