### PR TITLE
Switch weather provider to WeatherKit

### DIFF
--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		4066A4372F92AB4700724B7B /* TelemetryDeck in Frameworks */ = {isa = PBXBuildFile; productRef = 4066A4362F92AB4700724B7B /* TelemetryDeck */; };
 		40AF28D72F954481004EAEB9 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 40AF28D62F954481004EAEB9 /* Sentry */; };
 		40D264B02F929DBC0017627F /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		4A1000013A00000100000001 /* OpenMeteoSdk in Frameworks */ = {isa = PBXBuildFile; productRef = 4A1000023A00000100000001 /* OpenMeteoSdk */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,7 +77,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4A1000013A00000100000001 /* OpenMeteoSdk in Frameworks */,
 				4066A4372F92AB4700724B7B /* TelemetryDeck in Frameworks */,
 				40AF28D72F954481004EAEB9 /* Sentry in Frameworks */,
 			);
@@ -153,7 +151,6 @@
 			);
 			name = MigraineTracker;
 			packageProductDependencies = (
-				4A1000023A00000100000001 /* OpenMeteoSdk */,
 				4066A4362F92AB4700724B7B /* TelemetryDeck */,
 				40AF28D62F954481004EAEB9 /* Sentry */,
 			);
@@ -241,7 +238,6 @@
 			mainGroup = 402B8A552F896C00008B4D70;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				4A1000033A00000100000001 /* XCRemoteSwiftPackageReference "sdk" */,
 				4066A4352F92AB4700724B7B /* XCRemoteSwiftPackageReference "SwiftSDK" */,
 				40AF28D52F954481004EAEB9 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
@@ -487,7 +483,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Schmerztagebuch;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Open-Meteo auf Basis von DWD ICON abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Apple Weather abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -558,7 +554,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Schmerztagebuch;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.medical";
-				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Open-Meteo auf Basis von DWD ICON abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Apple Weather abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -766,14 +762,6 @@
 			traits = (
 			);
 		};
-		4A1000033A00000100000001 /* XCRemoteSwiftPackageReference "sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/open-meteo/sdk.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.5.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -786,11 +774,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 40AF28D52F954481004EAEB9 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
-		};
-		4A1000023A00000100000001 /* OpenMeteoSdk */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 4A1000033A00000100000001 /* XCRemoteSwiftPackageReference "sdk" */;
-			productName = OpenMeteoSdk;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/MigraineTracker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MigraineTracker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,24 +2,6 @@
   "originHash" : "202304f784cd480925a79897813a787cc917d7542d46e2eddae001fcdbac7176",
   "pins" : [
     {
-      "identity" : "flatbuffers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/flatbuffers.git",
-      "state" : {
-        "revision" : "7e163021e59cca4f8e1e35a7c828b5c6b7915953",
-        "version" : "25.12.19"
-      }
-    },
-    {
-      "identity" : "sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/open-meteo/sdk.git",
-      "state" : {
-        "revision" : "a29c4b62dd8445128e6db30f0a6fb5509fa1259c",
-        "version" : "1.26.0"
-      }
-    },
-    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa/",

--- a/MigraineTracker/Info.plist
+++ b/MigraineTracker/Info.plist
@@ -11,7 +11,7 @@
 	<key>NSLocationDefaultAccuracyReduced</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Open-Meteo auf Basis von DWD ICON abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.</string>
+	<string>Dein ungefährer Standort wird verwendet, um Wetterdaten für den ausgewählten Episodentag über Apple Weather abzurufen. Die App nutzt nur grob gerundete Koordinaten und speichert keine Positionsdaten.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/MigraineTracker/MigraineTracker.entitlements
+++ b/MigraineTracker/MigraineTracker.entitlements
@@ -6,6 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.weatherkit</key>
+	<true/>
 	<key>com.apple.developer.icloud-container-environment</key>
 	<string>$(ICLOUD_CONTAINER_ENVIRONMENT)</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>

--- a/MigraineTracker/Resources/Localizable.xcstrings
+++ b/MigraineTracker/Resources/Localizable.xcstrings
@@ -546,16 +546,6 @@
         }
       }
     },
