### PR TITLE
[codex] Add sync conflict dialog

### DIFF
--- a/MigraineTracker/Sources/Core/Settings/SettingsCore.swift
+++ b/MigraineTracker/Sources/Core/Settings/SettingsCore.swift
@@ -61,8 +61,8 @@ protocol SyncService: AnyObject {
     func refreshStatus()
     func syncNow() async
     func retryLastError() async
-    func resolveConflictKeepingLocal(_ conflict: SyncConflict)
-    func resolveConflictUsingRemote(_ conflict: SyncConflict)
+    func resolveConflictKeepingLocal(_ conflict: SyncConflict) async
+    func resolveConflictUsingRemote(_ conflict: SyncConflict) async
 }
 
 protocol AppLogService {
@@ -152,13 +152,13 @@ final class SettingsController {
         load()
     }
 
-    func resolveConflictKeepingLocal(_ conflict: SyncConflict) {
-        syncService.resolveConflictKeepingLocal(conflict)
+    func resolveConflictKeepingLocal(_ conflict: SyncConflict) async {
+        await syncService.resolveConflictKeepingLocal(conflict)
         load()
     }
 
-    func resolveConflictUsingRemote(_ conflict: SyncConflict) {
-        syncService.resolveConflictUsingRemote(conflict)
+    func resolveConflictUsingRemote(_ conflict: SyncConflict) async {
+        await syncService.resolveConflictUsingRemote(conflict)
         load()
     }
 

--- a/MigraineTracker/Sources/Features/Export/ExportView.swift
+++ b/MigraineTracker/Sources/Features/Export/ExportView.swift
@@ -251,6 +251,8 @@ private struct SyncStatusView: View {
 private struct ManageCloudDataView: View {
     let appContainer: AppContainer
     @Bindable var controller: SettingsController
+    @State private var selectedConflict: SyncConflict?
+    @State private var isResolvingConflict = false
 
     var body: some View {
         List {
@@ -303,16 +305,14 @@ private struct ManageCloudDataView: View {
                         VStack(alignment: .leading, spacing: 8) {
                             Text(conflictTitle(for: conflict))
                                 .font(.headline)
+                            Text("Lokaler Stand und Cloud-Stand unterscheiden sich.")
+                                .font(.subheadline)
                             Text("Abweichende Felder: \(conflict.conflictingFields.joined(separator: ", "))")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
 
-                            Button("Lokale Version behalten") {
-                                controller.resolveConflictKeepingLocal(conflict)
-                            }
-
-                            Button("Cloud-Version übernehmen") {
-                                controller.resolveConflictUsingRemote(conflict)
+                            Button("Konflikt lösen") {
+                                selectedConflict = conflict
                             }
                         }
                         .padding(.vertical, 4)
@@ -358,6 +358,36 @@ private struct ManageCloudDataView: View {
             }
         }
         .navigationTitle("Cloud-Daten")
+        .disabled(isResolvingConflict)
+        .overlay {
+            if isResolvingConflict {
+                ProgressView("Konflikt wird verarbeitet …")
+                    .padding(20)
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+        }
+        .confirmationDialog(
+            selectedConflict.map(dialogTitle(for:)) ?? "Sync-Konflikt",
+            isPresented: selectedConflictPresented,
+            titleVisibility: .visible,
+            presenting: selectedConflict
+        ) { conflict in
+            Button("Lokal hat recht") {
+                resolveConflict(conflict, preferLocal: true)
+            }
+            Button("Cloud hat recht") {
+                resolveConflict(conflict, preferLocal: false)
+            }
+            Button("Abbrechen", role: .cancel) {}
+        } message: { conflict in
+            Text(dialogMessage(for: conflict))
+        }
+        .onAppear {
+            presentNextConflictIfNeeded()
+        }
+        .onChange(of: controller.conflicts.map(\.id)) { _, _ in
+            presentNextConflictIfNeeded()
+        }
         .refreshable {
             controller.load()
         }
@@ -378,6 +408,52 @@ private struct ManageCloudDataView: View {
             Spacer()
             Text(value)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    private var selectedConflictPresented: Binding<Bool> {
+        Binding(
+            get: { selectedConflict != nil },
+            set: { isPresented in
+                if !isPresented {
+                    selectedConflict = nil
+                }
+            }
+        )
+    }
+
+    private func dialogTitle(for conflict: SyncConflict) -> String {
+        "\(conflictTitle(for: conflict)) in Konflikt"
+    }
+
+    private func dialogMessage(for conflict: SyncConflict) -> String {
+        "Der lokale Stand und die Cloud-Daten unterscheiden sich. Wähle, welche Version gelten soll. Abweichende Felder: \(conflict.conflictingFields.joined(separator: ", "))."
+    }
+
+    private func presentNextConflictIfNeeded() {
+        guard selectedConflict == nil, !controller.conflicts.isEmpty else {
+            return
+        }
+
+        selectedConflict = controller.conflicts.first
+    }
+
+    private func resolveConflict(_ conflict: SyncConflict, preferLocal: Bool) {
+        selectedConflict = nil
+        isResolvingConflict = true
+
+        Task {
+            if preferLocal {
+                await controller.resolveConflictKeepingLocal(conflict)
+                await controller.syncNow()
+            } else {
+                await controller.resolveConflictUsingRemote(conflict)
+            }
+
+            await MainActor.run {
+                isResolvingConflict = false
+                presentNextConflictIfNeeded()
+            }
         }
     }
 }

--- a/MigraineTracker/Sources/Features/Sync/SyncCoordinator.swift
+++ b/MigraineTracker/Sources/Features/Sync/SyncCoordinator.swift
@@ -118,40 +118,36 @@ final class SyncCoordinator {
         await syncNow()
     }
 
-    func resolveConflictKeepingLocal(_ conflict: SyncConflict) {
-        Task {
+    func resolveConflictKeepingLocal(_ conflict: SyncConflict) async {
+        await stateStore.removeConflict(documentID: conflict.documentID)
+        conflicts = await stateStore.conflicts()
+        await log(level: .info, operation: "coordinator.resolveConflictKeepingLocal", message: "Lokale Version eines Konflikts wurde beibehalten.", metadata: [
+            "documentID": conflict.documentID,
+            "entityType": conflict.entityType.rawValue,
+            "fields": conflict.conflictingFields.joined(separator: ",")
+        ])
+        status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+    }
+
+    func resolveConflictUsingRemote(_ conflict: SyncConflict) async {
+        do {
+            try repository.apply(remote: conflict.remote)
+            await stateStore.saveShadow(SyncShadow(envelope: conflict.remote), for: conflict.documentID)
             await stateStore.removeConflict(documentID: conflict.documentID)
             conflicts = await stateStore.conflicts()
-            await log(level: .info, operation: "coordinator.resolveConflictKeepingLocal", message: "Lokale Version eines Konflikts wurde beibehalten.", metadata: [
+            await log(level: .info, operation: "coordinator.resolveConflictUsingRemote", message: "Cloud-Version eines Konflikts wurde übernommen.", metadata: [
                 "documentID": conflict.documentID,
                 "entityType": conflict.entityType.rawValue,
                 "fields": conflict.conflictingFields.joined(separator: ",")
             ])
             status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
-        }
-    }
-
-    func resolveConflictUsingRemote(_ conflict: SyncConflict) {
-        Task {
-            do {
-                try repository.apply(remote: conflict.remote)
-                await stateStore.saveShadow(SyncShadow(envelope: conflict.remote), for: conflict.documentID)
-                await stateStore.removeConflict(documentID: conflict.documentID)
-                conflicts = await stateStore.conflicts()
-                await log(level: .info, operation: "coordinator.resolveConflictUsingRemote", message: "Cloud-Version eines Konflikts wurde übernommen.", metadata: [
-                    "documentID": conflict.documentID,
-                    "entityType": conflict.entityType.rawValue,
-                    "fields": conflict.conflictingFields.joined(separator: ",")
-                ])
-                status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
-            } catch {
-                await stateStore.setLastError(error.localizedDescription)
-                await log(level: .error, operation: "coordinator.resolveConflictUsingRemote.error", message: "Konflikt konnte nicht mit Cloud-Daten aufgelöst werden.", metadata: [
-                    "documentID": conflict.documentID,
-                    "error": error.localizedDescription
-                ])
-                status = await buildStatusSnapshot(baseState: .needsAttention, isSyncing: false)
-            }
+        } catch {
+            await stateStore.setLastError(error.localizedDescription)
+            await log(level: .error, operation: "coordinator.resolveConflictUsingRemote.error", message: "Konflikt konnte nicht mit Cloud-Daten aufgelöst werden.", metadata: [
+                "documentID": conflict.documentID,
+                "error": error.localizedDescription
+            ])
+            status = await buildStatusSnapshot(baseState: .needsAttention, isSyncing: false)
         }
     }
 

--- a/MigraineTracker/Sources/Infrastructure/Sync/SyncServiceAdapter.swift
+++ b/MigraineTracker/Sources/Infrastructure/Sync/SyncServiceAdapter.swift
@@ -28,12 +28,12 @@ final class SyncServiceAdapter: SyncService {
         await coordinator.retryLastError()
     }
 
-    func resolveConflictKeepingLocal(_ conflict: SyncConflict) {
-        coordinator.resolveConflictKeepingLocal(conflict)
+    func resolveConflictKeepingLocal(_ conflict: SyncConflict) async {
+        await coordinator.resolveConflictKeepingLocal(conflict)
     }
 
-    func resolveConflictUsingRemote(_ conflict: SyncConflict) {
-        coordinator.resolveConflictUsingRemote(conflict)
+    func resolveConflictUsingRemote(_ conflict: SyncConflict) async {
+        await coordinator.resolveConflictUsingRemote(conflict)
     }
 }
 


### PR DESCRIPTION
## Zusammenfassung

Diese Änderung ergänzt im Screen `Cloud-Daten` einen echten Konflikt-Dialog für erkannte Sync-Konflikte. Nutzer können klar zwischen lokalem und Cloud-Stand wählen, statt nur statische Inline-Aktionen in der Liste zu sehen.

Closes #57

## Was sich geändert hat

- Konflikte öffnen jetzt einen Dialog mit den Optionen `Lokal hat recht` und `Cloud hat recht`
- Der Dialog erklärt, dass lokaler und Cloud-Stand voneinander abweichen, und zeigt die abweichenden Felder an
- Während der Auflösung wird ein Fortschrittsstatus angezeigt, damit kein unklarer Zwischenzustand entsteht
- Die Konfliktauflösung läuft jetzt asynchron durch Controller, Service-Adapter und Coordinator
- Bei `Lokal hat recht` wird nach der Entscheidung direkt ein Sync gestartet, damit der lokale Stand wieder in die Cloud geschrieben wird

## Warum

Issue #57 verlangt eine sichtbare und verständliche Konfliktauflösung im UI sowie eine saubere Weitergabe der Entscheidung an Persistenz- und Sync-Ebene. Die bisherige Darstellung im `Cloud-Daten`-Screen war funktional, aber nicht als klarer Konflikt-Dialog umgesetzt.

## Validierung

- `xcodebuild -scheme MigraineTracker -project MigraineTracker.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16' build`
