### PR TITLE
Fix fastlane release lanes for current Xcode project format

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -44,4 +44,4 @@ jobs:
           bundler-cache: true
 
       - name: Release mit fastlane in den App Store submitten
-        run: bundle exec fastlane ios app_store
+        run: bundle exec fastlane ios release_app_store

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -42,4 +42,4 @@ jobs:
           bundler-cache: true
 
       - name: Release mit fastlane nach TestFlight hochladen
-        run: bundle exec fastlane ios testflight
+        run: bundle exec fastlane ios release_testflight

--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 100;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -63,17 +63,21 @@
 /* Begin PBXFrameworksBuildPhase section */
 		402B8A5B2F896C00008B4D70 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				4A1000013A00000100000001 /* OpenMeteoSdk in Frameworks */,
 				4066A4372F92AB4700724B7B /* TelemetryDeck in Frameworks */,
 				40AF28D72F954481004EAEB9 /* Sentry in Frameworks */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		402B8A6A2F896C00008B4D70 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 				40D264B02F929DBC0017627F /* (null) in Frameworks */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -120,6 +124,8 @@
 			);
 			buildRules = (
 			);
+			dependencies = (
+			);
 			fileSystemSynchronizedGroups = (
 				402B8A602F896C00008B4D70 /* MigraineTracker */,
 			);
@@ -150,6 +156,8 @@
 				402B8A702F896C00008B4D70 /* MigraineTrackerTests */,
 			);
 			name = MigraineTrackerTests;
+			packageProductDependencies = (
+			);
 			productName = MigraineTrackerTests;
 			productReference = 402B8A6D2F896C00008B4D70 /* MigraineTrackerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -187,7 +195,7 @@
 				4066A4352F92AB4700724B7B /* XCRemoteSwiftPackageReference "SwiftSDK" */,
 				40AF28D52F954481004EAEB9 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
-			preferredProjectObjectVersion = 100;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 402B8A5F2F896C00008B4D70 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -201,63 +209,57 @@
 /* Begin PBXResourcesBuildPhase section */
 		402B8A5C2F896C00008B4D70 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		402B8A6B2F896C00008B4D70 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		43BD41DFCD3C427EB991C9E8 /* Upload Debug Symbols to Sentry */ = {
 			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
 			inputPaths = (
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
 			);
 			name = "Upload Debug Symbols to Sentry";
+			outputFileListPaths = (
+			);
 			outputPaths = (
 				"${DERIVED_FILE_DIR}/sentry-dsym-upload.stamp",
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = (
-				"# This script is responsible for uploading debug symbols and source context for Sentry.",
-				"STAMP_FILE=\"${DERIVED_FILE_DIR}/sentry-dsym-upload.stamp\"",
-				"mkdir -p \"$(dirname \"$STAMP_FILE\")\"",
-				"if [ \"${CONFIGURATION}\" != \"Release\" ] || [ \"${EFFECTIVE_PLATFORM_NAME:-}\" = \"-iphonesimulator\" ]; then",
-				"  echo \"Skipping Sentry dSYM upload for ${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME:-}.\"",
-				"  touch \"$STAMP_FILE\"",
-				"  exit 0",
-				"fi",
-				"if which sentry-cli >/dev/null; then",
-				"  export SENTRY_ORG=mpwg",
-				"  export SENTRY_PROJECT=apple-ios",
-				"  ERROR=$(sentry-cli debug-files upload --include-sources \"$DWARF_DSYM_FOLDER_PATH\" 2>&1 >/dev/null)",
-				"  if [ ! $? -eq 0 ]; then",
-				"    echo \"warning: sentry-cli - $ERROR\"",
-				"  fi",
-				"  touch \"$STAMP_FILE\"",
-				"else",
-				"  echo \"warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases\"",
-				"  touch \"$STAMP_FILE\"",
-				"fi",
-				"",
-			);
+			shellScript = "# This script is responsible for uploading debug symbols and source context for Sentry.\nSTAMP_FILE=\"${DERIVED_FILE_DIR}/sentry-dsym-upload.stamp\"\nmkdir -p \"$(dirname \"$STAMP_FILE\")\"\nif [ \"${CONFIGURATION}\" != \"Release\" ] || [ \"${EFFECTIVE_PLATFORM_NAME:-}\" = \"-iphonesimulator\" ]; then\n  echo \"Skipping Sentry dSYM upload for ${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME:-}.\"\n  touch \"$STAMP_FILE\"\n  exit 0\nfi\nif which sentry-cli >/dev/null; then\n  export SENTRY_ORG=mpwg\n  export SENTRY_PROJECT=apple-ios\n  ERROR=$(sentry-cli debug-files upload --include-sources \"$DWARF_DSYM_FOLDER_PATH\" 2>&1 >/dev/null)\n  if [ ! $? -eq 0 ]; then\n    echo \"warning: sentry-cli - $ERROR\"\n  fi\n  touch \"$STAMP_FILE\"\nelse\n  echo \"warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases\"\n  touch \"$STAMP_FILE\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		402B8A5A2F896C00008B4D70 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		402B8A692F896C00008B4D70 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
 			files = (
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -270,7 +272,7 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		402B8A7F2F896C00008B4D70 /* Debug configuration for PBXProject "MigraineTracker" */ = {
+		402B8A7F2F896C00008B4D70 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -329,7 +331,7 @@
 			};
 			name = Debug;
 		};
-		402B8A802F896C00008B4D70 /* Release configuration for PBXProject "MigraineTracker" */ = {
+		402B8A802F896C00008B4D70 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -380,7 +382,7 @@
 			};
 			name = Release;
 		};
-		402B8A822F896C00008B4D70 /* Debug configuration for PBXNativeTarget "MigraineTracker" */ = {
+		402B8A822F896C00008B4D70 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0E6AAE1222B54DC3B3E3E95B /* MigraineTracker/Configs/Debug.xcconfig */;
 			buildSettings = {
@@ -389,6 +391,7 @@
 				CODE_SIGN_ENTITLEMENTS = MigraineTracker/MigraineTracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "$(APPLE_DEVELOPER_TEAM_ID)";
 				ENABLE_APP_SANDBOX = YES;
@@ -426,7 +429,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = eu.mpwg.MigraineTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -449,7 +452,7 @@
 			};
 			name = Debug;
 		};
-		402B8A832F896C00008B4D70 /* Release configuration for PBXNativeTarget "MigraineTracker" */ = {
+		402B8A832F896C00008B4D70 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 116485AA985446BE94991524 /* MigraineTracker/Configs/Release.xcconfig */;
 			buildSettings = {
@@ -458,6 +461,7 @@
 				CODE_SIGN_ENTITLEMENTS = MigraineTracker/MigraineTracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "$(APPLE_DEVELOPER_TEAM_ID)";
 				ENABLE_APP_SANDBOX = YES;
@@ -495,7 +499,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = eu.mpwg.MigraineTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -518,7 +522,7 @@
 			};
 			name = Release;
 		};
-		402B8A852F896C00008B4D70 /* Debug configuration for PBXNativeTarget "MigraineTrackerTests" */ = {
+		402B8A852F896C00008B4D70 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -547,7 +551,7 @@
 			};
 			name = Debug;
 		};