-    "CC BY 4.0 anzeigen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show CC BY 4.0"
-          }
-        }
-      }
-    },
     "Cloud hat recht": {
       "localizations": {
         "en": {
@@ -596,12 +586,12 @@
         }
       }
     },
-    "Das Wetter wird mit deinem ungefähren Standort über Open-Meteo auf Basis von DWD ICON geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.": {
+    "Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Weather is loaded with your approximate location via Open-Meteo based on DWD ICON. The entry is still saved without weather if permission is not granted."
+            "value": "Weather is loaded with your approximate location via Apple Weather. The entry is still saved without weather if permission is not granted."
           }
         }
       }
@@ -1716,16 +1706,6 @@
         }
       }
     },
-    "Open-Meteo öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Open-Meteo"
-          }
-        }
-      }
-    },
     "Optionale Details": {
       "localizations": {
         "en": {
@@ -1892,6 +1872,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Source: %1$@"
+          }
+        }
+      }
+    },
+    "Rechtliche Hinweise öffnen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Legal Notices"
           }
         }
       }
@@ -2342,6 +2332,26 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weather Data"
+          }
+        }
+      }
+    },
+    "Wetterquellen anzeigen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Weather Sources"
+          }
+        }
+      }
+    },
+    "Wetterquellen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather Sources"
           }
         }
       }

--- a/MigraineTracker/Sources/App/AppContainer.swift
+++ b/MigraineTracker/Sources/App/AppContainer.swift
@@ -24,7 +24,7 @@ final class AppContainer {
         modelContainer: ModelContainer,
         syncCoordinator: SyncCoordinator,
         appLogStore: AppLogStore,
-        weatherService: any WeatherService = OpenMeteoDwdWeatherService(),
+        weatherService: any WeatherService = AppleWeatherKitWeatherService(),
         locationService: any LocationService = SystemLocationService(),
         notificationService: any NotificationService = UserNotificationService()
     ) {

--- a/MigraineTracker/Sources/App/ScreenshotSupport.swift
+++ b/MigraineTracker/Sources/App/ScreenshotSupport.swift
@@ -220,7 +220,7 @@ private enum ScreenshotSeedFactory {
                 pressure: 1007,
                 precipitation: 0.7,
                 weatherCode: 61,
-                source: "Open-Meteo Demo"
+                source: "Apple Weather Demo"
             ),
             episode: primaryEpisode
         )
@@ -505,7 +505,7 @@ private struct ScreenshotWeatherService: WeatherService {
             pressure: 1007,
             precipitation: 0.7,
             weatherCode: 61,
-            source: "Open-Meteo Demo"
+            source: "Apple Weather Demo"
         )
     }
 }

--- a/MigraineTracker/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/MigraineTracker/Sources/Features/Capture/EpisodeEditorView.swift
@@ -111,7 +111,7 @@ struct EpisodeEditorView: View {
             } header: {
                 Text("Wetter")
             } footer: {
-                Text("Das Wetter wird mit deinem ungefähren Standort über Open-Meteo auf Basis von DWD ICON geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.")
+                Text("Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.")
             }
 
             Section("Medikamente") {
@@ -365,9 +365,7 @@ private struct WeatherStatusContent: View {
                 if !weather.source.isEmpty {
                     detailRow("Quelle", weather.source)
                 }
-                Text(WeatherAttribution.sourceDescription)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                WeatherAttributionView()
             }
             .padding(.vertical, 4)
         case .unavailable(let message):

--- a/MigraineTracker/Sources/Features/History/EpisodeDetailView.swift
+++ b/MigraineTracker/Sources/Features/History/EpisodeDetailView.swift
@@ -131,6 +131,8 @@ struct EpisodeDetailView: View {
                             detailRow("Quelle", weatherSnapshot.source)
                         }
                         detailRow("Erfasst", weatherSnapshot.recordedAt.formatted(date: .abbreviated, time: .shortened))
+                        WeatherAttributionView()
+                            .padding(.vertical, 4)
                     }
                 }
 

