### PR TITLE
Rebrand app as Schmerztagebuch

### DIFF
--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				ICLOUD_CONTAINER_ENVIRONMENT = Development;
 				INFOPLIST_FILE = MigraineTracker/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Schmerztagebuch;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Open-Meteo auf Basis von DWD ICON abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.";
@@ -482,6 +483,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				ICLOUD_CONTAINER_ENVIRONMENT = Production;
 				INFOPLIST_FILE = MigraineTracker/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Schmerztagebuch;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Open-Meteo auf Basis von DWD ICON abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.";

--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 				CODE_SIGN_ENTITLEMENTS = MigraineTracker/MigraineTracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "$(APPLE_DEVELOPER_TEAM_ID)";
 				ENABLE_APP_SANDBOX = YES;
@@ -430,7 +430,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = eu.mpwg.MigraineTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -462,7 +462,7 @@
 				CODE_SIGN_ENTITLEMENTS = MigraineTracker/MigraineTracker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "$(APPLE_DEVELOPER_TEAM_ID)";
 				ENABLE_APP_SANDBOX = YES;
@@ -501,7 +501,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = eu.mpwg.MigraineTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore eu.mpwg.MigraineTracker";

--- a/MigraineTracker/Sources/Core/History/HistoryCore.swift
+++ b/MigraineTracker/Sources/Core/History/HistoryCore.swift
@@ -113,7 +113,7 @@ final class HistoryController {
             selectedDayEpisodes = try loadDayEpisodesUseCase.execute(day: selectedDay)
             errorMessage = nil
         } catch {
-            errorMessage = "Verlauf konnte nicht geladen werden."
+            errorMessage = "Tagebuch konnte nicht geladen werden."
         }
     }
 

--- a/MigraineTracker/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/MigraineTracker/Sources/Features/Capture/EpisodeEditorView.swift
@@ -67,7 +67,7 @@ struct EpisodeEditorView: View {
             } header: {
                 Text("Schneller Eintrag")
             } footer: {
-                Text("Nur Typ, Intensität und Zeitpunkt sind direkt sichtbar. Alles Weitere ist optional.")
+                Text("So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional.")
             }
 
             tagSection(title: "Symptome", options: controller.symptomOptions, selection: $controller.draft.selectedSymptoms)
