### PR TITLE
[codex] Restrict CI and deployment triggers

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -6,7 +6,38 @@ on:
       - 'v*'
 
 jobs:
+  detect-release-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.filter.outputs.should_deploy }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Relevante Release-Änderungen prüfen
+        id: filter
+        run: |
+          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            changed_files="$(git diff --name-only HEAD^ HEAD)"
+          else
+            changed_files="$(git ls-tree --name-only -r HEAD)"
+          fi
+
+          printf 'Geänderte Dateien:\n%s\n' "${changed_files}"
+
+          if printf '%s\n' "${changed_files}" | grep -Eq '^(MigraineTracker/|MigraineTracker\.xcodeproj/|fastlane/|Gemfile$|Gemfile\.lock$|\.ruby-version$|\.github/workflows/ios-app-store\.yml$)'; then
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Keine relevanten Änderungen für ein App-Store-Deployment gefunden."
+          fi
+        shell: bash
+
   submit-to-app-store:
+    needs: detect-release-changes
+    if: needs.detect-release-changes.outputs.should_deploy == 'true'
     runs-on: macos-26
     timeout-minutes: 120
     permissions:

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -4,9 +4,19 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'MigraineTracker/**'
+      - 'MigraineTrackerTests/**'
+      - 'MigraineTracker.xcodeproj/**'
+      - '.github/workflows/ios-ci.yml'
   push:
     branches:
       - main
+    paths:
+      - 'MigraineTracker/**'
+      - 'MigraineTrackerTests/**'
+      - 'MigraineTracker.xcodeproj/**'
+      - '.github/workflows/ios-ci.yml'
 
 jobs:
   build-and-test:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'MigraineTracker/**'
+      - 'MigraineTracker.xcodeproj/**'
+      - 'fastlane/**'
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.ruby-version'
+      - '.github/workflows/ios-testflight.yml'
 
 jobs:
   upload-to-testflight:


### PR DESCRIPTION
## Was sich ändert

- begrenzt den `iOS CI`-Workflow auf Änderungen an App-Code, Tests, Projektdateien und dem Workflow selbst
- begrenzt den `TestFlight Release`-Workflow auf deploy-relevante Änderungen an App-, Projekt- und Fastlane-Dateien
- ergänzt im `App Store Release`-Workflow einen vorgeschalteten Prüfjob, der Releases ohne relevante Codeänderungen überspringt

## Warum

Builds und Deployments liefen bisher auch bei irrelevanten Änderungen, zum Beispiel an Dokumentation. Das erzeugt unnötige CI-Last und kann unbeabsichtigte Releases anstoßen.

## Auswirkung

Nur Änderungen an tatsächlich build- oder deployrelevanten Stellen lösen die entsprechenden Workflows aus. Reine Doku- oder Nebenänderungen starten diese Jobs nicht mehr.

## Verifikation

- YAML-Syntax der drei Workflow-Dateien lokal mit `Ruby YAML.load_file` geprüft
- Trigger- und Filterlogik in den aktualisierten GitHub-Workflows geprüft