### PR TITLE
Fix App Store deliver options

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -461,7 +461,6 @@ platform :ios do
       api_key: api_key,
       app_identifier: APP_IDENTIFIER,
       app_version: version,
-      build_number: build_number.to_s,
       ipa: ipa_path,
       submit_for_review: true,
       automatic_release: false,


### PR DESCRIPTION
## Zusammenfassung
- entfernt `build_number` aus dem `deliver`-Aufruf der App-Store-Release-Lane
- verhindert den Fastlane-Fehler `You can't use 'build_number' and 'ipa' options in one run`

## Verifikation
- `ruby -c fastlane/Fastfile`
- `git diff --check`

Hinweis: `bundle exec ruby -c fastlane/Fastfile` lief im Haupt-Workspace zuvor erfolgreich. Im temporären Worktree war nur `/usr/bin/bundle` verfügbar und konnte Bundler 4.0.10 nicht laden.