--- a/MigraineTracker/Sources/Features/Home/ProductInformationView.swift
+++ b/MigraineTracker/Sources/Features/Home/ProductInformationView.swift
@@ -2,8 +2,6 @@ import SwiftUI
 
 struct ProductInformationView: View {
     private let privacyURL = URL(string: "https://s3.privyr.com/privacy/privacy-policy.html?d=eyJlbWFpbCI6ImZldXJpZy5mZXVlcjdhQGljbG91ZC5jb20iLCJjb21wYW55IjoiTWF0dGhpYXMgV2FsbG5lci1H6WhyaSIsImdlbl9hdCI6IjIwMjYtMDQtMDlUMTE6MjI6MjUuOTYzWiJ9")!
-    private let weatherProviderURL = WeatherAttribution.providerURL
-    private let weatherLicenceURL = WeatherAttribution.licenceURL
 
     enum Mode {
         case standard
@@ -56,20 +54,14 @@ struct ProductInformationView: View {
             Section("Wetterdaten") {
                 infoRow(
                     title: "Quelle",
-                    detail: "Wetterdaten von Open-Meteo, basierend auf DWD ICON."
+                    detail: "Wetterdaten werden über WeatherKit von Apple Weather geladen."
                 )
                 infoRow(
-                    title: "Lizenz",
-                    detail: "Open-Meteo stellt diese Daten unter CC BY 4.0 bereit. Eine sichtbare Attribution ist erforderlich."
+                    title: "Attribution",
+                    detail: WeatherAttribution.modifiedSourceDescription
                 )
 
-                Link(destination: weatherProviderURL) {
-                    Label("Open-Meteo öffnen", systemImage: "link")
-                }
-
-                Link(destination: weatherLicenceURL) {
-                    Label("CC BY 4.0 anzeigen", systemImage: "doc.text")
-                }
+                WeatherAttributionView(showsDescription: false)
             }
 
             Section("Medizinische Einordnung") {

--- a/MigraineTracker/Sources/Shared/WeatherAttributionView.swift
+++ b/MigraineTracker/Sources/Shared/WeatherAttributionView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+struct WeatherAttributionView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var attribution = WeatherAttribution.fallback
+    @State private var showsAttributionDetails = false
+
+    var showsDescription = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if showsDescription {
+                Text(WeatherAttribution.modifiedSourceDescription)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let markURL {
+                AsyncImage(url: markURL) { image in
+                    image
+                        .resizable()
+                        .scaledToFit()
+                } placeholder: {
+                    weatherMarkFallback
+                }
+                .frame(maxWidth: 180, minHeight: 28, maxHeight: 48, alignment: .leading)
+                .accessibilityLabel(attribution.serviceName)
+            } else {
+                weatherMarkFallback
+            }
+
+            Button {
+                showsAttributionDetails = true
+            } label: {
+                Label("Wetterquellen anzeigen", systemImage: "doc.text")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.tint)
+            .font(.footnote)
+        }
+        .task {
+            attribution = await WeatherAttribution.load()
+        }
+        .sheet(isPresented: $showsAttributionDetails) {
+            WeatherAttributionDetailView(attribution: attribution)
+                .presentationDetents([.medium, .large])
+        }
+    }
+
+    private var markURL: URL? {
+        colorScheme == .dark ? attribution.combinedMarkLightURL : attribution.combinedMarkDarkURL
+    }
+
+    private var weatherMarkFallback: some View {
+        Text(attribution.serviceName)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .accessibilityLabel(attribution.serviceName)
+    }
+}
+
+private struct WeatherAttributionDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    let attribution: WeatherAttributionData
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    weatherMark
+
+                    if let legalAttributionText = attribution.legalAttributionText, !legalAttributionText.isEmpty {
+                        Text(legalAttributionText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(WeatherAttribution.sourceDescription)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Link(destination: attribution.legalPageURL) {
+                        Label("Rechtliche Hinweise öffnen", systemImage: "arrow.up.right.square")
+                    }
+                    .font(.footnote)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            }
+            .navigationTitle("Wetterquellen")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Schließen") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var weatherMark: some View {
+        if let markURL {
+            AsyncImage(url: markURL) { image in
+                image
+                    .resizable()
+                    .scaledToFit()
+            } placeholder: {
+                weatherMarkFallback
+            }
+            .frame(maxWidth: 220, minHeight: 32, maxHeight: 56, alignment: .leading)
+            .accessibilityLabel(attribution.serviceName)
+        } else {
+            weatherMarkFallback
+        }
+    }
+
+    private var markURL: URL? {
+        colorScheme == .dark ? attribution.combinedMarkLightURL : attribution.combinedMarkDarkURL
+    }
+
+    private var weatherMarkFallback: some View {
+        Text(attribution.serviceName)
+            .font(.footnote.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .accessibilityLabel(attribution.serviceName)
+    }
+}

--- a/MigraineTracker/Sources/Shared/WeatherIntegration.swift
+++ b/MigraineTracker/Sources/Shared/WeatherIntegration.swift
@@ -1,7 +1,7 @@
 import CoreLocation
 import Foundation
-import OpenMeteoSdk
 import SwiftData
+import WeatherKit
 
 struct WeatherSnapshotData: Equatable, Sendable {
     let recordedAt: Date
@@ -48,11 +48,41 @@ struct WeatherSnapshotData: Equatable, Sendable {
 }
 
 enum WeatherAttribution {
-    static let providerName = "Open-Meteo"
-    static let providerURL = URL(string: "https://open-meteo.com/")!
-    static let licenceName = "CC BY 4.0"
-    static let licenceURL = URL(string: "https://creativecommons.org/licenses/by/4.0/")!
-    static let sourceDescription = "Wetterdaten von Open-Meteo, basierend auf DWD ICON."
+    static let providerName = "Apple Weather"
+    static let providerURL = URL(string: "https://weatherkit.apple.com/legal-attribution.html")!
+    static let sourceDescription = "Wetterdaten von Apple Weather über WeatherKit."
+    static let modifiedSourceDescription = "Wetterdaten von Apple Weather über WeatherKit. Die Werte werden als Snapshot für den Episodenzeitpunkt gespeichert."
+
+    static let fallback = WeatherAttributionData(
+        serviceName: providerName,
+        legalPageURL: providerURL,
+        combinedMarkDarkURL: nil,
+        combinedMarkLightURL: nil,
+        legalAttributionText: nil
+    )
+
+    static func load() async -> WeatherAttributionData {
+        do {
+            let attribution = try await WeatherKit.WeatherService.shared.attribution
+            return WeatherAttributionData(
+                serviceName: attribution.serviceName,
+                legalPageURL: attribution.legalPageURL,
+                combinedMarkDarkURL: attribution.combinedMarkDarkURL,
+                combinedMarkLightURL: attribution.combinedMarkLightURL,
+                legalAttributionText: attribution.legalAttributionText
+            )
+        } catch {
+            return fallback
+        }
+    }
+}
+
+struct WeatherAttributionData: Equatable, Sendable {
+    let serviceName: String
+    let legalPageURL: URL
+    let combinedMarkDarkURL: URL?
+    let combinedMarkLightURL: URL?
+    let legalAttributionText: String?
 }
 
 protocol WeatherService {
@@ -84,6 +114,7 @@ enum LocationServiceError: LocalizedError {
 enum WeatherServiceError: LocalizedError {
     case noHourlyData
     case noMatchingHour
+    case weatherKitAuthentication
 
     var errorDescription: String? {
         switch self {
@@ -91,6 +122,8 @@ enum WeatherServiceError: LocalizedError {
             "Die Wetterquelle hat keine stündlichen Daten geliefert."
         case .noMatchingHour:
             "Für den Episodenzeitpunkt wurde kein passender Wetterwert gefunden."
+        case .weatherKitAuthentication:
+            "WeatherKit konnte nicht authentifizieren. Prüfe, ob WeatherKit im Apple Developer Portal für diese App-ID aktiviert ist und ob das Provisioning Profile aktualisiert wurde."
         }
     }
 }
@@ -173,93 +206,139 @@ final class SystemLocationService: NSObject, LocationService, CLLocationManagerD
     }
 }
 
-struct OpenMeteoDwdWeatherService: WeatherService {
+struct AppleWeatherKitWeatherService: WeatherService {
+    private let service = WeatherKit.WeatherService.shared
+    private let earliestHourlyDate = Date(timeIntervalSince1970: 1_627_776_000)
+
     func fetchWeather(for date: Date, location: CLLocation) async throws -> WeatherSnapshotData? {
         if date > .now {
             throw EpisodeSaveError.futureDate
         }
 
-        let endpoint = endpointURL(for: date)
-        var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)
-        components?.queryItems = [
-            URLQueryItem(name: "latitude", value: String(location.coordinate.latitude)),
-            URLQueryItem(name: "longitude", value: String(location.coordinate.longitude)),
-            URLQueryItem(name: "hourly", value: "temperature_2m,relative_humidity_2m,surface_pressure,precipitation,weather_code"),
-            URLQueryItem(name: "timezone", value: "auto"),
-            URLQueryItem(name: "format", value: "flatbuffers"),
-            URLQueryItem(name: "start_date", value: isoDayString(for: date)),
-            URLQueryItem(name: "end_date", value: isoDayString(for: date)),
-            URLQueryItem(name: "past_days", value: "0"),
-            URLQueryItem(name: "models", value: isHistorical(date) ? "icon_seamless" : nil),
-        ].compactMap { item in
-            guard let value = item.value else {
-                return nil
-            }
-            return URLQueryItem(name: item.name, value: value)
-        }
-
-        guard let url = components?.url else {
+        guard date >= earliestHourlyDate else {
             return nil
         }
 
-        let responses = try await WeatherApiResponse.fetch(url: url)
-        guard let response = responses.first, let hourly = response.hourly else {
-            throw WeatherServiceError.noHourlyData
+        let interval = hourlyInterval(containing: date)
+        let hourlyForecast: Forecast<HourWeather>
+        do {
+            hourlyForecast = try await service.weather(
+                for: location,
+                including: .hourly(startDate: interval.start, endDate: interval.end)
+            )
+        } catch {
+            if isWeatherKitAuthenticationError(error) {
+                throw WeatherServiceError.weatherKitAuthentication
+            }
+            throw error
         }
 
-        let timestamps = hourly.getDateTime(offset: response.utcOffsetSeconds)
-        guard let matchedIndex = timestamps.enumerated().min(by: {
-            abs($0.element.timeIntervalSince(date)) < abs($1.element.timeIntervalSince(date))
-        })?.offset else {
+        guard let matchedHour = hourlyForecast.forecast.min(by: {
+            abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+        }) else {
             throw WeatherServiceError.noMatchingHour
         }
 
-        let temperature = value(at: matchedIndex, from: hourly, variableIndex: 0)
-        let humidity = value(at: matchedIndex, from: hourly, variableIndex: 1)
-        let pressure = value(at: matchedIndex, from: hourly, variableIndex: 2)
-        let precipitation = value(at: matchedIndex, from: hourly, variableIndex: 3)
-        let weatherCodeValue = value(at: matchedIndex, from: hourly, variableIndex: 4)
-        let weatherCode = weatherCodeValue.map { Int($0.rounded()) }
-
         return WeatherSnapshotData(
-            recordedAt: timestamps[matchedIndex],
-            condition: WeatherCodeMapper.description(for: weatherCode),
-            temperature: temperature,
-            humidity: humidity,
-            pressure: pressure,
-            precipitation: precipitation,
-            weatherCode: weatherCode,
-            source: isHistorical(date) ? "Open-Meteo DWD ICON Archiv" : "Open-Meteo DWD ICON"
+            recordedAt: matchedHour.date,
+            condition: WeatherConditionMapper.description(for: matchedHour.condition),
+            temperature: matchedHour.temperature.converted(to: .celsius).value,
+            humidity: matchedHour.humidity * 100,
+            pressure: matchedHour.pressure.converted(to: .hectopascals).value,
+            precipitation: matchedHour.precipitationAmount.converted(to: .millimeters).value,
+            weatherCode: nil,
+            source: WeatherAttribution.providerName
         )
     }
 
-    private func endpointURL(for date: Date) -> URL {
-        if isHistorical(date) {
-            return URL(string: "https://historical-forecast-api.open-meteo.com/v1/forecast")!
+    private func hourlyInterval(containing date: Date) -> DateInterval {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: date)
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? date.addingTimeInterval(86_400)
+        return DateInterval(start: startOfDay, end: endOfDay)
+    }
+
+    private func isWeatherKitAuthenticationError(_ error: any Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain.contains("WeatherDaemon.WDSJWTAuthenticatorServiceListener.Errors")
+            || nsError.localizedDescription.contains("WDSJWTAuthenticator")
+    }
+}
+
+enum WeatherConditionMapper {
+    static func description(for condition: WeatherCondition) -> String {
+        switch condition {
+        case .blizzard:
+            return "Schneesturm"
+        case .blowingDust:
+            return "Staubwind"
+        case .blowingSnow:
+            return "Schneetreiben"
+        case .breezy:
+            return "Windig"
+        case .clear:
+            return "Klar"
+        case .cloudy:
+            return "Bedeckt"
+        case .drizzle:
+            return "Nieselregen"
+        case .flurries:
+            return "Leichter Schneefall"
+        case .foggy:
+            return "Nebelig"
+        case .freezingDrizzle:
+            return "Gefrierender Nieselregen"
+        case .freezingRain:
+            return "Gefrierender Regen"
+        case .frigid:
+            return "Frostig"
+        case .hail:
+            return "Hagel"
+        case .haze:
+            return "Dunstig"
+        case .heavyRain:
+            return "Starker Regen"
+        case .heavySnow:
+            return "Starker Schneefall"
+        case .hot:
+            return "Heiß"
+        case .hurricane:
+            return "Orkan"
+        case .isolatedThunderstorms:
+            return "Vereinzelte Gewitter"
+        case .mostlyClear:
+            return "Überwiegend klar"
+        case .mostlyCloudy:
+            return "Überwiegend bewölkt"
+        case .partlyCloudy:
+            return "Teilweise bewölkt"
+        case .rain:
+            return "Regen"
+        case .scatteredThunderstorms:
+            return "Verstreute Gewitter"
+        case .sleet:
+            return "Schneeregen"
+        case .smoky:
+            return "Rauchig"
+        case .snow:
+            return "Schnee"
+        case .strongStorms:
+            return "Schwere Gewitter"
+        case .sunFlurries:
+            return "Schneeschauer mit Sonne"
+        case .sunShowers:
+            return "Regenschauer mit Sonne"
+        case .thunderstorms:
+            return "Gewitter"
+        case .tropicalStorm:
+            return "Tropischer Sturm"
+        case .windy:
+            return "Windig"
+        case .wintryMix:
+            return "Winterlicher Niederschlag"
+        @unknown default:
+            return "Unbekannt"
         }
-
-        return URL(string: "https://api.open-meteo.com/v1/dwd-icon")!
-    }
-
-    private func isHistorical(_ date: Date) -> Bool {
-        !Calendar.current.isDate(date, inSameDayAs: .now)
-    }
-
-    private func isoDayString(for date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = .current
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: date)
-    }
-
-    private func value(at offset: Int, from hourly: openmeteo_sdk_VariablesWithTime, variableIndex: Int) -> Double? {
-        guard let values = hourly.variables(at: Int32(variableIndex))?.values, values.indices.contains(offset) else {
-            return nil
-        }
-
-        return Double(values[offset])
     }
 }
 
@@ -270,40 +349,24 @@ enum WeatherCodeMapper {
         }
 
         switch code {
-        case 0:
-            return "Klar"
-        case 1:
-            return "Überwiegend klar"
-        case 2:
-            return "Teilweise bewölkt"
-        case 3:
-            return "Bedeckt"
-        case 45, 48:
-            return "Nebelig"
-        case 51, 53, 55:
-            return "Nieselregen"
-        case 56, 57:
-            return "Gefrierender Nieselregen"
-        case 61, 63, 65:
-            return "Regen"
-        case 66, 67:
-            return "Gefrierender Regen"
-        case 71, 73, 75, 77:
-            return "Schnee"
-        case 80, 81, 82:
-            return "Regenschauer"
-        case 85, 86:
-            return "Schneeschauer"
-        case 95:
-            return "Gewitter"
-        case 96, 99:
-            return "Gewitter mit Hagel"
-        default:
-            return "Unbekannt"
+        case 0: return "Klar"
+        case 1: return "Überwiegend klar"
+        case 2: return "Teilweise bewölkt"
+        case 3: return "Bedeckt"
+        case 45, 48: return "Nebelig"
+        case 51, 53, 55: return "Nieselregen"
+        case 56, 57: return "Gefrierender Nieselregen"
+        case 61, 63, 65: return "Regen"
+        case 66, 67: return "Gefrierender Regen"
+        case 71, 73, 75, 77: return "Schnee"
+        case 80, 81, 82: return "Regenschauer"
+        case 85, 86: return "Schneeschauer"
+        case 95: return "Gewitter"
+        case 96, 99: return "Gewitter mit Hagel"
+        default: return "Unbekannt"
         }
     }
 }
-
 @MainActor
 final class WeatherBackfillService {
     private let modelContainer: ModelContainer

--- a/MigraineTrackerTests/CoreArchitectureTests.swift
+++ b/MigraineTrackerTests/CoreArchitectureTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import CoreLocation
 import Testing
+import WeatherKit
 @testable import MigraineTracker
 
 @MainActor
@@ -31,13 +33,31 @@ struct CoreArchitectureTests {
             pressure: 1004,
             precipitation: 1.4,
             weatherCode: 63,
-            source: "Open-Meteo DWD ICON"
+            source: "Apple Weather"
         )
 
         let savedID = try useCase.execute(draft, weatherSnapshot: snapshot)
 
         #expect(savedID == repository.savedDraftID)
         #expect(repository.lastWeatherSnapshot == snapshot)
+    }
+
+    @Test
+    func appleWeatherKitServiceSkipsDatesBeforeHourlyHistory() async throws {
+        let service = AppleWeatherKitWeatherService()
+        let oldDate = Date(timeIntervalSince1970: 1_627_775_999)
+        let location = CLLocation(latitude: 48.2082, longitude: 16.3738)
+
+        let snapshot = try await service.fetchWeather(for: oldDate, location: location)
+
+        #expect(snapshot == nil)
+    }
+
+    @Test
+    func weatherConditionMapperUsesGermanDescriptions() {
+        #expect(WeatherConditionMapper.description(for: .clear) == "Klar")
+        #expect(WeatherConditionMapper.description(for: .heavyRain) == "Starker Regen")
+        #expect(WeatherConditionMapper.description(for: .thunderstorms) == "Gewitter")
     }
 
     @Test

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Der aktuelle Stand der App deckt diese Bereiche ab:
 - schneller neuer Eintrag mit Intensität, Zeitpunkt und optionalen Zusatzangaben
 - Symptome, Trigger, Notizen, Schmerzlokalisation, Schmerzcharakter und funktionelle Einschränkung
 - Medikamentendokumentation inklusive eigener Vorlagen
-- Wetter-Snapshots über `Open-Meteo` auf Basis von `DWD ICON`
+- Wetter-Snapshots über `Apple Weather` mit `WeatherKit`
 - Tagebuchansicht mit Kalender, Tagesauswahl, Detailansicht, Bearbeiten und Papierkorb
 - PDF-Bericht und JSON5-Backup für frei wählbare Zeiträume
 - Ärztinnen- und Ärzte-Verwaltung inklusive lokaler Termine und Erinnerungen
@@ -63,7 +63,7 @@ Die App bleibt klar migränefokussiert, ist aber bewusst nicht nur für Migräne
 - lokale Persistenz mit `SwiftData`
 - Architektur `lokal-first`
 - Zielplattform primär `iPhone`
-- Wetterdaten über `Open-Meteo`
+- Wetterdaten über `Apple Weather` mit `WeatherKit`
 - PDF-Erzeugung lokal auf dem Gerät
 - optionale iCloud-Synchronisation getrennt von der lokalen Kernnutzung
 

--- a/docs/MVP-Konzept.md
+++ b/docs/MVP-Konzept.md
@@ -20,7 +20,7 @@ Diese Entscheidungen gelten für die erste App-Store-Submission als fest:
 - Persistenz: `SwiftData`
 - Plattform: `iPhone only`
 - Architekturprinzip: `lokal-first`
-- Wetterquelle: `Open-Meteo`
+- Wetterquelle: `Apple Weather` über `WeatherKit`
 - Export: PDF lokal auf dem Gerät erzeugen
 
 Nicht Teil dieser Architekturversion sind:
@@ -104,10 +104,10 @@ Beim Anlegen einer Episode:
 - Luftfeuchtigkeit, sofern verfügbar
 - Luftdruck, sofern verfügbar
 
-Quelle im MVP:
+Quelle:
 
-- bevorzugt `Open-Meteo` oder vergleichbare freie Quelle
-- `WeatherKit` später als Ausbauoption
+- `Apple Weather` über `WeatherKit`
+- Wetter wird als Snapshot gespeichert und bleibt optional
 
 ### 4. Tagebuch und Auswertung
 
@@ -204,7 +204,7 @@ Die App wird als kompakte iPhone-App mit klar getrennten Verantwortlichkeiten au
    - zuständig für Laden, Schreiben, Filtern und Sortieren lokaler Daten
 
 4. Integrationen
-   - Wetterdienst über `Open-Meteo`
+   - Wetterdienst über `WeatherKit`
    - PDF-Erzeugung und systemweites Teilen
    - keine weitere externe Abhängigkeit in v1
 
@@ -232,7 +232,7 @@ Die App wird als kompakte iPhone-App mit klar getrennten Verantwortlichkeiten au
 ### Integrationsansatz
 
 - Wetterabruf
-  - über `Open-Meteo`
+  - über `WeatherKit`
   - bei fehlender Verbindung bleibt die Episode trotzdem speicherbar
   - Wetter wird als Snapshot zur Episode abgelegt, nicht live nachgeladen
 


### PR DESCRIPTION
## Summary
- Replace Open-Meteo weather loading with Apple Weather via WeatherKit
- Add WeatherKit entitlement and remove the Open-Meteo Swift package dependency
- Centralize Apple Weather attribution and move the long legal attribution text into a sheet
- Update privacy/help copy, README, docs, strings, and tests for Apple Weather

## Tests
- `jq empty MigraineTracker/Resources/Localizable.xcstrings`
- `xcodebuild test -project MigraineTracker.xcodeproj -scheme MigraineTrackerTests -destination 'platform=iOS Simulator,id=948C045F-31C1-4BFA-A4D5-0258C9998CB3' -skip-testing:MigraineTrackerUITests`

## Follow-up before release
- Enable WeatherKit for App ID `eu.mpwg.MigraineTracker` in Apple Developer Portal and regenerate/download provisioning profiles.