@@ -107,7 +107,7 @@ struct EpisodeEditorView: View {
             } header: {
                 Text("Wetter")
             } footer: {
-                Text("Das Wetter wird mit deinem ungefähren Standort über Open-Meteo auf Basis von DWD ICON geladen. Die Episode wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.")
+                Text("Das Wetter wird mit deinem ungefähren Standort über Open-Meteo auf Basis von DWD ICON geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.")
             }
 
             Section("Medikamente") {
@@ -187,7 +187,7 @@ struct EpisodeEditorView: View {
             }
 
             Section {
-                Button(controller.mode == .create ? "Episode speichern" : "Änderungen speichern") {
+                Button(controller.mode == .create ? "Eintrag speichern" : "Änderungen speichern") {
                     controller.save(onSaved: onSaved) {
                         dismiss()
                     }
@@ -196,7 +196,7 @@ struct EpisodeEditorView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
             }
         }
-        .navigationTitle(controller.mode == .create ? "Erfassen" : "Episode bearbeiten")
+        .navigationTitle(controller.mode == .create ? "Neuer Eintrag" : "Eintrag bearbeiten")
         .toolbar {
             if showsDismissButton {
                 ToolbarItem(placement: dismissButtonPlacement) {
@@ -207,10 +207,10 @@ struct EpisodeEditorView: View {
             }
         }
         .scrollDismissesKeyboard(.interactively)
-        .alert("Episode gespeichert", isPresented: $controller.saveMessageVisible) {
+        .alert("Eintrag gespeichert", isPresented: $controller.saveMessageVisible) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Die Episode wurde lokal gespeichert.")
+            Text("Dein Eintrag wurde lokal gespeichert.")
         }
         .sheet(item: $controller.customMedicationEditor) { editorState in
             NavigationStack {

--- a/MigraineTracker/Sources/Features/Export/DataExportView.swift
+++ b/MigraineTracker/Sources/Features/Export/DataExportView.swift
@@ -18,18 +18,18 @@ struct DataExportView: View {
             }
 
             Section("Bericht") {
-                Text("Episoden im Zeitraum: \(controller.summary.episodeCount)")
+                Text("Einträge im Zeitraum: \(controller.summary.episodeCount)")
                     .font(.headline)
                 if controller.summary.episodeCount > 0 {
                     Text("Durchschnittliche Intensität: \(controller.summary.averageIntensity.formatted(.number.precision(.fractionLength(1))))/10")
                         .foregroundStyle(.secondary)
                 }
-                Text("Der PDF-Export wird lokal erzeugt und kann systemweit geteilt werden.")
+                Text("Der PDF-Bericht von \(ProductBranding.displayName) wird lokal erzeugt und kann systemweit geteilt werden.")
                     .foregroundStyle(.secondary)
             }
 
             Section("Daten sichern") {
-                Text("JSON5-Export enthält alle Episoden sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.")
+                Text("JSON5-Export enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.")
                     .foregroundStyle(.secondary)
 
                 Button("JSON5 erstellen") {
@@ -75,9 +75,9 @@ struct DataExportView: View {
             if controller.summary.records.isEmpty {
                 Section {
                     ContentUnavailableView(
-                        "Keine Episoden im Zeitraum",
+                        "Keine Einträge im Zeitraum",
                         systemImage: "square.and.arrow.up",
-                        description: Text("Passe den Zeitraum an, damit ein PDF-Bericht erstellt werden kann.")
+                        description: Text("Passe den Zeitraum an, damit ein Bericht aus deinem Tagebuch erstellt werden kann.")
                     )
                 }
             } else {

--- a/MigraineTracker/Sources/Features/Export/DataTransfer.swift
+++ b/MigraineTracker/Sources/Features/Export/DataTransfer.swift
@@ -12,7 +12,7 @@ enum DataTransferError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidFormat:
-            return "Die Datei enthält kein unterstütztes MigraineTracker-Datenformat."
+            return "Die Datei enthält kein unterstütztes Datenformat für \(ProductBranding.displayName)."
         }
     }
 }
@@ -47,7 +47,7 @@ struct DataTransferSnapshot: Codable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
 
-        let fileName = "migraine-tracker-export-\(Self.fileDateFormatter.string(from: exportedAt)).json5"
+        let fileName = "schmerztagebuch-export-\(Self.fileDateFormatter.string(from: exportedAt)).json5"
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
         let data = try encoder.encode(self)
 

--- a/MigraineTracker/Sources/Features/Export/PDFExportWriter.swift
+++ b/MigraineTracker/Sources/Features/Export/PDFExportWriter.swift
@@ -5,7 +5,7 @@ import PDFKit
 
 enum PDFExportWriter {
     static func write(summary: ExportPeriodSummary) throws -> URL {
-        let fileName = "MigraineTracker-\(dateStamp(summary.startDate))-\(dateStamp(summary.endDate)).pdf"
+        let fileName = "Schmerztagebuch-Migraene-Co-\(dateStamp(summary.startDate))-\(dateStamp(summary.endDate)).pdf"
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
         let pageRect = CGRect(x: 0, y: 0, width: 595, height: 842)
         let layout = PDFLayout(pageRect: pageRect)
@@ -19,9 +19,9 @@ enum PDFExportWriter {
     private static func writeRawPDF(summary: ExportPeriodSummary, to url: URL, layout: PDFLayout) throws {
         var mediaBox = layout.pageRect
         let metadata = [
-            kCGPDFContextCreator: "MigraineTracker",
-            kCGPDFContextAuthor: "MigraineTracker",
-            kCGPDFContextTitle: "Migraine Tracker Bericht"
+            kCGPDFContextCreator: ProductBranding.displayName,
+            kCGPDFContextAuthor: ProductBranding.displayName,
+            kCGPDFContextTitle: "\(ProductBranding.displayName) Bericht"
         ] as CFDictionary
 
         guard let consumer = CGDataConsumer(url: url as CFURL),
@@ -32,9 +32,9 @@ enum PDFExportWriter {
 
         var page = PDFPageContext(context: context, layout: layout)
         page.beginPage()
-        try page.drawTitle("Migraine Tracker Bericht")
+        try page.drawTitle("\(ProductBranding.displayName) Bericht")
         try page.drawBodyLine("Zeitraum: \(summary.startDate.formatted(date: .abbreviated, time: .omitted)) bis \(summary.endDate.formatted(date: .abbreviated, time: .omitted))")
-        try page.drawBodyLine("Episoden: \(summary.episodeCount)")
+        try page.drawBodyLine("Einträge: \(summary.episodeCount)")
 
         if summary.episodeCount > 0 {
             try page.drawBodyLine("Durchschnittliche Intensität: \(summary.averageIntensity.formatted(.number.precision(.fractionLength(1))))/10")
@@ -45,7 +45,7 @@ enum PDFExportWriter {
         }
 
         page.addSpacing(18)
-        try page.drawSectionTitle("Episodenübersicht")
+        try page.drawSectionTitle("Tagebuchübersicht")
 
         for record in summary.records {
             try page.drawBlock(exportLines(for: record))
@@ -61,9 +61,9 @@ enum PDFExportWriter {
         }
 
         document.documentAttributes = [
-            PDFDocumentAttribute.titleAttribute: "Migraine Tracker Bericht",
-            PDFDocumentAttribute.authorAttribute: "MigraineTracker",
-            PDFDocumentAttribute.creatorAttribute: "MigraineTracker"
+            PDFDocumentAttribute.titleAttribute: "\(ProductBranding.displayName) Bericht",
+            PDFDocumentAttribute.authorAttribute: ProductBranding.displayName,
+            PDFDocumentAttribute.creatorAttribute: ProductBranding.displayName
         ]
 
         guard let data = document.dataRepresentation() else {

--- a/MigraineTracker/Sources/Features/History/HistoryView.swift
+++ b/MigraineTracker/Sources/Features/History/HistoryView.swift
@@ -14,7 +14,7 @@ struct HistoryView: View {
             VStack(alignment: .leading, spacing: 20) {
                 contentSection(
                     title: "Kalender",
-                    footer: "Wähle einen Tag aus und füge direkt einen Migräneanfall hinzu oder öffne vorhandene Einträge."
+                    footer: "Wähle einen Tag aus und füge direkt einen neuen Eintrag hinzu oder öffne vorhandene Dokumentationen."
                 ) {
                     VStack(alignment: .leading, spacing: 16) {
                         MonthHeader(
@@ -37,12 +37,12 @@ struct HistoryView: View {
                 Button {
                     controller.isPresentingNewEpisode = true
                 } label: {
-                    Label("Migräneanfall hinzufügen", systemImage: "plus.circle.fill")
+                    Label("Neuer Eintrag", systemImage: "plus.circle.fill")
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.large)
-                .accessibilityHint("Öffnet die Erfassung mit dem aktuell ausgewählten Kalendertag.")
+                .accessibilityHint("Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag.")
 
                 contentSection(title: "Ausgewählter Tag") {
                     VStack(alignment: .leading, spacing: 12) {
@@ -50,9 +50,9 @@ struct HistoryView: View {
 
                         if controller.selectedDayEpisodes.isEmpty {
                             ContentUnavailableView(
-                                "Keine Episoden an diesem Tag",
+                                "Noch keine Einträge an diesem Tag",
                                 systemImage: "calendar",
-                                description: Text("Für \(controller.selectedDay.formatted(date: .complete, time: .omitted)) sind keine Episoden gespeichert.")
+                                description: Text("Für \(controller.selectedDay.formatted(date: .complete, time: .omitted)) ist noch nichts dokumentiert.")
                             )
                         } else {
                             ForEach(controller.selectedDayEpisodes) { episode in
@@ -80,7 +80,7 @@ struct HistoryView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 20)
         }
-        .navigationTitle("Verlauf")
+        .navigationTitle("Tagebuch")
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
@@ -120,7 +120,7 @@ struct HistoryView: View {
             }
         }
         .confirmationDialog(
-            "Episode löschen?",
+            "Eintrag löschen?",
             isPresented: Binding(
                 get: { controller.pendingDeletionID != nil },
                 set: { isPresented in
@@ -257,7 +257,7 @@ private struct EpisodeRow: View {
         .padding(.vertical, 2)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilitySummary)
-        .accessibilityHint("Öffnet die Detailansicht der Episode.")
+        .accessibilityHint("Öffnet die Detailansicht des Eintrags.")
     }
 
     private var episodeMetaLine: String {

--- a/MigraineTracker/Sources/Features/Home/HomeView.swift
+++ b/MigraineTracker/Sources/Features/Home/HomeView.swift
@@ -18,27 +18,29 @@ struct HomeView: View {
     var body: some View {
         List {
             Section {
-                if let latestEpisode = overview.latestEpisode {
-                    MetricRow(
-                        title: "Letzte Episode: \(latestEpisode.type.rawValue)",
-                        detail: "Intensität \(latestEpisode.intensity)/10 · \(latestEpisode.startedAt.formatted(date: .abbreviated, time: .shortened))"
-                    )
-                } else {
-                    MetricRow(
-                        title: "Noch keine Episode erfasst",
-                        detail: "Starte mit einem schnellen Eintrag für Intensität, Symptome und Medikamente."
-                    )
-                }
+                DiaryWelcomeCard(overview: overview)
 
                 Button {
                     isPresentingEpisodeEditor = true
                 } label: {
-                    Label("Episode erfassen", systemImage: "plus.circle.fill")
+                    Label("Neuer Eintrag", systemImage: "plus.circle.fill")
+                        .frame(maxWidth: .infinity, alignment: .center)
                 }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                NavigationLink {
+                    HistoryView(appContainer: appContainer)
+                } label: {
+                    Label("Tagebuch öffnen", systemImage: "book.closed")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
             } header: {
-                Text("Tracking")
+                Text("Tagebuch")
             } footer: {
-                Text("Gespeicherte Episoden: \(overview.episodeCount)")
+                Text("Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten.")
             }
 
             Section {
@@ -105,12 +107,6 @@ struct HomeView: View {
 
             Section {
                 NavigationLink {
-                    HistoryView(appContainer: appContainer)
-                } label: {
-                    Label("Verlauf öffnen", systemImage: "calendar")
-                }
-
-                NavigationLink {
                     SettingsView(appContainer: appContainer)
                 } label: {
                     Label("Einstellungen", systemImage: "gearshape")
@@ -122,10 +118,11 @@ struct HomeView: View {
                     Label("Datenschutz und Hinweise", systemImage: "hand.raised")
                 }
             } header: {
-                Text("Verlauf & mehr")
+                Text("Mehr")
             }
         }
-        .navigationTitle("Übersicht")
+        .listStyle(.insetGrouped)
+        .navigationTitle("Willkommen")
         .task {
             reload()
         }
@@ -172,20 +169,44 @@ struct HomeView: View {
     }
 }
 
-private struct MetricRow: View {
-    let title: String
-    let detail: String
+private struct DiaryWelcomeCard: View {
+    let overview: HomeOverviewData
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
+        VStack(alignment: .leading, spacing: 14) {
+            Text(ProductBranding.displayName)
+                .font(.title3.weight(.semibold))
+
+            Text(summaryTitle)
                 .font(.headline)
-            Text(detail)
+
+            Text(summaryDetail)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+
+            if overview.episodeCount > 0 {
+                LabeledContent("Bisher dokumentiert", value: "\(overview.episodeCount) Eintrag\(overview.episodeCount == 1 ? "" : "e")")
+                    .font(.subheadline)
+            }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 8)
         .accessibilityElement(children: .combine)
+    }
+
+    private var summaryTitle: String {
+        if let latestEpisode = overview.latestEpisode {
+            return "Dein letzter Eintrag: \(latestEpisode.type.rawValue)"
+        }
+
+        return "Schön, dass du dein Tagebuch startest."
+    }
+
+    private var summaryDetail: String {
+        if let latestEpisode = overview.latestEpisode {
+            return "Intensität \(latestEpisode.intensity)/10 · \(latestEpisode.startedAt.formatted(date: .abbreviated, time: .shortened))"
+        }
+
+        return "Mit einem neuen Eintrag hältst du Beschwerden, Symptome, Medikamente und hilfreichen Kontext in wenigen Schritten fest."
     }
 }
 

--- a/MigraineTracker/Sources/Features/Home/ProductInformationView.swift
+++ b/MigraineTracker/Sources/Features/Home/ProductInformationView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 
 struct ProductInformationView: View {
     private let privacyURL = URL(string: "https://s3.privyr.com/privacy/privacy-policy.html?d=eyJlbWFpbCI6ImZldXJpZy5mZXVlcjdhQGljbG91ZC5jb20iLCJjb21wYW55IjoiTWF0dGhpYXMgV2FsbG5lci1H6WhyaSIsImdlbl9hdCI6IjIwMjYtMDQtMDlUMTE6MjI6MjUuOTYzWiJ9")!
-    private let repositoryURL = URL(string: "https://github.com/mpwg/MigraineTracker")!
-    private let issuesURL = URL(string: "https://github.com/mpwg/MigraineTracker/issues")!
     private let weatherProviderURL = WeatherAttribution.providerURL
     private let weatherLicenceURL = WeatherAttribution.licenceURL
 
@@ -19,7 +17,7 @@ struct ProductInformationView: View {
         List {
             if mode == .onboarding {
                 Section("Bevor du startest") {
-                    Text("Migraine Tracker speichert deine Angaben ausschließlich lokal auf diesem Gerät. Die App dient der Dokumentation für dich und für Arztgespräche.")
+                    Text("\(ProductBranding.displayName) speichert deine Angaben ausschließlich lokal auf diesem Gerät. Die App hilft dir, Migräne, Kopfschmerzen und andere Schmerzereignisse für dich und für Arztgespräche strukturiert festzuhalten.")
                     Text("Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt.")
                         .foregroundStyle(.secondary)
                 }
@@ -50,8 +48,8 @@ struct ProductInformationView: View {
                     detail: "Die App fragt beim Wetterabruf nach dem ungefähren Standort. Die Koordinaten werden nicht gespeichert."
                 )
                 infoRow(
-                    title: "Keine Health- oder Kalender-Anbindung",
-                    detail: "Apple Health, Arzttermine und andere Systemdaten sind in Version 1 nicht integriert."
+                    title: "Keine Health-Anbindung",
+                    detail: "Apple Health und andere sensible Systemdaten sind in Version 1 nicht integriert. Termine verwaltet die App ausschließlich lokal."
                 )
             }
 
@@ -77,7 +75,7 @@ struct ProductInformationView: View {
             Section("Medizinische Einordnung") {
                 infoRow(
                     title: "Dokumentationshilfe",
-                    detail: "Die App hilft dir, Migräneepisoden, Medikamente und Auslöser strukturiert festzuhalten."
+                    detail: "Die App hilft dir, Migräne, Kopfschmerzen, Medikamente und mögliche Auslöser strukturiert festzuhalten."
                 )
                 infoRow(
                     title: "Keine Diagnose, keine Therapieempfehlung",
@@ -92,7 +90,7 @@ struct ProductInformationView: View {
             Section("Version 1") {
                 infoRow(
                     title: "Aktueller Umfang",
-                    detail: "Episode anlegen, Medikamente erfassen, Verlauf ansehen und PDF exportieren."
+                    detail: "Neuer Eintrag, Tagebuch, Medikamente, Export und hilfreicher Kontext wie Wetter."
                 )
                 infoRow(
                     title: "Plattform und Sprache",
@@ -122,7 +120,7 @@ struct ProductInformationView: View {
                     Label("Projekt auf GitHub öffnen", systemImage: "link")
                 }
 
-                Link(destination: issuesURL) {
+                Link(destination: ProductBranding.supportURL) {
                     Label("GitHub-Issues öffnen", systemImage: "exclamationmark.bubble")
                 }
             }
@@ -138,6 +136,8 @@ struct ProductInformationView: View {
         }
         .navigationTitle("Datenschutz und Hinweise")
     }
+
+    private var repositoryURL: URL { ProductBranding.repositoryURL }
 
     @ViewBuilder
     private func infoRow(title: String, detail: String) -> some View {

--- a/MigraineTracker/Sources/Shared/ProductBranding.swift
+++ b/MigraineTracker/Sources/Shared/ProductBranding.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum ProductBranding {
+    nonisolated static let displayName = "Schmerztagebuch - Migräne & Co."
+    nonisolated static let supportURL = URL(string: "https://github.com/mpwg/MigraineTracker/issues")!
+    nonisolated static let repositoryURL = URL(string: "https://github.com/mpwg/MigraineTracker")!
+}

--- a/README.md
+++ b/README.md
@@ -1,188 +1,121 @@
-# Migraine Tracker
+# Schmerztagebuch - Migräne & Co.
 
-Migraine Tracker ist eine App-Idee für das schnelle Erfassen von Kopfschmerzen und Migräneepisoden. Der Fokus liegt auf wenigen, klaren Eingaben, damit Betroffene Symptome, Medikamente, Wetterkontext und Verlauf ohne großen Aufwand dokumentieren können.
+Schmerztagebuch - Migräne & Co. ist eine lokal-first iPhone-App für das strukturierte Dokumentieren von Migräne, Kopfschmerzen und ähnlichen Schmerzereignissen. Die App kombiniert einen schnellen neuen Eintrag mit einem persönlichen Tagebuch, Wetterkontext, Medikamentendokumentation, Export und ergänzenden Organisationsfunktionen für Arztkontakte.
 
-## Ziel
+## Produktstand
 
-Die App soll helfen,
+Der aktuelle Stand der App deckt diese Bereiche ab:
 
-- Episoden konsistent zu erfassen,
-- mögliche Auslöser und Muster sichtbar zu machen,
-- die Wirkung von Medikamenten besser nachzuvollziehen,
-- zyklusbezogene oder hormonelle Zusammenhänge zu erkennen,
-- Arztgespräche mit belastbaren Verlaufsdaten vorzubereiten.
-
-## Kernfunktionen
-
-- Erfassung von Kopfschmerz- und Migräneepisoden
-- Intensitätsskala von `1` bis `10`
-- Dokumentation von Medikamenten, Dosis und Wirkung
-- Erfassung weiterer Kontextdaten wie Menstruationsstatus, mögliche Trigger und Schmerzlokalisation
-- automatisches Anhängen von Wetterdaten zum Zeitpunkt des Eintrags
-- Kalender- und Verlaufsansicht
-- Export einer Übersicht für Ärztinnen und Ärzte
+- Tagebuch für Schmerzereignisse mit den Typen `Migräne`, `Kopfschmerz` und `Unklar`
+- schneller neuer Eintrag mit Intensität, Zeitpunkt und optionalen Zusatzangaben
+- Symptome, Trigger, Notizen, Schmerzlokalisation, Schmerzcharakter und funktionelle Einschränkung
+- Medikamentendokumentation inklusive eigener Vorlagen
+- Wetter-Snapshots über `Open-Meteo` auf Basis von `DWD ICON`
+- Tagebuchansicht mit Kalender, Tagesauswahl, Detailansicht, Bearbeiten und Papierkorb
+- PDF-Bericht und JSON5-Backup für frei wählbare Zeiträume
+- Ärztinnen- und Ärzte-Verwaltung inklusive lokaler Termine und Erinnerungen
+- optionale iCloud-Synchronisation mit Konfliktanzeige, Cloud-Datenverwaltung und Sync-Protokoll
 
 ## Produktidee
 
-Jeder Eintrag soll so schnell wie möglich erstellt werden können. Statt langer Formulare setzt die App auf einen kompakten Ablauf:
+Die App bleibt klar migränefokussiert, ist aber bewusst nicht nur für Migräne gedacht. Das Produktversprechen ist ein freundliches, nüchternes und alltagstaugliches Schmerztagebuch:
 
-1. Intensität wählen
-2. Symptome, Kontext und Medikamente ergänzen
-3. Wetter automatisch anhängen
-4. Verlauf später in Kalender und Statistiken auswerten
+- Beschwerden schnell dokumentieren, ohne von langen Formularen ausgebremst zu werden
+- Muster, Trigger und Medikamentenwirkung nachvollziehbarer machen
+- Arztgespräche mit belastbaren, exportierbaren Daten vorbereiten
+- sensible Gesundheitsdaten standardmäßig lokal halten
 
-## MVP
+## Hauptflows
 
-Der erste Produktumfang ist bewusst klein gehalten. Details stehen im Dokument [docs/MVP-Konzept.md](docs/MVP-Konzept.md).
+### 1. Neuer Eintrag
 
-Enthalten sind:
+- Typ wählen
+- Intensität festhalten
+- Zeitpunkt bestätigen oder anpassen
+- optional Symptome, Trigger, Notiz, Wetter und Medikamente ergänzen
+- lokal speichern
 
-- Episoden erfassen
-- Medikamente dokumentieren
-- zusätzliche Kontextfaktoren wie Zyklusstatus, Trigger und andere Schmerzmittel dokumentieren
-- Wetterdaten speichern
-- Verlauf in Liste und Kalender anzeigen
-- Export für Arztbesuche vorbereiten
+### 2. Tagebuch öffnen
 
-Nicht Teil der ersten App-Store-MVP sind:
+- Einträge im Kalender und pro Tag ansehen
+- Details öffnen
+- Einträge bearbeiten oder in den Papierkorb verschieben
 
-- `Apple Health`
-- `iPad`
-- `Englisch` oder weitere Lokalisierungen
-- `Cloud-Sync` oder eigenes Backend
-- `Arzttermine`
+### 3. Export und Sicherung
 
-## Mögliche Datenquellen für Wetter
+- PDF-Bericht für einen Zeitraum erzeugen und teilen
+- JSON5-Backup erzeugen oder importieren
 
-- `WeatherKit` von Apple für tiefe iOS-Integration
-- `Open-Meteo` mit DWD ICON für freie, einfache Wetter-Snapshots
+### 4. Ärztinnen, Ärzte und Termine
 
-Für den aktuellen Stand wird `Open-Meteo` auf Basis von `DWD ICON` verwendet. Später kann bei Bedarf auf `WeatherKit` erweitert werden.
+- Arztkontakte aus der ÖGK-Liste übernehmen oder manuell anlegen
+- lokale Termine mit Erinnerung verwalten
 
-## Zielgruppe
+### 5. Optionale Synchronisation
 
-- Menschen mit wiederkehrenden Kopfschmerzen
-- Menschen mit diagnostizierter Migräne
-- Patientinnen und Patienten, die ihren Verlauf für Arzttermine besser dokumentieren möchten
+- iCloud-Sync aktivieren oder deaktivieren
+- Konflikte einsehen und auflösen
+- Cloud-Daten und Sync-Protokoll prüfen
 
-## Verbindlicher MVP-Scope
-
-Die erste einreichbare Version für den App Store ist bewusst eng geschnitten:
-
-- nur `iPhone`
-- nur `Deutsch`
-- nur lokale Datenspeicherung auf dem Gerät
-- kein Account, kein Backend, keine Synchronisation
-- Fokus auf `Episode anlegen`, `Medikamente erfassen`, `Verlauf ansehen`, `PDF exportieren`
-
-## Technischer Stack für die erste MVP
-
-Die erste Version basiert auf diesen verbindlichen Entscheidungen:
+## Technische Leitplanken
 
 - UI mit `SwiftUI`
 - lokale Persistenz mit `SwiftData`
-- Zielplattform nur `iPhone`
-- Architektur `lokal-first` ohne Serverabhängigkeit
-- Wetterdaten über `Open-Meteo` auf Basis von `DWD ICON`
+- Architektur `lokal-first`
+- Zielplattform primär `iPhone`
+- Wetterdaten über `Open-Meteo`
 - PDF-Erzeugung lokal auf dem Gerät
+- optionale iCloud-Synchronisation getrennt von der lokalen Kernnutzung
 
-Diese Entscheidungen reduzieren Integrationsrisiko und halten die erste App-Store-Submission technisch überschaubar.
+Interne technische Kennungen wie `MigraineTracker`, Bundle-ID, Scheme und iCloud-Container bestehen derzeit aus Migrations- und Release-Gründen weiter, obwohl die sichtbare Produktmarke bereits auf `Schmerztagebuch - Migräne & Co.` umgestellt wird.
+
+## Datenschutz und medizinische Einordnung
+
+- Gesundheitsdaten bleiben ohne aktivierten Sync lokal auf dem Gerät
+- der PDF-Export entsteht nur auf ausdrücklichen Befehl
+- die App ist eine Dokumentationshilfe, keine Diagnose- oder Therapieempfehlung
+- Apple Health ist aktuell nicht integriert
 
 ## Build und Release
 
-Dieses Projekt verwendet nur `GitHub Actions` für CI und CD:
+Dieses Projekt verwendet `GitHub Actions` und `fastlane` für CI/CD.
 
-- Workflow `iOS CI` liefert Build-, Test- und PR-Feedback
-- Workflow `TestFlight Release` ruft `fastlane ios testflight` auf
-- Workflow `App Store Release` reagiert nur auf Tags im Format `vX.Y.Z` und ruft `fastlane ios app_store` auf
+CI:
 
-CI über `GitHub Actions`:
+- Workflow `iOS CI` bei `pull_request` und `push` auf `main`
+- Build und Tests für das Shared Scheme `MigraineTracker`
+- Upload des `xcresult` als Artifact
 
-- Workflow `iOS CI` läuft bei `pull_request` und `push` auf `main`
-- das Shared Scheme `MigraineTracker` wird auf einem iPhone-Simulator gebaut und getestet
-- das `xcresult` wird als Artifact hochgeladen
+CD:
 
-CD über `GitHub Actions`:
-
-- `main` ist der einzige automatische Pfad für neue `TestFlight`-Builds
-- nur Git-Tags `vX.Y.Z` lösen produktive `App Store`-Releases aus
-- `MARKETING_VERSION` im Projekt ist die führende Release-Version und muss zu `vX.Y.Z` passen
-- `CURRENT_PROJECT_VERSION` wird in fastlane je Lauf auf eine eindeutig höhere Buildnummer gesetzt
-- `match` liefert Distribution-Zertifikate und Provisioning Profiles reproduzierbar aus einem separaten Signierungs-Repository
-
-Benötigte GitHub-Secrets für Release-Läufe:
-
-- `APPLE_DEVELOPER_TEAM_ID`
-- `APP_STORE_CONNECT_ISSUER_ID`
-- `APP_STORE_CONNECT_KEY_ID`
-- `APP_STORE_CONNECT_PRIVATE_KEY`
-- `MATCH_GIT_URL`
-- `MATCH_PASSWORD`
-- `SENTRY_DSN`
-
-Optional:
-
-- `MATCH_GIT_BRANCH`
-- `MATCH_GIT_BASIC_AUTHORIZATION`
-- `TELEMETRY_APP_ID`
-
-Für die Distribution nutzt das Projekt fastlane durchgängig:
-
-- `match` für Distribution-Signing
-- `build_app` für Archiv und IPA-Export
-- `pilot` für `TestFlight`
-- `deliver` für den `App Store`
+- Workflow `TestFlight Release` für Builds von `main`
+- Workflow `App Store Release` für Tags im Format `vX.Y.Z`
+- `fastlane match`, `build_app`, `pilot` und `deliver` für Signing und Distribution
 
 Die projektspezifische Release-Einrichtung ist in [docs/Xcode-Cloud.md](/Users/mat/code/MigraineTracker/docs/Xcode-Cloud.md) dokumentiert.
 
-Für lokale Builds:
+## Lokale Entwicklung
 
-- [LocalSecrets.example.xcconfig](/Users/mat/code/MigraineTracker/MigraineTracker/Configs/LocalSecrets.example.xcconfig) nach `MigraineTracker/Configs/LocalSecrets.xcconfig` kopieren
-- darin mindestens `APPLE_DEVELOPER_TEAM_ID` setzen
-- optional `SENTRY_DSN` mit dem echten Wert setzen
-- die Datei bleibt wegen `.gitignore` untracked
+Voraussetzungen:
 
-## Definition of Done für die erste Submission
+- Xcode mit iPhone-Simulator
+- lokales Secrets-File auf Basis von [LocalSecrets.example.xcconfig](/Users/mat/code/MigraineTracker/MigraineTracker/Configs/LocalSecrets.example.xcconfig)
 
-Die erste MVP gilt als fertig, wenn diese Punkte erfüllt sind:
+Einrichtung:
 
-- eine Episode kann auf dem iPhone vollständig angelegt, bearbeitet und gelöscht werden
-- Medikamente können pro Episode dokumentiert und im Verlauf wieder eingesehen werden
-- Wetterdaten werden, wenn verfügbar, automatisch als Kontext gespeichert
-- vergangene Episoden sind in einer verständlichen Verlaufsansicht sichtbar
-- für einen frei wählbaren Zeitraum kann ein verständlicher PDF-Bericht erzeugt und geteilt werden
-- die App ist auf Deutsch nutzbar und ohne Account vollständig funktionsfähig
-- es gibt keine Health-, Sync- oder Arzttermin-Abhängigkeit für die Kernnutzung
+1. `MigraineTracker/Configs/LocalSecrets.example.xcconfig` nach `MigraineTracker/Configs/LocalSecrets.xcconfig` kopieren.
+2. Mindestens `APPLE_DEVELOPER_TEAM_ID` setzen.
+3. Optional `SENTRY_DSN` und weitere Release-Secrets ergänzen.
 
-## Zusätzliche sinnvolle Datenpunkte
+Typische lokale Prüfung:
 
-Für eine medizinisch nützlichere, aber weiterhin schlanke Dokumentation sind insbesondere diese Felder sinnvoll:
+```bash
+xcodebuild test -scheme MigraineTracker -destination 'platform=iOS Simulator,name=iPhone 16'
+```
 
-- Menstruationsstatus oder Zyklusbezug, um hormonelle Muster sichtbar zu machen
-- Art der Episode, z. B. Migräne, Spannungskopfschmerz oder unklar
-- Schmerzlokalisation und Schmerzcharakter, z. B. einseitig, pulsierend, drückend
-- mögliche Trigger wie Schlafmangel, Stress, Alkohol, bestimmte Lebensmittel oder Bildschirmzeit
-- funktionelle Einschränkung im Alltag, z. B. arbeitsfähig, eingeschränkt, bettlägerig
-- andere Schmerzmittel oder Begleitmedikation zusätzlich zu klassischen Migränemitteln
-- Wiederholungseinnahmen und Zeitpunkt der Wirkung, um Übergebrauch und Nutzen besser einordnen zu können
+## Weiterführende Dokumente
 
-## Apple Health Integration
-
-Eine Apple-Health-Integration kann den dokumentierten Verlauf deutlich verbessern, wenn sie strikt optional bleibt und nur mit klarer Einwilligung arbeitet.
-
-Sinnvolle Daten, die Migraine Tracker in Apple Health schreiben könnte:
-
-- Kopfschmerz- oder Migräneeinträge, soweit über passende Health-Kategorien abbildbar
-- Symptom- oder Episodenereignisse mit Start- und Endzeit
-- Medikamenteneinnahmen, sofern im gewünschten Integrationsumfang vorgesehen
-
-Sinnvolle Daten, die aus Apple Health gelesen werden könnten:
-
-- Schlafdauer und Schlafregelmäßigkeit
-- Zyklus- und Menstruationsdaten
-- Schrittzahl und Aktivitätsniveau
-- Trainings und körperliche Belastung
-- Herzfrequenz, Ruheherzfrequenz und Herzfrequenzvariabilität
-- optional weitere Vitaldaten, wenn sie therapeutisch relevant erscheinen
-
-Der Mehrwert liegt vor allem darin, Trigger und Muster besser zu erkennen, ohne die manuelle Eingabe unnötig zu vergrößern.
+- [docs/MVP-Konzept.md](/Users/mat/code/MigraineTracker/docs/MVP-Konzept.md)
+- [docs/App-Store-Metadaten.md](/Users/mat/code/MigraineTracker/docs/App-Store-Metadaten.md)
+- [docs/Teststrategie-und-Release-Checkliste.md](/Users/mat/code/MigraineTracker/docs/Teststrategie-und-Release-Checkliste.md)
+- [GitHub-Issues](https://github.com/mpwg/MigraineTracker/issues)

--- a/docs/App-Store-Metadaten.md
+++ b/docs/App-Store-Metadaten.md
@@ -2,19 +2,19 @@
 
 ## Produktname
 
-Migraine Tracker
+Schmerztagebuch - Migräne & Co.
 
 ## Untertitel
 
-Migräne einfach dokumentieren
+Beschwerden freundlich dokumentieren
 
 ## Kurzbeschreibung
 
-Erfasse Migräneepisoden, Medikamente, Trigger und Wetter lokal auf deinem iPhone. Behalte deinen Verlauf im Blick und exportiere kompakte PDF-Berichte für Arztgespräche.
+Erfasse Migräne, Kopfschmerzen, Medikamente, Trigger und Wetter lokal auf deinem iPhone. Behalte dein Tagebuch im Blick und exportiere kompakte PDF-Berichte für Arztgespräche.
 
 ## Keywords
 
-Migräne,Kopfschmerz,Trigger,Medikamente,Schmerztagebuch,PDF,Verlauf,Wetter
+Migräne,Kopfschmerz,Schmerzen,Tagebuch,Trigger,Medikamente,PDF,Wetter
 
 ## Support-URL
 
@@ -36,10 +36,10 @@ https://s3.privyr.com/privacy/privacy-policy.html?d=eyJlbWFpbCI6ImZldXJpZy5mZXVl
 
 Benötigte Screenshots vorbereiten:
 
-1. Home mit Fokus auf lokalem Tracking und Schnellzugriffen
-2. Erfassen mit Typ, Intensität, Symptomen und optionalen Wetterdaten
-3. Verlauf in Listenansicht
-4. Verlauf in Kalenderansicht
+1. Home mit freundlichem Tagebuch-Einstieg und Schnellzugriffen
+2. Neuer Eintrag mit Typ, Intensität, Symptomen und optionalen Wetterdaten
+3. Tagebuch in Listenansicht
+4. Tagebuch in Kalenderansicht
 5. PDF-Export mit Zeitraum und Vorschau
 
 ## Asset-Stand

--- a/docs/MVP-Konzept.md
+++ b/docs/MVP-Konzept.md
@@ -2,7 +2,7 @@
 
 ## Produktziel
 
-Das MVP von Migraine Tracker soll ein verlässliches, schnelles Migräne-Tagebuch sein. Nutzerinnen und Nutzer sollen eine Episode in wenigen Sekunden erfassen und später nachvollziehen können, wie häufig Beschwerden auftreten, welche Medikamente helfen und ob Wetter oder andere Faktoren eine Rolle spielen.
+Das MVP von Schmerztagebuch - Migräne & Co. soll ein verlässliches, schnelles Schmerztagebuch mit klarem Fokus auf Migräne sein. Nutzerinnen und Nutzer sollen einen Eintrag in wenigen Sekunden erfassen und später nachvollziehen können, wie häufig Beschwerden auftreten, welche Medikamente helfen und ob Wetter oder andere Faktoren eine Rolle spielen.
 
 Für die erste App-Store-Submission gilt ein bewusst enger Scope:
 
@@ -10,7 +10,7 @@ Für die erste App-Store-Submission gilt ein bewusst enger Scope:
 - nur `Deutsch`
 - nur lokale Datenspeicherung auf dem Gerät
 - kein Account, kein Backend, keine Synchronisation
-- Fokus auf `Episode anlegen`, `Medikamente erfassen`, `Verlauf ansehen`, `PDF exportieren`
+- Fokus auf `Neuer Eintrag`, `Medikamente erfassen`, `Tagebuch öffnen`, `PDF exportieren`
 
 ## Verbindliche Architekturentscheidungen
 
@@ -50,7 +50,7 @@ Diese Punkte sind zunächst bewusst ausgeschlossen:
 
 - Menschen mit wiederkehrenden Kopfschmerzen
 - Menschen mit Migräne
-- Personen, die Arzttermine mit strukturierten Verlaufsdaten vorbereiten möchten
+- Personen, die Arzttermine mit strukturierten Tagebuchdaten vorbereiten möchten
 
 ## Kernproblem
 
@@ -58,7 +58,7 @@ Viele Betroffene dokumentieren Symptome unregelmäßig oder gar nicht, weil vorh
 
 ## Wertversprechen
 
-Migraine Tracker reduziert Dokumentation auf das Wesentliche und ergänzt automatisch Kontextdaten wie Wetter. Dadurch entsteht ohne großen Aufwand ein verwertbarer Verlauf für den Alltag und für ärztliche Gespräche.
+Schmerztagebuch - Migräne & Co. reduziert Dokumentation auf das Wesentliche und ergänzt automatisch Kontextdaten wie Wetter. Dadurch entsteht ohne großen Aufwand ein verwertbares Tagebuch für den Alltag und für ärztliche Gespräche.
 
 ## MVP-Funktionsumfang
 
@@ -109,7 +109,7 @@ Quelle im MVP:
 - bevorzugt `Open-Meteo` oder vergleichbare freie Quelle
 - `WeatherKit` später als Ausbauoption
 
-### 4. Verlauf und Auswertung
+### 4. Tagebuch und Auswertung
 
 - Kalenderansicht mit Tagen und Episoden
 - Listenansicht der letzten Einträge
@@ -139,7 +139,7 @@ Diese Flows müssen ohne Produktentscheidungen umsetzbar und testbar sein:
    - Name, Kategorie, Dosis, Zeitpunkt und Wirkung festhalten
    - bestehende Medikamente schnell erneut auswählen
 
-3. Verlauf ansehen
+3. Tagebuch öffnen
    - letzte Episoden in einer Liste oder Kalenderansicht sehen
    - eine Episode im Detail mit Medikamenten und Wetterkontext öffnen
 
@@ -151,9 +151,9 @@ Diese Flows müssen ohne Produktentscheidungen umsetzbar und testbar sein:
 ## Empfohlene Screens
 
 1. Startseite
-   - heutige Übersicht
-   - Button `Episode erfassen`
-   - letzter Verlaufseintrag oder Schnellzugriff auf den Verlauf
+   - freundlicher Tagebuch-Einstieg
+   - Button `Neuer Eintrag`
+   - letzter Eintrag oder Schnellzugriff auf das Tagebuch
 
 2. Neue Episode
    - Intensität
@@ -168,7 +168,7 @@ Diese Flows müssen ohne Produktentscheidungen umsetzbar und testbar sein:
    - Typ und Wirkung dokumentieren
    - zuletzt verwendete Medikamente schnell auswählen
 
-4. Kalender / Verlauf
+4. Kalender / Tagebuch
    - Tages- und Monatsansicht
    - Detailansicht pro Episode
 
@@ -192,7 +192,7 @@ Die App wird als kompakte iPhone-App mit klar getrennten Verantwortlichkeiten au
 ### Schichten
 
 1. Präsentation
-   - `SwiftUI`-Screens für Erfassung, Verlauf, Detailansicht und Export
+   - `SwiftUI`-Screens für Eintragserfassung, Tagebuch, Detailansicht und Export
    - zuständig für Navigation, Formzustand und Darstellung
 
 2. Anwendungslogik
@@ -219,7 +219,7 @@ Die App wird als kompakte iPhone-App mit klar getrennten Verantwortlichkeiten au
 - `Export`-Modul
   - Zeitraum auswählen und PDF-Bericht aus vorhandenen lokalen Daten erzeugen
 - `History`-Modul
-  - Listen-, Kalender- und Detailansichten aus persistierten Episoden ableiten
+  - Tagebuch-, Kalender- und Detailansichten aus persistierten Episoden ableiten
 
 ### Geplanter Datenfluss
 
@@ -227,7 +227,7 @@ Die App wird als kompakte iPhone-App mit klar getrennten Verantwortlichkeiten au
 2. Die Anwendungslogik validiert Eingaben und erzeugt lokale Datenobjekte.
 3. `SwiftData` speichert Episode, Medikamente und später den Wetter-Snapshot.
 4. Der Wetterdienst ergänzt, wenn verfügbar, Kontextdaten ohne den Speichervorgang zu blockieren.
-5. Verlauf und Export lesen ausschließlich aus der lokalen Persistenz.
+5. Tagebuch und Export lesen ausschließlich aus der lokalen Persistenz.
 
 ### Integrationsansatz
 
@@ -246,7 +246,7 @@ Die App wird als kompakte iPhone-App mit klar getrennten Verantwortlichkeiten au
 - Views bleiben schlank und enthalten keine Persistenz- oder Netzwerklogik
 - externe Integrationen werden über klar getrennte Services angebunden
 - alle Kernfunktionen müssen offline benutzbar bleiben, abgesehen vom optionalen Wetterabruf
-- Persistenzmodelle und UI-Darstellung werden logisch getrennt gehalten, damit Export und Verlauf dieselbe Datenbasis nutzen
+- Persistenzmodelle und UI-Darstellung werden logisch getrennt gehalten, damit Export und Tagebuch dieselbe Datenbasis nutzen
 
 ## Vorschlag für Datenmodell
 
@@ -299,7 +299,7 @@ Die App wird als kompakte iPhone-App mit klar getrennten Verantwortlichkeiten au
 ## Erfolgskriterien für das MVP
 
 - Nutzer können eine Episode in kurzer Zeit erfassen
-- Verlauf ist in Kalender und Liste nachvollziehbar
+- Das Tagebuch ist in Kalender und Liste nachvollziehbar
 - Medikamente sind pro Episode sichtbar
 - zusätzliche Kontextdaten liefern erkennbaren Mehrwert, ohne den Erfassungsflow unnötig zu verlangsamen
 - Wetterdaten werden zuverlässig gespeichert, wenn verfügbar
@@ -314,7 +314,7 @@ Die erste MVP ist fertig, wenn alle Punkte erfüllt sind:
 - eine Episode kann angelegt, bearbeitet und gelöscht werden
 - Medikamente können pro Episode erfasst und angezeigt werden
 - Wetterkontext wird, wenn verfügbar, automatisch gespeichert
-- der Verlauf ist in einer verständlichen Listen- oder Kalenderansicht sichtbar
+- das Tagebuch ist in einer verständlichen Listen- oder Kalenderansicht sichtbar
 - ein PDF-Bericht für einen wählbaren Zeitraum kann lokal erzeugt und geteilt werden
 - die App funktioniert vollständig ohne Account, Backend oder Synchronisation
 - weder `Apple Health` noch `Arzttermine` sind Voraussetzung für die Kernnutzung

--- a/docs/Teststrategie-und-Release-Checkliste.md
+++ b/docs/Teststrategie-und-Release-Checkliste.md
@@ -40,7 +40,7 @@ Damit sind die fehleranfälligen, nicht-visuellen Regeln des MVP reproduzierbar 
 
 Vor einem Release-Kandidaten einmal vollständig prüfen:
 
-### Erfassen
+### Neuer Eintrag
 
 - Neue Episode anlegen und speichern
 - Standortfreigabe erlauben und Wetter automatisch laden
@@ -48,11 +48,11 @@ Vor einem Release-Kandidaten einmal vollständig prüfen:
 - Zukunftsdatum wählen und Validierungsfehler prüfen
 - Medikament aus „Zuletzt verwendet“ übernehmen und speichern
 
-### Verlauf
+### Tagebuch
 
 - Gespeicherte Episode in Liste und Kalender finden
 - Detailansicht öffnen und Wetter- sowie Medikamentendaten prüfen
-- Episode bearbeiten, erneut speichern und Änderung im Verlauf sehen
+- Eintrag bearbeiten, erneut speichern und Änderung im Tagebuch sehen
 
 ### Export
 
@@ -68,7 +68,7 @@ Vor einem Release-Kandidaten einmal vollständig prüfen:
 
 ### Produktqualität
 
-- Dynamic Type mit großer Schriftgröße in Home, Erfassen, Verlauf und Export prüfen
+- Dynamic Type mit großer Schriftgröße in Home, Neuer Eintrag, Tagebuch und Export prüfen
 - VoiceOver-Basis für Schnellzugriffe, Intensitätsauswahl, Kalender und Fehlermeldungen prüfen
 - Offensichtliche leere Zustände und Fehlertexte auf Verständlichkeit prüfen
 


### PR DESCRIPTION
## Zusammenfassung
- stellt die sichtbare Produktmarke auf `Schmerztagebuch - Migräne & Co.` um
- überarbeitet Home, Tagebuch und Eintragserfassung auf die neue, freundlichere Begriffswelt
- aktualisiert Exporttexte, Infotexte und die README auf den aktuellen Produktstand

## Test
- `xcodebuild test -scheme MigraineTracker -destination 'platform=iOS Simulator,name=iPhone 16'`

## Closes
- Closes #79
- Closes #80
- Closes #81
- Closes #82
- Closes #83
- Closes #84
- Closes #85

## Weiter offen
- #86 Entscheidungsvorlage für spätere technische Umbenennung vorbereiten

## Hinweis
- Die lokale, themenfremde Änderung an `MigraineTracker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` ist bewusst nicht Teil dieses PRs.