### PR TITLE
Add GitHub CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,79 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'MigraineTracker/**'
+      - 'MigraineTrackerTests/**'
+      - 'MigraineTracker.xcodeproj/**'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'MigraineTracker/**'
+      - 'MigraineTrackerTests/**'
+      - 'MigraineTracker.xcodeproj/**'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze (Swift)
+    runs-on: macos-26
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - swift
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Xcode 26.4 auswählen
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.4'
+
+      - name: CodeQL initialisieren
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: manual
+
+      - name: Simulator-Ziel wählen
+        run: |
+          DEVICE_NAME="$(xcrun simctl list devices available | grep -E 'iPhone (17|Air)' | head -n 1 | sed -E 's/^[[:space:]]*([^()]+) \(.*/\1/' | xargs)"
+          if [ -z "${DEVICE_NAME}" ]; then
+            echo "Kein passender iPhone-Simulator gefunden."
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "IOS_DESTINATION=platform=iOS Simulator,name=${DEVICE_NAME}" >> "$GITHUB_ENV"
+          echo "Verwende Simulator: ${DEVICE_NAME}"
+
+      - name: Swift Packages auflösen
+        run: xcodebuild -resolvePackageDependencies -project MigraineTracker.xcodeproj -scheme MigraineTracker
+
+      - name: App für CodeQL bauen
+        run: |
+          xcodebuild build \
+            -project MigraineTracker.xcodeproj \
+            -scheme MigraineTracker \
+            -destination "${IOS_DESTINATION}" \
+            -derivedDataPath "${RUNNER_TEMP}/DerivedData" \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: CodeQL analysieren
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Zusammenfassung
- fügt einen separaten GitHub-Actions-Workflow für CodeQL hinzu
- analysiert Swift-Code bei Pushes und Pull Requests auf `main`
- unterstützt zusätzlich manuelle Ausführung und einen wöchentlichen Scan

## Details
- verwendet `github/codeql-action` mit `build-mode: manual`
- baut das iOS-Projekt auf `macos-26` mit Xcode `26.4`
- deaktiviert Codesigning für den Analyse-Build mit `CODE_SIGNING_ALLOWED=NO`

## Test
- YAML-Syntax lokal validiert