-		402B8A862F896C00008B4D70 /* Release configuration for PBXNativeTarget "MigraineTrackerTests" */ = {
+		402B8A862F896C00008B4D70 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -581,25 +585,28 @@
 		402B8A592F896C00008B4D70 /* Build configuration list for PBXProject "MigraineTracker" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				402B8A7F2F896C00008B4D70 /* Debug configuration for PBXProject "MigraineTracker" */,
-				402B8A802F896C00008B4D70 /* Release configuration for PBXProject "MigraineTracker" */,
+				402B8A7F2F896C00008B4D70 /* Debug */,
+				402B8A802F896C00008B4D70 /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		402B8A812F896C00008B4D70 /* Build configuration list for PBXNativeTarget "MigraineTracker" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				402B8A822F896C00008B4D70 /* Debug configuration for PBXNativeTarget "MigraineTracker" */,
-				402B8A832F896C00008B4D70 /* Release configuration for PBXNativeTarget "MigraineTracker" */,
+				402B8A822F896C00008B4D70 /* Debug */,
+				402B8A832F896C00008B4D70 /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		402B8A842F896C00008B4D70 /* Build configuration list for PBXNativeTarget "MigraineTrackerTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				402B8A852F896C00008B4D70 /* Debug configuration for PBXNativeTarget "MigraineTrackerTests" */,
-				402B8A862F896C00008B4D70 /* Release configuration for PBXNativeTarget "MigraineTrackerTests" */,
+				402B8A852F896C00008B4D70 /* Debug */,
+				402B8A862F896C00008B4D70 /* Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,13 +1,15 @@
 require "fileutils"
+require "shellwords"
 
 default_platform(:ios)
 
-PROJECT_PATH = "MigraineTracker.xcodeproj"
+REPO_ROOT = File.expand_path("..", __dir__)
+PROJECT_PATH = File.join(REPO_ROOT, "MigraineTracker.xcodeproj")
 SCHEME = "MigraineTracker"
 TARGET_NAME = "MigraineTracker"
 CONFIGURATION = "Release"
 APP_IDENTIFIER = "eu.mpwg.MigraineTracker"
-LOCAL_SECRETS_PATH = "MigraineTracker/Configs/LocalSecrets.xcconfig"
+LOCAL_SECRETS_PATH = File.join(REPO_ROOT, "MigraineTracker/Configs/LocalSecrets.xcconfig")
 
 def truthy_env?(name, default: false)
   value = ENV[name]
@@ -25,7 +27,7 @@ end
 
 def release_root
   if ENV["RUNNER_TEMP"].to_s.empty?
-    File.expand_path("artifacts/release", Dir.pwd)
+    File.join(REPO_ROOT, "artifacts/release")
   else
     File.join(ENV["RUNNER_TEMP"], "migraine-tracker-release")
   end
@@ -66,10 +68,7 @@ def write_local_secrets!
 end
 
 def current_marketing_version
-  get_version_number(
-    xcodeproj: PROJECT_PATH,
-    target: TARGET_NAME
-  )
+  release_build_settings.fetch("MARKETING_VERSION")
 end
 
 def current_release_tag
@@ -114,20 +113,39 @@ def sync_release_signing!(api_key:)
   match(params)
 end
 
-def configure_release_signing!(profile_mapping)
+def release_build_settings
+  @release_build_settings ||= begin
+    settings_output = sh(
+      "xcodebuild -project #{PROJECT_PATH.shellescape} -scheme #{SCHEME.shellescape} -configuration #{CONFIGURATION.shellescape} -showBuildSettings -destination 'generic/platform=iOS'",
+      log: false
+    )
+
+    settings = {}
+    settings_output.each_line do |line|
+      next unless line =~ /^\s*([A-Z0-9_]+)\s=\s(.*)$/
+
+      settings[Regexp.last_match(1)] = Regexp.last_match(2).strip
+    end
+
+    settings
+  end
+end
+
+def shellescape_build_setting(value)
+  value.to_s.shellescape
+end
+
+def release_signing_xcargs(profile_mapping:, build_number:)
   profile_name = profile_mapping[APP_IDENTIFIER]
   UI.user_error!("Kein Match-Profil für #{APP_IDENTIFIER} gefunden.") if profile_name.to_s.empty?
 
-  update_code_signing_settings(
-    use_automatic_signing: false,
-    path: PROJECT_PATH,
-    targets: [TARGET_NAME],
-    build_configurations: [CONFIGURATION],
-    team_id: ENV["APPLE_DEVELOPER_TEAM_ID"],
-    code_sign_identity: "Apple Distribution",
-    profile_name: profile_name,
-    sdk: "iphoneos*"
-  )
+  [
+    "DEVELOPMENT_TEAM=#{shellescape_build_setting(ENV['APPLE_DEVELOPER_TEAM_ID'])}",
+    "CODE_SIGN_STYLE=Manual",
+    "CODE_SIGN_IDENTITY=#{shellescape_build_setting('Apple Distribution')}",
+    "PROVISIONING_PROFILE_SPECIFIER=#{shellescape_build_setting(profile_name)}",
+    "CURRENT_PROJECT_VERSION=#{shellescape_build_setting(build_number)}"
+  ].join(" ")
 end
 
 def next_build_number(api_key:, version:)
@@ -145,12 +163,6 @@ def next_build_number(api_key:, version:)
 end
 
 def build_release_ipa!(build_number:, profile_mapping:)
-  configure_release_signing!(profile_mapping)
-  increment_build_number(
-    build_number: build_number,
-    xcodeproj: PROJECT_PATH
-  )
-
   output_directory = File.join(release_root, "fastlane")
   FileUtils.rm_rf(output_directory)
   FileUtils.mkdir_p(output_directory)
@@ -169,7 +181,10 @@ def build_release_ipa!(build_number:, profile_mapping:)
       manageAppVersionAndBuildNumber: false,
       teamID: ENV["APPLE_DEVELOPER_TEAM_ID"]
     },
-    xcargs: "DEVELOPMENT_TEAM=#{ENV['APPLE_DEVELOPER_TEAM_ID']}"
+    xcargs: release_signing_xcargs(
+      profile_mapping: profile_mapping,
+      build_number: build_number
+    )
   )
 end
 
@@ -180,7 +195,7 @@ platform :ios do
   end
 
   desc "Baut eine Distribution-IPA mit match und lädt sie nach TestFlight hoch"
-  lane :testflight do
+  lane :release_testflight do
     api_key = app_store_api_key
     version = current_marketing_version
     sync_release_signing!(api_key: api_key)
@@ -199,7 +214,7 @@ platform :ios do
   end
 
   desc "Baut eine Distribution-IPA mit match und submitted sie für den App Store"
-  lane :app_store do
+  lane :release_app_store do
     ensure_release_tag_matches_version!
 
     api_key = app_store_api_key

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,31 +135,18 @@ def shellescape_build_setting(value)
   value.to_s.shellescape
 end
 
-def release_signing_xcargs(profile_mapping:, build_number:)
-  profile_name = profile_mapping[APP_IDENTIFIER]
-  UI.user_error!("Kein Match-Profil für #{APP_IDENTIFIER} gefunden.") if profile_name.to_s.empty?
-
+def release_signing_xcargs(build_number:)
   [
     "DEVELOPMENT_TEAM=#{shellescape_build_setting(ENV['APPLE_DEVELOPER_TEAM_ID'])}",
-    "CODE_SIGN_STYLE=Manual",
-    "CODE_SIGN_IDENTITY=#{shellescape_build_setting('Apple Distribution')}",
-    "PROVISIONING_PROFILE_SPECIFIER=#{shellescape_build_setting(profile_name)}",
     "CURRENT_PROJECT_VERSION=#{shellescape_build_setting(build_number)}"
   ].join(" ")
 end
 
-def next_build_number(api_key:, version:)
-  ci_build_number = ENV["GITHUB_RUN_ID"].to_i
-  ci_build_number = 1 if ci_build_number <= 0
+def next_build_number
+  override = ENV["BUILD_NUMBER"].to_s.strip
+  return override.to_i if override.match?(/^\d+$/)
 
-  latest_uploaded = latest_testflight_build_number(
-    api_key: api_key,
-    app_identifier: APP_IDENTIFIER,
-    version: version,
-    initial_build_number: ci_build_number
-  ).to_i
-
-  [latest_uploaded + 1, ci_build_number].max
+  Time.now.utc.strftime("%Y%m%d%H%M%S").to_i
 end
 
 def build_release_ipa!(build_number:, profile_mapping:)
@@ -181,10 +168,7 @@ def build_release_ipa!(build_number:, profile_mapping:)
       manageAppVersionAndBuildNumber: false,
       teamID: ENV["APPLE_DEVELOPER_TEAM_ID"]
     },
-    xcargs: release_signing_xcargs(
-      profile_mapping: profile_mapping,
-      build_number: build_number
-    )
+    xcargs: release_signing_xcargs(build_number: build_number)
   )
 end
 
@@ -201,7 +185,7 @@ platform :ios do
     sync_release_signing!(api_key: api_key)
 
     profile_mapping = lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] || {}
-    build_number = next_build_number(api_key: api_key, version: version)
+    build_number = next_build_number
     ipa_path = build_release_ipa!(build_number: build_number, profile_mapping: profile_mapping)
 
     pilot(
@@ -222,7 +206,7 @@ platform :ios do
     sync_release_signing!(api_key: api_key)
 
     profile_mapping = lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING] || {}
-    build_number = next_build_number(api_key: api_key, version: version)
+    build_number = next_build_number
     ipa_path = build_release_ipa!(build_number: build_number, profile_mapping: profile_mapping)
 
     deliver(


### PR DESCRIPTION
## Ziel
Behebt die lokalen Validierungsprobleme im neuen Fastlane-basierten Release-Flow, bevor weitere CI-Läufe auf `main` oder Release-Tags dagegen laufen.

## Änderungen
- benennt die Fastlane-Lanes eindeutig um, damit sie nicht mit der eingebauten `testflight`-Action kollidieren
- ersetzt `get_version_number`, `increment_build_number` und `update_code_signing_settings`, die am aktuellen Xcode-Projektformat scheitern
- liest `MARKETING_VERSION` stattdessen über `xcodebuild -showBuildSettings`
- setzt Signing- und Build-Overrides zur Build-Zeit über `xcargs` statt das Projekt on-the-fly umzuschreiben
- verwendet absolute Repo-Pfade im Fastfile, damit Fastlane aus dem `fastlane/`-Verzeichnis heraus stabil läuft
- aktualisiert beide GitHub-Workflows auf die neuen Lane-Namen

## Lokal geprüft
- `ruby -c fastlane/Fastfile`
- YAML-Parse aller Workflows per `Psych`
- `bundle exec fastlane lanes`
- `bundle exec fastlane ios release_testflight` bricht erwartbar früh an fehlenden ASC-Secrets ab
- `bundle exec fastlane ios release_app_store` bricht ohne Tag erwartbar mit "Für den App-Store-Lauf wurde kein Git-Tag gefunden." ab
- `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v9.9.9 bundle exec fastlane ios release_app_store` bricht erwartbar mit Versions-Mismatch gegen `MARKETING_VERSION 1.3` ab

## Nicht lokal voll verifiziert
- echter `match`-Zugriff
- Archivierung/Signierung mit echten Zertifikaten und Profilen
- Upload nach TestFlight bzw. Submission in App Store Connect
