### PR TITLE
[codex] Fastlane screenshot upload reparieren

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,7 +49,8 @@ end
 
 def screenshot_result_bundle_path(output_directory, device_name)
   sanitized_name = device_name.gsub(/[^A-Za-z0-9]+/, "-").gsub(/^-|-$/, "")
-  File.join(output_directory, "test_output", SCREENSHOT_LANGUAGE, "#{SCREENSHOT_SCHEME}-#{sanitized_name}.xcresult")
+  platform_name = File.basename(output_directory)
+  File.join(SCREENSHOT_ROOT, "test_output", platform_name, SCREENSHOT_LANGUAGE, "#{SCREENSHOT_SCHEME}-#{sanitized_name}.xcresult")
 end
 
 def write_snapshot_configuration_files!
@@ -366,6 +367,7 @@ end
 
 def upload_screenshot_sets!(api_key:, version:)
   UI.user_error!("Keine vorhandenen iOS-Screenshots unter #{screenshot_language_directory(IOS_SCREENSHOT_OUTPUT)} gefunden.") if Dir.glob(File.join(screenshot_language_directory(IOS_SCREENSHOT_OUTPUT), "*.png")).empty?
+  FileUtils.rm_rf(File.join(IOS_SCREENSHOT_OUTPUT, "test_output"))
 
   deliver(
     api_key: api_key,


### PR DESCRIPTION
## Änderung

Korrigiert den Fastlane-Screenshot-Upload, indem `.xcresult`-Testartefakte nicht mehr innerhalb von `fastlane/screenshots/ios` abgelegt werden. Zusätzlich entfernt der Upload defensiv einen alten `fastlane/screenshots/ios/test_output`-Ordner, damit `deliver` nur gültige Sprachordner wie `de-DE` sieht.

## Ursache

`deliver` validiert direkte Unterordner von `fastlane/screenshots/ios` als Sprach-/Plattformordner. Der dort liegende `test_output`-Ordner führte zu `Unsupported directory name(s)` und brach den Upload ab.

## Validierung

- `ruby -c fastlane/Fastfile`
- `bundle exec fastlane ios upload_screenshots` erfolgreich ausgeführt und alle deutschen Screenshots für Version `1.4.0` hochgeladen.