### PR TITLE
iPad- und Mac-Oberfläche adaptiv verbessern

### DIFF
--- a/MigraineTracker.xcodeproj/project.pbxproj
+++ b/MigraineTracker.xcodeproj/project.pbxproj
@@ -498,7 +498,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = eu.mpwg.MigraineTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -569,7 +569,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
-				MARKETING_VERSION = 1.4.1;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = eu.mpwg.MigraineTracker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore eu.mpwg.MigraineTracker";

--- a/MigraineTracker/Resources/Localizable.xcstrings
+++ b/MigraineTracker/Resources/Localizable.xcstrings
@@ -1,2411 +1,2430 @@
 {
-  "sourceLanguage": "de",
-  "strings": {
-    "": {},
-    "%@ · Intensität %lld/10": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@ · Intensität %2$lld/10"
+  "sourceLanguage" : "de",
+  "strings" : {
+    "" : {
+
+    },
+    "%@ · Intensität %lld/10" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ · Intensität %2$lld/10"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ · Intensity %2$lld/10"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · Intensity %2$lld/10"
           }
         }
       }
     },
-    "%@ abwählen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deselect %1$@"
+    "%@ abwählen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deselect %1$@"
           }
         }
       }
     },
-    "%@ speichert deine Angaben ausschließlich lokal auf diesem Gerät. Die App hilft dir, Migräne, Kopfschmerzen und andere Schmerzereignisse für dich und für Arztgespräche strukturiert festzuhalten.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ stores your information only locally on this device. The app helps you keep a structured record of migraines, headaches and other pain events for yourself and for doctor appointments."
+    "%@ speichert deine Angaben ausschließlich lokal auf diesem Gerät. Die App hilft dir, Migräne, Kopfschmerzen und andere Schmerzereignisse für dich und für Arztgespräche strukturiert festzuhalten." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ stores your information only locally on this device. The app helps you keep a structured record of migraines, headaches and other pain events for yourself and for doctor appointments."
           }
         }
       }
     },
-    "%@ wird aus SwiftData entfernt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ will be removed from SwiftData."
+    "%@ wird aus SwiftData entfernt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ will be removed from SwiftData."
           }
         }
       }
     },
-    "%@ wird in den Papierkorb verschoben.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ will be moved to the trash."
+    "%@ wird in den Papierkorb verschoben." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ will be moved to the trash."
           }
         }
       }
     },
-    "%@: %@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@: %2$@"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@: %2$@"
-          }
-        }
-      }
-    },
-    "%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld"
-          }
-        }
-      }
-    },
-    "%lld Eintrag%@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$lld Eintrag%2$@"
+    "%@: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: %2$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld entr%2$@"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: %2$@"
           }
         }
       }
     },
-    "%lld Eintrag%@ · Höchste Intensität %lld/10": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$lld Eintrag%2$@ · Höchste Intensität %3$lld/10"
+    "%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        }
+      }
+    },
+    "%lld Eintrag%@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld Eintrag%2$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld entr%2$@ · Highest intensity %3$lld/10"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld entr%2$@"
           }
         }
       }
     },
-    "%lld/10": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld/10"
+    "%lld Eintrag%@ · Höchste Intensität %lld/10" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld Eintrag%2$@ · Höchste Intensität %3$lld/10"
           }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld entr%2$@ · Highest intensity %3$lld/10"
+          }
+        }
+      }
+    },
+    "%lld/10" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/10"
+          }
         }
       }
     },
-    "%lldx": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lldx"
+    "%lldx" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lldx"
           }
         }
       }
     },
-    "2 Stunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2 hours"
+    "2 Stunden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 hours"
           }
         }
       }
     },
-    "24 Stunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "24 hours"
+    "24 Stunden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24 hours"
           }
         }
       }
     },
-    "30 Minuten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "30 minutes"
+    "30 Minuten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 minutes"
           }
         }
       }
     },
-    "Abbrechen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "Abbrechen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         }
       }
     },
-    "Abweichende Felder: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conflicting fields: %1$@"
+    "Abweichende Felder: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conflicting fields: %1$@"
           }
         }
       }
     },
-    "Adresse": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address"
+    "Adresse" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address"
           }
         }
       }
     },
-    "Aktionen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actions"
+    "Aktionen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actions"
           }
         }
       }
     },
-    "Aktive Episoden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active Episodes"
+    "Aktive Episoden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active Episodes"
           }
         }
       }
     },
-    "Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable sync to use iCloud synchronization and conflict handling."
+    "Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable sync to use iCloud synchronization and conflict handling."
           }
         }
       }
     },
-    "Aktualisieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refresh"
+    "Aktualisieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
           }
         }
       }
     },
-    "Aktuell ausgewählt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currently selected."
+    "Aktuell ausgewählt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currently selected."
           }
         }
       }
     },
-    "Alle": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All"
+    "Alle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
           }
         }
       }
     },
-    "Allgemein": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
+    "Allgemein" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
           }
         }
       }
     },
-    "Als Wiederholungseinnahme dokumentiert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Documented as a repeat dose"
+    "Als Wiederholungseinnahme dokumentiert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Documented as a repeat dose"
           }
         }
       }
     },
-    "Änderungen speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save Changes"
+    "Änderungen speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save Changes"
           }
         }
       }
     },
-    "Ansicht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View"
+    "Ansicht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View"
           }
         }
       }
     },
-    "Anzahl": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quantity"
+    "Anzahl" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quantity"
           }
         }
       }
     },
-    "Anzahl: %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quantity: %lld"
+    "Anzahl: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quantity: %lld"
           }
         }
       }
     },
-    "Arzt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doctor"
+    "Arzt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doctor"
           }
         }
       }
     },
-    "Arzt anlegen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create Doctor"
+    "Arzt anlegen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create Doctor"
           }
         }
       }
     },
-    "Arzt aus ÖGK-Liste hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Doctor from OeGK List"
+    "Arzt aus Musterverzeichnis hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Doctor from Sample Directory"
           }
         }
       }
     },
-    "Arzt aus Musterverzeichnis hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Doctor from Sample Directory"
+    "Arzt aus ÖGK-Liste hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Doctor from OeGK List"
           }
         }
       }
     },
-    "Arzt auswählen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Doctor"
+    "Arzt auswählen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Doctor"
           }
         }
       }
     },
-    "Arzt bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Doctor"
+    "Arzt bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Doctor"
           }
         }
       }
     },
-    "Arzt hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Doctor"
+    "Arzt hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Doctor"
           }
         }
       }
     },
-    "Arzt manuell hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Doctor Manually"
+    "Arzt manuell hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Doctor Manually"
           }
         }
       }
     },
-    "Arzt nicht gefunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doctor Not Found"
+    "Arzt nicht gefunden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doctor Not Found"
           }
         }
       }
     },
-    "Arzt speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save Doctor"
+    "Arzt speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save Doctor"
           }
         }
       }
     },
-    "Arzt zuerst anlegen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create a Doctor First"
+    "Arzt zuerst anlegen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create a Doctor First"
           }
         }
       }
     },
-    "Arztdetail": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doctor Details"
+    "Arztdetail" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doctor Details"
           }
         }
       }
     },
-    "Ärzte": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Doctors"
+    "Ärzte" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doctors"
           }
         }
       }
     },
-    "Ausgewählt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selected"
+    "Ausgewählt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selected"
           }
         }
       }
     },
-    "Bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit"
+    "Bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
           }
         }
       }
     },
-    "Beginn": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start"
+    "Beginn" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
           }
         }
       }
     },
-    "Beim Laden wird dein ungefährer Standort verwendet, um Wetterdaten für den Episodenzeitpunkt abzurufen.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When loading, your approximate location is used to retrieve weather data for the episode time."
+    "Beim Laden wird dein ungefährer Standort verwendet, um Wetterdaten für den Episodenzeitpunkt abzurufen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When loading, your approximate location is used to retrieve weather data for the episode time."
           }
         }
       }
     },
-    "Berechtigungen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permissions"
+    "Berechtigungen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permissions"
           }
         }
       }
     },
-    "Bericht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Report"
+    "Bericht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report"
           }
         }
       }
     },
-    "Bevor du startest": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Before You Start"
+    "Bevor du startest" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Before You Start"
           }
         }
       }
     },
-    "Bis": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To"
+    "Bis" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To"
           }
         }
       }
     },
-    "Bisher dokumentiert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logged So Far"
+    "Bisher dokumentiert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logged So Far"
           }
         }
       }
     },
-    "Bundesland": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State"
+    "Bundesland" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "State"
           }
         }
       }
     },
-    "Cloud hat recht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Cloud Version"
+    "Cloud hat recht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Cloud Version"
           }
         }
       }
     },
-    "Cloud-Daten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud Data"
+    "Cloud-Daten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloud Data"
           }
         }
       }
     },
-    "Cloud-Daten verwalten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manage Cloud Data"
+    "Cloud-Daten verwalten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manage Cloud Data"
           }
         }
       }
     },
-    "Das Protokoll bleibt lokal auf diesem Gerät. Es enthält technische Metadaten zu Synchronisation, Konflikten und Fehlern, aber keine sensiblen Freitextinhalte im Klartext.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The log stays local on this device. It contains technical metadata about synchronization, conflicts and errors, but no sensitive free-text content in plain text."
+    "Das Protokoll bleibt lokal auf diesem Gerät. Es enthält technische Metadaten zu Synchronisation, Konflikten und Fehlern, aber keine sensiblen Freitextinhalte im Klartext." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The log stays local on this device. It contains technical metadata about synchronization, conflicts and errors, but no sensitive free-text content in plain text."
           }
         }
       }
     },
-    "Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather is loaded with your approximate location via Apple Weather. The entry is still saved without weather if permission is not granted."
+    "Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather is loaded with your approximate location via Apple Weather. The entry is still saved without weather if permission is not granted."
           }
         }
       }
     },
-    "Daten exportieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export Data"
+    "Daten exportieren" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Data"
           }
         }
       }
     },
-    "Daten sichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back Up Data"
+    "Daten sichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back Up Data"
           }
         }
       }
     },
-    "Datenexport": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data Export"
+    "Datenexport" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Export"
           }
         }
       }
     },
-    "Datenschutz": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy"
+    "Datenschutz" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
           }
         }
       }
     },
-    "Datenschutz und Hinweise": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy and Notes"
+    "Datenschutz und Hinweise" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy and Notes"
           }
         }
       }
     },
-    "Datenschutzerklärung öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Privacy Policy"
+    "Datenschutzerklärung öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Privacy Policy"
           }
         }
       }
     },
-    "Dein Eintrag wurde lokal gespeichert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your entry was saved locally."
+    "Dein Eintrag wurde lokal gespeichert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your entry was saved locally."
           }
         }
       }
     },
-    "Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your entries stay local on this device and help you keep track of patterns, triggers and routines that work."
+    "Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your entries stay local on this device and help you keep track of patterns, triggers and routines that work."
           }
         }
       }
     },
-    "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync works defensively: conflicts are not overwritten silently, but made visible here."
+    "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync works defensively: conflicts are not overwritten silently, but made visible here."
           }
         }
       }
     },
-    "Der PDF-Bericht von %@ wird lokal erzeugt und kann systemweit geteilt werden.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The PDF report from %1$@ is created locally and can be shared system-wide."
+    "Der PDF-Bericht von %@ wird lokal erzeugt und kann systemweit geteilt werden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The PDF report from %1$@ is created locally and can be shared system-wide."
           }
         }
       }
     },
-    "Der Termin wurde lokal gespeichert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The appointment was saved locally."
+    "Der Termin wurde lokal gespeichert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The appointment was saved locally."
           }
         }
       }
     },
-    "Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The app remains fully usable locally. iCloud sync is optional, works separately from SwiftData and can be disabled again at any time."
+    "Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The app remains fully usable locally. iCloud sync is optional, works separately from SwiftData and can be disabled again at any time."
           }
         }
       }
     },
-    "Die Erinnerung wird lokal auf dem Gerät geplant. Ohne Berechtigung bleibt der Termin trotzdem gespeichert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The reminder is scheduled locally on the device. Without permission, the appointment is still saved."
+    "Die Erinnerung wird lokal auf dem Gerät geplant. Ohne Berechtigung bleibt der Termin trotzdem gespeichert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The reminder is scheduled locally on the device. Without permission, the appointment is still saved."
           }
         }
       }
     },
-    "Die Erinnerung zu diesem Termin wird ebenfalls entfernt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The reminder for this appointment will also be removed."
+    "Die Erinnerung zu diesem Termin wird ebenfalls entfernt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The reminder for this appointment will also be removed."
           }
         }
       }
     },
-    "Die Liste zeigt Beispieldaten für den Screenshot-Modus.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The list shows sample data for screenshot mode."
+    "Die Liste zeigt Beispieldaten für den Screenshot-Modus." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The list shows sample data for screenshot mode."
           }
         }
       }
     },
-    "Die Treffer sind nach relevanten Fachgebieten gruppiert und innerhalb der Gruppen nach PLZ und Name sortiert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Results are grouped by relevant specialties and sorted within groups by postal code and name."
+    "Die Treffer sind nach relevanten Fachgebieten gruppiert und innerhalb der Gruppen nach PLZ und Name sortiert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Results are grouped by relevant specialties and sorted within groups by postal code and name."
           }
         }
       }
     },
-    "Diese Episode wird in den Papierkorb verschoben.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This episode will be moved to the trash."
+    "Diese Episode wird in den Papierkorb verschoben." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This episode will be moved to the trash."
           }
         }
       }
     },
-    "Dosierung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosage"
+    "Dosierung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosage"
           }
         }
       }
     },
-    "Du kannst die Standortfreigabe in den Einstellungen dieser App unter \"Standort\" auf \"Beim Verwenden der App\" ändern.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can change location permission in this app's settings under \"Location\" to \"While Using the App\"."
+    "Du kannst die Standortfreigabe in den Einstellungen dieser App unter \"Standort\" auf \"Beim Verwenden der App\" ändern." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can change location permission in this app's settings under \"Location\" to \"While Using the App\"."
           }
         }
       }
     },
-    "Durchschnittliche Intensität: %@/10": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Average intensity: %1$@/10"
+    "Durchschnittliche Intensität: %@/10" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Average intensity: %1$@/10"
           }
         }
       }
     },
-    "E-Mail": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Email"
+    "E-Mail" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email"
           }
         }
       }
     },
-    "Eigenes Medikament": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom Medication"
+    "Eigenes Medikament" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Medication"
           }
         }
       }
     },
-    "Eigenes Medikament hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Custom Medication"
+    "Eigenes Medikament hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Custom Medication"
           }
         }
       }
     },
-    "Eigenes Medikament löschen?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Custom Medication?"
+    "Eigenes Medikament löschen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Custom Medication?"
           }
         }
       }
     },
-    "Einstellungen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settings"
+    "Einstellungen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
           }
         }
       }
     },
-    "Einstellungen öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Settings"
+    "Einstellungen öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Settings"
           }
         }
       }
     },
-    "Eintrag bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Entry"
+    "Eintrag bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Entry"
           }
         }
       }
     },
-    "Eintrag gespeichert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entry Saved"
+    "Eintrag gespeichert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entry Saved"
           }
         }
       }
     },
-    "Eintrag löschen?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Entry?"
+    "Eintrag löschen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Entry?"
           }
         }
       }
     },
-    "Eintrag speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save Entry"
+    "Eintrag speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save Entry"
           }
         }
       }
     },
-    "Einträge": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entries"
+    "Einträge" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries"
           }
         }
       }
     },
-    "Einträge im Zeitraum: %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entries in period: %lld"
+    "Einträge im Zeitraum: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries in period: %lld"
           }
         }
       }
     },
-    "Ende": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "End"
+    "Ende" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "End"
           }
         }
       }
     },
-    "Ende angeben": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Specify End"
+    "Ende angeben" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specify End"
           }
         }
       }
     },
-    "Endzeit angeben": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Specify End Time"
+    "Endzeit angeben" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specify End Time"
           }
         }
       }
     },
-    "Entfernen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove"
+    "Entfernen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
           }
         }
       }
     },
-    "Entfernt die Auswahl.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removes the selection."
+    "Entfernt die Auswahl." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Removes the selection."
           }
         }
       }
     },
-    "Episode": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Episode"
+    "Episode" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode"
           }
         }
       }
     },
-    "Episode löschen?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Episode?"
+    "Episode löschen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Episode?"
           }
         }
       }
     },
-    "Episode nicht gefunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Episode Not Found"
+    "Episode nicht gefunden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode Not Found"
           }
         }
       }
     },
-    "Episodendetail": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Episode Details"
+    "Episodendetail" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode Details"
           }
         }
       }
     },
-    "Erinnerung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reminder"
+    "Erinnerung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder"
           }
         }
       }
     },
-    "Erinnerung aktivieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Reminder"
+    "Erinnerung aktivieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Reminder"
           }
         }
       }
     },
-    "Erinnerung: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reminder: %1$@"
+    "Erinnerung: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder: %1$@"
           }
         }
       }
     },
-    "Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create a PDF report or JSON5 backup for a freely selectable period."
+    "Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create a PDF report or JSON5 backup for a freely selectable period."
           }
         }
       }
+    },
+    "Export" : {
+
     },
-    "Fachgebiet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Specialty"
+    "Fachgebiet" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specialty"
           }
         }
       }
     },
-    "Fehler erneut versuchen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry Error"
+    "Fehler erneut versuchen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry Error"
           }
         }
       }
     },
-    "Fehler: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %1$@"
+    "Fehler: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %1$@"
           }
         }
       }
     },
-    "Filter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filter"
+    "Filter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter"
           }
         }
       }
     },
-    "Füge zuerst eine Ärztin oder einen Arzt aus der ÖGK-Liste hinzu oder lege den Eintrag manuell an.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "First add a doctor from the OeGK list or create the entry manually."
+    "Füge zuerst eine Ärztin oder einen Arzt aus der ÖGK-Liste hinzu oder lege den Eintrag manuell an." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First add a doctor from the OeGK list or create the entry manually."
           }
         }
       }
     },
-    "Funktionelle Einschränkung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Functional Limitation"
+    "Funktionelle Einschränkung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Functional Limitation"
           }
         }
       }
     },
-    "Für %@ ist noch nichts dokumentiert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nothing has been documented for %1$@ yet."
+    "Für %@ ist noch nichts dokumentiert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing has been documented for %1$@ yet."
           }
         }
       }
     },
-    "Für Termine brauchst du zuerst einen Arzt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You Need a Doctor First for Appointments"
+    "Für Termine brauchst du zuerst einen Arzt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You Need a Doctor First for Appointments"
           }
         }
       }
     },
-    "GitHub-Issues öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open GitHub Issues"
+    "GitHub-Issues öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open GitHub Issues"
           }
         }
       }
     },
-    "Hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add"
+    "Heute" : {
+
+    },
+    "Hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
           }
         }
       }
     },
-    "Im Screenshot-Modus werden ausschließlich anonymisierte Musterärztinnen und Musterärzte angezeigt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Screenshot mode shows anonymized sample doctors only."
+    "Im Screenshot-Modus werden ausschließlich anonymisierte Musterärztinnen und Musterärzte angezeigt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Screenshot mode shows anonymized sample doctors only."
           }
         }
       }
     },
-    "Intensität": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensity"
+    "Intensität" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intensity"
           }
         }
       }
     },
-    "Intensität %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensity %lld"
+    "Intensität %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intensity %lld"
           }
         }
       }
     },
-    "Jetzt synchronisieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Now"
+    "Jetzt synchronisieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Now"
           }
         }
       }
     },
-    "JSON5 erstellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create JSON5"
+    "JSON5 erstellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create JSON5"
           }
         }
       }
     },
-    "JSON5 importieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import JSON5"
+    "JSON5 importieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import JSON5"
           }
         }
       }
     },
-    "JSON5 teilen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share JSON5"
+    "JSON5 teilen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share JSON5"
           }
         }
       }
     },
-    "JSON5-Export enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON5 export contains all entries and custom medication templates, including trashed entries."
+    "JSON5-Export enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON5 export contains all entries and custom medication templates, including trashed entries."
           }
         }
       }
     },
-    "Kategorie": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Category"
+    "Kategorie" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Category"
           }
         }
       }
     },
-    "Kein Medikament gefunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Medication Found"
+    "Kein Medikament gefunden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Medication Found"
           }
         }
       }
     },
-    "Kein Protokoll vorhanden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Log Available"
+    "Kein Protokoll vorhanden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Log Available"
           }
         }
       }
     },
-    "Keine Einträge im Zeitraum": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Entries in Period"
+    "Keine Einträge im Zeitraum" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Entries in Period"
           }
         }
       }
     },
-    "Keine gelöschten Einträge.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No deleted entries."
+    "Keine gelöschten Einträge." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No deleted entries."
           }
         }
       }
     },
-    "Keine kommenden Termine": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Upcoming Appointments"
+    "Keine kommenden Termine" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Upcoming Appointments"
           }
         }
       }
     },
-    "Keine offenen Konflikte.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No open conflicts."
+    "Keine offenen Konflikte." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No open conflicts."
           }
         }
       }
     },
-    "Keine passenden Ärztinnen oder Ärzte": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Matching Doctors"
+    "Keine passenden Ärztinnen oder Ärzte" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Matching Doctors"
           }
         }
       }
     },
-    "Keine Termine": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Appointments"
+    "Keine Termine" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Appointments"
           }
         }
       }
     },
-    "Kommende Termine": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Upcoming Appointments"
+    "Kommende Termine" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upcoming Appointments"
           }
         }
       }
     },
-    "Konflikt lösen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resolve Conflict"
+    "Konflikt lösen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resolve Conflict"
           }
         }
       }
     },
-    "Konflikt wird verarbeitet …": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processing conflict ..."
+    "Konflikt wird verarbeitet …" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing conflict ..."
           }
         }
       }
     },
-    "Konflikte": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conflicts"
+    "Konflikte" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conflicts"
           }
         }
       }
     },
-    "Kontakt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact"
+    "Kontakt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact"
           }
         }
       }
     },
-    "Kurz notieren, was auffällt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Briefly note what stands out"
+    "Kurz notieren, was auffällt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Briefly note what stands out"
           }
         }
       }
     },
-    "Lege den ersten Termin mit optionaler Erinnerung an.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create the first appointment with an optional reminder."
+    "Lege den ersten Termin mit optionaler Erinnerung an." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create the first appointment with an optional reminder."
           }
         }
       }
     },
-    "Lege einen Termin an. Falls noch keine Ärztin oder kein Arzt vorhanden ist, startet zuerst der Arzt-Flow.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create an appointment. If no doctor exists yet, the doctor flow starts first."
+    "Lege einen Termin an, sobald du eine Ärztin oder einen Arzt erfasst hast." : {
+
+    },
+    "Lege einen Termin an. Falls noch keine Ärztin oder kein Arzt vorhanden ist, startet zuerst der Arzt-Flow." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create an appointment. If no doctor exists yet, the doctor flow starts first."
           }
         }
       }
     },
-    "Letzter Fehler": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Latest Error"
+    "Letzter Fehler" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latest Error"
           }
         }
       }
     },
-    "Lokal hat recht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Local Version"
+    "Lokal hat recht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Local Version"
           }
         }
       }
     },
-    "Lokaler Stand und Cloud-Stand unterscheiden sich.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local and cloud versions differ."
+    "Lokaler Stand und Cloud-Stand unterscheiden sich." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local and cloud versions differ."
           }
         }
       }
     },
-    "Lokales JSON5-Backup erstellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create Local JSON5 Backup"
+    "Lokales JSON5-Backup erstellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create Local JSON5 Backup"
           }
         }
       }
     },
-    "Löschen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
+    "Löschen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
           }
         }
       }
     },
-    "Medikament": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medication"
+    "Medikament" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medication"
           }
         }
       }
     },
-    "Medikament ausgewählt. Passe die Anzahl an.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medication selected. Adjust the quantity."
+    "Medikament ausgewählt. Passe die Anzahl an." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medication selected. Adjust the quantity."
           }
         }
       }
     },
-    "Medikament bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Medication"
+    "Medikament bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Medication"
           }
         }
       }
     },
-    "Medikament nach Namen filtern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filter medication by name"
+    "Medikament nach Namen filtern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter medication by name"
           }
         }
       }
     },
-    "Medikamente": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medications"
+    "Medikamente" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medications"
           }
         }
       }
     },
-    "Medizinische Einordnung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medical Context"
+    "Medizinische Einordnung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medical Context"
           }
         }
       }
     },
-    "Mehr": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More"
+    "Mehr" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
           }
         }
       }
     },
-    "Meine Ärzte": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "My Doctors"
+    "Meine Ärzte" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "My Doctors"
           }
         }
       }
     },
-    "Menstruationsstatus": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Menstruation Status"
+    "Menstruationsstatus" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menstruation Status"
           }
         }
       }
     },
-    "Nach Name, Fachgebiet oder Ort suchen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search by name, specialty or place"
+    "Nach Name, Fachgebiet oder Ort suchen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search by name, specialty or place"
           }
         }
       }
     },
-    "Nächster Monat": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Next Month"
+    "Nächster Monat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next Month"
           }
         }
       }
     },
-    "Name": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name"
+    "Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
           }
         }
       }
     },
-    "Neuer Eintrag": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Entry"
+    "Neuer Eintrag" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Entry"
           }
         }
       }
     },
-    "Noch kein Eintrag für diesen Tag.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No entry for this day yet."
+    "Noch kein Eintrag für diesen Tag." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No entry for this day yet."
           }
         }
       }
     },
-    "Noch keine Ärztinnen oder Ärzte": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Doctors Yet"
+    "Noch keine Ärztinnen oder Ärzte" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Doctors Yet"
           }
         }
       }
     },
-    "Noch keine Einträge an diesem Tag": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Entries on This Day Yet"
+    "Noch keine Einträge an diesem Tag" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Entries on This Day Yet"
           }
         }
       }
     },
-    "Notiz": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note"
+    "Notiz" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note"
           }
         }
       }
     },
-    "Nur ergänzen, wenn du heute etwas genommen hast.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only add this if you took something today."
+    "Nur ergänzen, wenn du heute etwas genommen hast." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only add this if you took something today."
           }
         }
       }
     },
-    "Nur Fehler": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Errors Only"
+    "Nur Fehler" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errors Only"
           }
         }
       }
     },
-    "Nur Sync": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Only"
+    "Nur Sync" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Only"
           }
         }
       }
     },
-    "Nutze die ÖGK-Liste als Startpunkt oder lege eine Ärztin bzw. einen Arzt vollständig manuell an.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use the OeGK list as a starting point or create a doctor fully manually."
+    "Nutze die ÖGK-Liste als Startpunkt oder lege eine Ärztin bzw. einen Arzt vollständig manuell an." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use the OeGK list as a starting point or create a doctor fully manually."
           }
         }
       }
     },
-    "Öffnet die Detailansicht des Eintrags.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opens the entry detail view."
+    "Öffnet die Detailansicht des Eintrags." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opens the entry detail view."
           }
         }
       }
     },
-    "Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opens a new diary entry for the currently selected calendar day."
+    "Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opens a new diary entry for the currently selected calendar day."
           }
         }
       }
     },
-    "ÖGK-Auswahl": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OeGK Selection"
+    "ÖGK-Auswahl" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OeGK Selection"
           }
         }
       }
     },
-    "OK": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+    "OK" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
     },
-    "Open Source": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Source"
+    "Open Source" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Source"
           }
         }
       }
     },
-    "Optionale Details": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Optional Details"
+    "Optionale Details" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optional Details"
           }
         }
       }
     },
-    "Optionaler Hinweis": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Optional Note"
+    "Optionaler Hinweis" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optional Note"
           }
         }
       }
     },
-    "Ort": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Place"
+    "Ort" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Place"
           }
         }
       }
     },
-    "Papierkorb": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trash"
+    "Papierkorb" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trash"
           }
         }
       }
     },
-    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trashed entries remain local and in the cloud until you intentionally restore them or permanently remove them later."
+    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trashed entries remain local and in the cloud until you intentionally restore them or permanently remove them later."
           }
         }
       }
     },
-    "Passe den Suchbegriff an oder füge ein eigenes Medikament hinzu.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust the search term or add a custom medication."
+    "Passe den Suchbegriff an oder füge ein eigenes Medikament hinzu." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adjust the search term or add a custom medication."
           }
         }
       }
     },
-    "Passe den Suchbegriff an oder nutze die manuelle Anlage.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust the search term or use manual creation."
+    "Passe den Suchbegriff an oder nutze die manuelle Anlage." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adjust the search term or use manual creation."
           }
         }
       }
     },
-    "Passe den Zeitraum an, damit ein Bericht aus deinem Tagebuch erstellt werden kann.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust the period so a report can be created from your diary."
+    "Passe den Zeitraum an, damit ein Bericht aus deinem Tagebuch erstellt werden kann." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adjust the period so a report can be created from your diary."
           }
         }
       }
     },
-    "PDF": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "PDF"
+    "PDF" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
           }
         }
       }
     },
-    "PDF erstellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create PDF"
+    "PDF erstellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create PDF"
           }
         }
       }
     },
-    "PDF teilen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share PDF"
+    "PDF teilen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share PDF"
           }
         }
       }
     },
-    "PLZ": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postal Code"
+    "PLZ" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postal Code"
           }
         }
       }
     },
-    "Praxis / Ort": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Practice / Place"
+    "Praxis / Ort" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Practice / Place"
           }
         }
       }
     },
-    "Projekt auf GitHub öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Project on GitHub"
+    "Projekt auf GitHub öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Project on GitHub"
           }
         }
       }
     },
-    "Protokoll löschen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Log"
+    "Protokoll löschen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Log"
           }
         }
       }
     },
-    "Protokoll teilen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share Log"
+    "Protokoll teilen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share Log"
           }
         }
       }
     },
-    "Quelle: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source: %1$@"
+    "Quelle: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source: %1$@"
           }
         }
       }
     },
-    "Rechtliche Hinweise öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Legal Notices"
+    "Rechtliche Hinweise öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Legal Notices"
           }
         }
       }
     },
-    "Schließen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+    "Schließen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         }
       }
     },
-    "Schmerzcharakter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pain Character"
+    "Schmerzcharakter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pain Character"
           }
         }
       }
     },
-    "Schmerzlokalisation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pain Location"
+    "Schmerzlokalisation" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pain Location"
           }
         }
       }
     },
-    "Schmerztagebuch": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pain Diary"
+    "Schmerztagebuch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pain Diary"
           }
         }
       }
     },
-    "Schneller Eintrag": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quick Entry"
+    "Schneller Eintrag" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Entry"
           }
         }
       }
     },
-    "Setzt die Intensität auf %lld von 10.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sets intensity to %lld out of 10."
+    "Setzt die Intensität auf %lld von 10." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sets intensity to %lld out of 10."
           }
         }
       }
     },
-    "Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "It does not replace medical diagnosis, treatment decisions or emergency contacts."
+    "Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It does not replace medical diagnosis, treatment decisions or emergency contacts."
           }
         }
       }
     },
-    "So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This quickly creates a useful diary entry. Everything else is optional."
+    "So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This quickly creates a useful diary entry. Everything else is optional."
           }
         }
       }
     },
-    "Sobald Sync-Vorgänge oder Fehler auftreten, erscheinen sie hier.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Once sync operations or errors occur, they will appear here."
+    "Sobald Sync-Vorgänge oder Fehler auftreten, erscheinen sie hier." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once sync operations or errors occur, they will appear here."
           }
         }
       }
     },
-    "Speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+    "Speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         }
       }
     },
-    "Stammdaten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Master Data"
+    "Stammdaten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Master Data"
           }
         }
       }
     },
-    "Status": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status"
+    "Status" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
           }
         }
       }
     },
-    "Straße": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Street"
+    "Straße" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Street"
           }
         }
       }
     },
-    "Suchquelle: ÖGK Vertragspartner Fachärztinnen und Fachärzte. Fehlende Kontaktdaten können danach manuell ergänzt werden.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search source: OeGK contracted specialists. Missing contact details can be added manually afterwards."
+    "Suchquelle: ÖGK Vertragspartner Fachärztinnen und Fachärzte. Fehlende Kontaktdaten können danach manuell ergänzt werden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search source: OeGK contracted specialists. Missing contact details can be added manually afterwards."
           }
         }
       }
     },
-    "Symptome": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symptoms"
+    "Symptome" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symptoms"
           }
         }
       }
     },
-    "Sync aktivieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Sync"
+    "Sync aktivieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Sync"
           }
         }
       }
     },
-    "Sync-Protokoll": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Log"
+    "Sync-Protokoll" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Log"
           }
         }
       }
     },
-    "Synchronisation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Synchronization"
+    "Synchronisation" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronization"
           }
         }
       }
     },
-    "Tagebuch": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diary"
+    "Tagebuch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diary"
           }
         }
       }
     },
-    "Tagebuch öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Diary"
+    "Tagebuch öffnen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Diary"
           }
         }
       }
     },
-    "Telefon": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phone"
+    "Telefon" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phone"
           }
         }
       }
     },
-    "Termin": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appointment"
+    "Termin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appointment"
           }
         }
       }
     },
-    "Termin bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Appointment"
+    "Termin bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Appointment"
           }
         }
       }
     },
-    "Termin gespeichert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appointment Saved"
+    "Termin gespeichert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appointment Saved"
           }
         }
       }
     },
-    "Termin hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Appointment"
+    "Termin hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Appointment"
           }
         }
       }
     },
-    "Termin löschen?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Appointment?"
+    "Termin löschen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Appointment?"
           }
         }
       }
     },
-    "Termin speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save Appointment"
+    "Termin speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save Appointment"
           }
         }
       }
     },
-    "Termine": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appointments"
+    "Termine" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appointments"
           }
         }
       }
     },
-    "Trigger": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Triggers"
+    "Trigger" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triggers"
           }
         }
       }
     },
-    "Typ": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type"
+    "Typ" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type"
           }
         }
       }
     },
-    "Übersicht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overview"
+    "Übersicht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overview"
           }
         }
       }
     },
-    "Version 1": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version 1"
+    "Version 1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version 1"
           }
         }
       }
     },
-    "Verstanden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Understood"
+    "Verstanden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Understood"
           }
         }
       }
     },
-    "Von": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "From"
+    "Von" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "From"
           }
         }
       }
     },
-    "Vorheriger Monat": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous Month"
+    "Vorheriger Monat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous Month"
           }
         }
       }
     },
-    "Vorlauf": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lead Time"
+    "Vorlauf" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lead Time"
           }
         }
       }
     },
-    "Vorschau": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview"
+    "Vorschau" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preview"
           }
         }
       }
+    },
+    "Wähle links eine Ärztin oder einen Arzt aus, um Stammdaten und Termine parallel zu sehen." : {
+
     },
-    "Wählt diese Option aus.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selects this option."
+    "Wählt diese Option aus." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selects this option."
           }
         }
       }
     },
-    "Wählt dieses Medikament aus.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selects this medication."
+    "Wählt dieses Medikament aus." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selects this medication."
           }
         }
       }
     },
-    "Weitere Angaben": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Additional Details"
+    "Weitere Angaben" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Additional Details"
           }
         }
       }
     },
-    "Wetter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather"
+    "Wetter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather"
           }
         }
       }
     },
-    "Wetter wird ermittelt …": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading weather ..."
+    "Wetter wird ermittelt …" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading weather ..."
           }
         }
       }
     },
-    "Wetter wird vorbereitet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing Weather"
+    "Wetter wird vorbereitet" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing Weather"
           }
         }
       }
     },
-    "Wetter: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather: %1$@"
+    "Wetter: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather: %1$@"
           }
         }
       }
     },
-    "Wetterdaten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather Data"
+    "Wetterdaten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather Data"
           }
         }
       }
     },
-    "Wetterquellen anzeigen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Weather Sources"
+    "Wetterquellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather Sources"
           }
         }
       }
     },
-    "Wetterquellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather Sources"
+    "Wetterquellen anzeigen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Weather Sources"
           }
         }
       }
     },
-    "Wiederherstellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore"
+    "Wiederherstellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
           }
         }
       }
     },
-    "Wirkung: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effect: %1$@"
+    "Wirkung: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effect: %1$@"
           }
         }
       }
     },
-    "Wirkungseintritt: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onset of relief: %1$@"
+    "Wirkungseintritt: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onset of relief: %1$@"
           }
         }
       }
     },
-    "Zeigt die Episoden dieses Tages darunter an.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shows this day's episodes below."
+    "Zeigt die Episoden dieses Tages darunter an." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shows this day's episodes below."
           }
         }
       }
     },
-    "Zeitraum": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Period"
+    "Zeitraum" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Period"
           }
         }
       }
     }
   },
-  "version": "1.2"
+  "version" : "1.2"
 }

--- a/MigraineTracker/Sources/App/AppShellView.swift
+++ b/MigraineTracker/Sources/App/AppShellView.swift
@@ -37,6 +37,7 @@ struct AppShellView: View {
     let appContainer: AppContainer
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var selectedSection: AppSection = .overview
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
         Group {
@@ -69,11 +70,12 @@ struct AppShellView: View {
     }
 
     private var regularRoot: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             List {
                 ForEach(AppSection.allCases) { section in
                     Button {
                         selectedSection = section
+                        columnVisibility = .all
                     } label: {
                         Label(section.title, systemImage: section.systemImage)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -86,7 +88,7 @@ struct AppShellView: View {
             .navigationSplitViewColumnWidth(min: 220, ideal: 250)
         } detail: {
             NavigationStack {
-                content(for: selectedSection)
+                regularContent(for: selectedSection)
             }
         }
         .navigationSplitViewStyle(.balanced)
@@ -109,8 +111,39 @@ struct AppShellView: View {
             ProductInformationView(mode: .standard)
         }
     }
+
+    @ViewBuilder
+    private func regularContent(for section: AppSection) -> some View {
+        switch section {
+        case .overview, .history, .doctors:
+            content(for: section)
+        case .export, .settings, .information:
+            RegularDetailSurface {
+                content(for: section)
+            }
+        }
+    }
 }
 
 #Preview {
     Text("Preview nicht verfügbar")
+}
+
+private struct RegularDetailSurface<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Divider()
+
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .brandScreen()
+    }
 }

--- a/MigraineTracker/Sources/App/AppShellView.swift
+++ b/MigraineTracker/Sources/App/AppShellView.swift
@@ -1,17 +1,112 @@
 import SwiftUI
 
+enum AppSection: String, CaseIterable, Identifiable {
+    case overview
+    case history
+    case doctors
+    case export
+    case settings
+    case information
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .overview: "Übersicht"
+        case .history: "Tagebuch"
+        case .doctors: "Ärzte"
+        case .export: "Export"
+        case .settings: "Einstellungen"
+        case .information: "Hinweise"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .overview: "house"
+        case .history: "book.closed"
+        case .doctors: "cross.case"
+        case .export: "square.and.arrow.up"
+        case .settings: "gearshape"
+        case .information: "hand.raised"
+        }
+    }
+}
+
 struct AppShellView: View {
     let appContainer: AppContainer
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @State private var selectedSection: AppSection = .overview
 
     var body: some View {
-        NavigationStack {
-            HomeView(appContainer: appContainer)
+        Group {
+            if horizontalSizeClass == .compact {
+                compactRoot
+            } else {
+                regularRoot
+            }
         }
         .tint(AppTheme.ocean)
         .toolbarBackground(AppTheme.ink.opacity(0.96), for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
             await appContainer.weatherBackfillService.runIfNeeded()
+        }
+    }
+
+    private var compactRoot: some View {
+        TabView(selection: $selectedSection) {
+            ForEach([AppSection.overview, .history, .doctors, .export, .settings]) { section in
+                NavigationStack {
+                    content(for: section)
+                }
+                .tabItem {
+                    Label(section.title, systemImage: section.systemImage)
+                }
+                .tag(section)
+            }
+        }
+    }
+
+    private var regularRoot: some View {
+        NavigationSplitView {
+            List {
+                ForEach(AppSection.allCases) { section in
+                    Button {
+                        selectedSection = section
+                    } label: {
+                        Label(section.title, systemImage: section.systemImage)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .listRowBackground(selectedSection == section ? AppTheme.selectedFill : Color.clear)
+                }
+            }
+            .navigationTitle(ProductBranding.displayName)
+            .navigationSplitViewColumnWidth(min: 220, ideal: 250)
+        } detail: {
+            NavigationStack {
+                content(for: selectedSection)
+            }
+        }
+        .navigationSplitViewStyle(.balanced)
+    }
+
+    @ViewBuilder
+    private func content(for section: AppSection) -> some View {
+        switch section {
+        case .overview:
+            HomeView(appContainer: appContainer)
+        case .history:
+            HistoryView(appContainer: appContainer)
+        case .doctors:
+            DoctorsHubView(appContainer: appContainer)
+        case .export:
+            DataExportView(appContainer: appContainer)
+        case .settings:
+            SettingsView(appContainer: appContainer, showsCloseButton: false)
+        case .information:
+            ProductInformationView(mode: .standard)
         }
     }
 }

--- a/MigraineTracker/Sources/Features/Doctors/DoctorsHubView.swift
+++ b/MigraineTracker/Sources/Features/Doctors/DoctorsHubView.swift
@@ -16,9 +16,216 @@ enum DoctorAddEntryMode: Identifiable {
 
 struct DoctorsHubView: View {
     let appContainer: AppContainer
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    @State private var controller: DoctorHubController
+    @State private var selectedDoctorID: UUID?
+    @State private var doctorAddMode: DoctorAddEntryMode?
+    @State private var isPresentingAppointmentFlow = false
+
+    init(appContainer: AppContainer) {
+        self.appContainer = appContainer
+        _controller = State(initialValue: appContainer.makeDoctorHubController())
+    }
 
     var body: some View {
-        HomeView(appContainer: appContainer)
+        Group {
+            if horizontalSizeClass == .compact {
+                compactContent
+            } else {
+                regularContent
+            }
+        }
+        .navigationTitle("Ärzte")
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                Button {
+                    isPresentingAppointmentFlow = true
+                } label: {
+                    Label("Termin", systemImage: "calendar.badge.plus")
+                }
+
+                Button {
+                    doctorAddMode = .oegkDirectory
+                } label: {
+                    Label("Arzt hinzufügen", systemImage: "cross.case.fill")
+                }
+            }
+        }
+        .task {
+            reload()
+        }
+        .refreshable {
+            reload()
+        }
+        .sheet(item: $doctorAddMode) { mode in
+            NavigationStack {
+                DoctorAddFlowView(appContainer: appContainer, startMode: mode) { doctorID in
+                    doctorAddMode = nil
+                    reload(selecting: doctorID)
+                }
+            }
+        }
+        .sheet(isPresented: $isPresentingAppointmentFlow) {
+            NavigationStack {
+                AppointmentCreationFlowView(appContainer: appContainer) {
+                    isPresentingAppointmentFlow = false
+                    reload()
+                }
+            }
+        }
+    }
+
+    private var compactContent: some View {
+        List {
+            actionSection
+            appointmentsSection
+            doctorsSection(compactLinks: true)
+        }
+        .listStyle(.insetGrouped)
+        .brandGroupedScreen()
+    }
+
+    private var regularContent: some View {
+        HStack(alignment: .top, spacing: 0) {
+            List(selection: $selectedDoctorID) {
+                actionSection
+                doctorsSection(compactLinks: false)
+            }
+            .listStyle(.sidebar)
+            .frame(minWidth: 300, idealWidth: 360, maxWidth: 420)
+            .scrollContentBackground(.hidden)
+            .background(AppTheme.appBackground)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: AppTheme.dashboardSpacing) {
+                AdaptiveDashboardCard(title: "Kommende Termine") {
+                    appointmentRows
+                }
+
+                if let selectedDoctorID {
+                    DoctorDetailView(appContainer: appContainer, doctorID: selectedDoctorID)
+                        .frame(maxHeight: .infinity)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                } else {
+                    ContentUnavailableView(
+                        "Arzt auswählen",
+                        systemImage: "cross.case",
+                        description: Text("Wähle links eine Ärztin oder einen Arzt aus, um Stammdaten und Termine parallel zu sehen.")
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .brandCard()
+                }
+            }
+            .padding(24)
+            .wideContent()
+            .frame(maxHeight: .infinity, alignment: .top)
+            .brandScreen()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .brandScreen()
+    }
+
+    private var actionSection: some View {
+        Section {
+            Button {
+                doctorAddMode = .oegkDirectory
+            } label: {
+                Label("Arzt aus ÖGK-Liste hinzufügen", systemImage: "cross.case.fill")
+            }
+
+            Button {
+                doctorAddMode = .manual
+            } label: {
+                Label("Arzt manuell hinzufügen", systemImage: "square.and.pencil")
+            }
+
+            Button {
+                isPresentingAppointmentFlow = true
+            } label: {
+                Label("Termin hinzufügen", systemImage: "calendar.badge.plus")
+            }
+        }
+    }
+
+    private var appointmentsSection: some View {
+        Section("Kommende Termine") {
+            appointmentRows
+        }
+    }
+
+    @ViewBuilder
+    private var appointmentRows: some View {
+        if controller.upcomingAppointments.isEmpty {
+            ContentUnavailableView(
+                "Keine kommenden Termine",
+                systemImage: "calendar.badge.clock",
+                description: Text("Lege einen Termin an, sobald du eine Ärztin oder einen Arzt erfasst hast.")
+            )
+        } else {
+            ForEach(controller.upcomingAppointments) { appointment in
+                if let doctor = controller.doctors.first(where: { $0.id == appointment.doctorID }) {
+                    NavigationLink {
+                        DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
+                    } label: {
+                        AppointmentSummaryRow(appointment: appointment, doctor: doctor)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private func doctorsSection(compactLinks: Bool) -> some View {
+        Section {
+            if controller.doctors.isEmpty {
+                ContentUnavailableView(
+                    "Noch keine Ärztinnen oder Ärzte",
+                    systemImage: "cross.case",
+                    description: Text("Nutze die ÖGK-Liste als Startpunkt oder lege eine Ärztin bzw. einen Arzt vollständig manuell an.")
+                )
+            } else {
+                ForEach(controller.doctors) { doctor in
+                    if compactLinks {
+                        NavigationLink {
+                            DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
+                        } label: {
+                            DoctorSummaryRow(doctor: doctor)
+                        }
+                    } else {
+                        Button {
+                            selectedDoctorID = doctor.id
+                        } label: {
+                            DoctorSummaryRow(doctor: doctor)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .buttonStyle(.plain)
+                        .listRowBackground(selectedDoctorID == doctor.id ? AppTheme.selectedFill : Color.clear)
+                    }
+                }
+            }
+        } header: {
+            Text("Meine Ärzte")
+        } footer: {
+            Text(
+                AppStoreScreenshotMode.isEnabled
+                ? "Im Screenshot-Modus werden ausschließlich anonymisierte Musterärztinnen und Musterärzte angezeigt."
+                : "Suchquelle: ÖGK Vertragspartner Fachärztinnen und Fachärzte. Fehlende Kontaktdaten können danach manuell ergänzt werden."
+            )
+        }
+    }
+
+    private func reload(selecting doctorID: UUID? = nil) {
+        controller.reload()
+
+        if let doctorID {
+            selectedDoctorID = doctorID
+        } else if selectedDoctorID == nil {
+            selectedDoctorID = controller.doctors.first?.id
+        } else if !controller.doctors.contains(where: { $0.id == selectedDoctorID }) {
+            selectedDoctorID = controller.doctors.first?.id
+        }
     }
 }
 

--- a/MigraineTracker/Sources/Features/Export/DataExportView.swift
+++ b/MigraineTracker/Sources/Features/Export/DataExportView.swift
@@ -82,7 +82,7 @@ struct DataExportView: View {
                 }
             } else {
                 Section("Vorschau") {
-                    ForEach(controller.summary.records.prefix(5)) { record in
+                    ForEach(controller.summary.records.prefix(8)) { record in
                         VStack(alignment: .leading, spacing: 4) {
                             Text(record.startedAt, style: .date)
                                 .font(.headline)

--- a/MigraineTracker/Sources/Features/Export/ExportView.swift
+++ b/MigraineTracker/Sources/Features/Export/ExportView.swift
@@ -3,10 +3,12 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     let appContainer: AppContainer
+    let showsCloseButton: Bool
     @State private var controller: SettingsController
 
-    init(appContainer: AppContainer) {
+    init(appContainer: AppContainer, showsCloseButton: Bool = true) {
         self.appContainer = appContainer
+        self.showsCloseButton = showsCloseButton
         _controller = State(initialValue: appContainer.makeSettingsController())
     }
 
@@ -89,9 +91,11 @@ struct SettingsView: View {
         .navigationTitle("Einstellungen")
         .brandGroupedScreen()
         .toolbar {
-            ToolbarItem(placement: closeButtonPlacement) {
-                Button("Schließen") {
-                    dismiss()
+            if showsCloseButton {
+                ToolbarItem(placement: closeButtonPlacement) {
+                    Button("Schließen") {
+                        dismiss()
+                    }
                 }
             }
         }

--- a/MigraineTracker/Sources/Features/History/EpisodeDetailView.swift
+++ b/MigraineTracker/Sources/Features/History/EpisodeDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct EpisodeDetailView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     let appContainer: AppContainer
     let episodeID: UUID
@@ -22,6 +23,54 @@ struct EpisodeDetailView: View {
     }
 
     var body: some View {
+        Group {
+            if horizontalSizeClass == .compact {
+                detailList
+            } else {
+                regularDetail
+            }
+        }
+        .navigationTitle("Episodendetail")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Bearbeiten") {
+                    isEditing = true
+                }
+                .disabled(episode == nil)
+            }
+
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Löschen", role: .destructive) {
+                    isShowingDeleteConfirmation = true
+                }
+                .disabled(episode == nil)
+            }
+        }
+        .sheet(isPresented: $isEditing) {
+            NavigationStack {
+                EpisodeEditorView(
+                    appContainer: appContainer,
+                    episodeID: episodeID,
+                    onSaved: reload
+                )
+            }
+        }
+        .confirmationDialog(
+            "Episode löschen?",
+            isPresented: $isShowingDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Löschen", role: .destructive) {
+                deleteEpisode()
+            }
+
+            Button("Abbrechen", role: .cancel) {}
+        } message: {
+            Text("Diese Episode wird in den Papierkorb verschoben.")
+        }
+    }
+
+    private var detailList: some View {
         List {
             if let episode {
                 Section("Episode") {
@@ -145,45 +194,107 @@ struct EpisodeDetailView: View {
                 ContentUnavailableView("Episode nicht gefunden", systemImage: "exclamationmark.triangle")
             }
         }
-        .navigationTitle("Episodendetail")
         .brandGroupedScreen()
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("Bearbeiten") {
-                    isEditing = true
-                }
-                .disabled(episode == nil)
-            }
+    }
 
-            ToolbarItem(placement: .topBarTrailing) {
-                Button("Löschen", role: .destructive) {
-                    isShowingDeleteConfirmation = true
-                }
-                .disabled(episode == nil)
-            }
-        }
-        .sheet(isPresented: $isEditing) {
-            NavigationStack {
-                EpisodeEditorView(
-                    appContainer: appContainer,
-                    episodeID: episodeID,
-                    onSaved: reload
-                )
-            }
-        }
-        .confirmationDialog(
-            "Episode löschen?",
-            isPresented: $isShowingDeleteConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button("Löschen", role: .destructive) {
-                deleteEpisode()
-            }
+    private var regularDetail: some View {
+        ScrollView {
+            if let episode {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 320), spacing: AppTheme.dashboardSpacing, alignment: .top)],
+                    alignment: .leading,
+                    spacing: AppTheme.dashboardSpacing
+                ) {
+                    AdaptiveDashboardCard(title: "Episode") {
+                        detailValue("Typ", episode.type.rawValue)
+                        detailValue("Intensität", "\(episode.intensity) / 10")
+                        detailValue("Beginn", episode.startedAt.formatted(date: .abbreviated, time: .shortened))
+                        if let endedAt = episode.endedAt {
+                            detailValue("Ende", endedAt.formatted(date: .abbreviated, time: .shortened))
+                        }
+                        if !episode.painLocation.isEmpty {
+                            detailValue("Lokalisation", episode.painLocation)
+                        }
+                        if !episode.painCharacter.isEmpty {
+                            detailValue("Charakter", episode.painCharacter)
+                        }
+                        if !episode.functionalImpact.isEmpty {
+                            detailValue("Einschränkung", episode.functionalImpact)
+                        }
+                        if episode.menstruationStatus != .unknown {
+                            detailValue("Menstruationsstatus", episode.menstruationStatus.rawValue)
+                        }
+                    }
 
-            Button("Abbrechen", role: .cancel) {}
-        } message: {
-            Text("Diese Episode wird in den Papierkorb verschoben.")
+                    if !episode.symptoms.isEmpty {
+                        AdaptiveDashboardCard(title: "Symptome") {
+                            tagFlow(episode.symptoms)
+                        }
+                    }
+
+                    if !episode.triggers.isEmpty {
+                        AdaptiveDashboardCard(title: "Trigger") {
+                            tagFlow(episode.triggers)
+                        }
+                    }
+
+                    if !episode.medications.isEmpty {
+                        AdaptiveDashboardCard(title: "Medikamente") {
+                            ForEach(episode.medications.sorted(by: { $0.takenAt < $1.takenAt })) { medication in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack(alignment: .firstTextBaseline) {
+                                        Text(medication.name)
+                                            .font(.headline)
+                                        Spacer()
+                                        Text(medication.takenAt.formatted(date: .omitted, time: .shortened))
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Text(medicationHeadline(for: medication))
+                                        .foregroundStyle(.secondary)
+                                }
+                                .padding(12)
+                                .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            }
+                        }
+                    }
+
+                    if let weatherSnapshot = episode.weather {
+                        AdaptiveDashboardCard(title: "Wetter") {
+                            if !weatherSnapshot.condition.isEmpty {
+                                detailValue("Bedingung", weatherSnapshot.condition)
+                            }
+                            if let temperature = weatherSnapshot.temperature {
+                                detailValue("Temperatur", temperature.formatted(.number.precision(.fractionLength(1))) + " °C")
+                            }
+                            if let humidity = weatherSnapshot.humidity {
+                                detailValue("Luftfeuchte", humidity.formatted(.number.precision(.fractionLength(0))) + " %")
+                            }
+                            if let pressure = weatherSnapshot.pressure {
+                                detailValue("Luftdruck", pressure.formatted(.number.precision(.fractionLength(0))) + " hPa")
+                            }
+                            if let precipitation = weatherSnapshot.precipitation {
+                                detailValue("Niederschlag", precipitation.formatted(.number.precision(.fractionLength(1))) + " mm")
+                            }
+                            detailValue("Erfasst", weatherSnapshot.recordedAt.formatted(date: .abbreviated, time: .shortened))
+                            WeatherAttributionView()
+                        }
+                    }
+
+                    if !episode.notes.isEmpty {
+                        AdaptiveDashboardCard(title: "Notiz") {
+                            Text(episode.notes)
+                        }
+                    }
+                }
+                .padding(24)
+                .wideContent()
+            } else {
+                ContentUnavailableView("Episode nicht gefunden", systemImage: "exclamationmark.triangle")
+                    .frame(maxWidth: .infinity, minHeight: 360)
+            }
         }
+        .brandScreen()
     }
 
     private func detailRow(_ title: String, _ value: String) -> some View {
@@ -196,6 +307,29 @@ struct EpisodeDetailView: View {
         .padding(.vertical, 2)
         .brandGroupedRow()
         .accessibilityElement(children: .combine)
+    }
+
+    private func detailValue(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func tagFlow(_ values: [String]) -> some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 8)], alignment: .leading, spacing: 8) {
+            ForEach(values, id: \.self) { value in
+                Text(value)
+                    .font(.subheadline.weight(.medium))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(AppTheme.secondaryFill, in: Capsule())
+            }
+        }
     }
 
     private func medicationHeadline(for medication: MedicationRecord) -> String {

--- a/MigraineTracker/Sources/Features/History/HistoryView.swift
+++ b/MigraineTracker/Sources/Features/History/HistoryView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HistoryView: View {
     let appContainer: AppContainer
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var controller: HistoryController
 
     init(appContainer: AppContainer) {
@@ -11,79 +12,33 @@ struct HistoryView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                contentSection(
-                    title: "Kalender",
-                    footer: "Wähle einen Tag aus und füge direkt einen neuen Eintrag hinzu oder öffne vorhandene Dokumentationen."
-                ) {
-                    VStack(alignment: .leading, spacing: 16) {
-                        MonthHeader(
-                            month: controller.displayedMonth,
-                            onPrevious: controller.goToPreviousMonth,
-                            onNext: controller.goToNextMonth
-                        )
-
-                        MonthGrid(
-                            month: controller.displayedMonth,
-                            selectedDay: Binding(
-                                get: { controller.selectedDay },
-                                set: { controller.selectDay($0) }
-                            ),
-                            episodesByDay: controller.episodesByDay
-                        )
-                    }
-                }
-
-                Button {
-                    controller.isPresentingNewEpisode = true
-                } label: {
-                    Label("Neuer Eintrag", systemImage: "plus.circle.fill")
-                        .frame(maxWidth: .infinity, alignment: .center)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .accessibilityHint("Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag.")
-
-                contentSection(title: "Ausgewählter Tag") {
-                    VStack(alignment: .leading, spacing: 12) {
-                        daySummary
-
-                        if controller.selectedDayEpisodes.isEmpty {
-                            ContentUnavailableView(
-                                "Noch keine Einträge an diesem Tag",
-                                systemImage: "calendar",
-                                description: Text("Für \(controller.selectedDay.formatted(date: .complete, time: .omitted)) ist noch nichts dokumentiert.")
-                            )
-                        } else {
-                            ForEach(controller.selectedDayEpisodes) { episode in
-                                episodeLink(for: episode)
-                            }
-                        }
-                    }
-                }
-
-                contentSection(title: "Export") {
-                    NavigationLink {
-                        DataExportView(appContainer: appContainer)
-                    } label: {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Label("Daten exportieren", systemImage: "square.and.arrow.up")
-                            Text("Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum.")
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .buttonStyle(.plain)
-                }
+            if horizontalSizeClass == .compact {
+                compactContent
+            } else {
+                regularContent
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 20)
         }
         .background(AppTheme.appBackground.ignoresSafeArea())
         .tint(AppTheme.ocean)
         .navigationTitle("Tagebuch")
         .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink {
+                    DataExportView(appContainer: appContainer)
+                } label: {
+                    Label("Export", systemImage: "square.and.arrow.up")
+                }
+            }
+
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    controller.isPresentingNewEpisode = true
+                } label: {
+                    Label("Neuer Eintrag", systemImage: "plus.circle.fill")
+                }
+                .keyboardShortcut("n", modifiers: .command)
+            }
+
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     controller.isPresentingSettings = true
@@ -147,6 +102,82 @@ struct HistoryView: View {
             }
         } message: { episode in
             Text("\(episode.startedAt.formatted(date: .abbreviated, time: .shortened)) wird in den Papierkorb verschoben.")
+        }
+    }
+
+    private var compactContent: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            calendarSection
+
+            Button {
+                controller.isPresentingNewEpisode = true
+            } label: {
+                Label("Neuer Eintrag", systemImage: "plus.circle.fill")
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .accessibilityHint("Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag.")
+
+            selectedDaySection
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 20)
+    }
+
+    private var regularContent: some View {
+        HStack(alignment: .top, spacing: AppTheme.dashboardSpacing) {
+            calendarSection
+                .frame(minWidth: 420, maxWidth: 560, alignment: .top)
+
+            selectedDaySection
+                .frame(maxWidth: .infinity, alignment: .top)
+        }
+        .padding(24)
+        .wideContent()
+    }
+
+    private var calendarSection: some View {
+        contentSection(
+            title: "Kalender",
+            footer: "Wähle einen Tag aus und füge direkt einen neuen Eintrag hinzu oder öffne vorhandene Dokumentationen."
+        ) {
+            VStack(alignment: .leading, spacing: 16) {
+                MonthHeader(
+                    month: controller.displayedMonth,
+                    onPrevious: controller.goToPreviousMonth,
+                    onNext: controller.goToNextMonth
+                )
+
+                MonthGrid(
+                    month: controller.displayedMonth,
+                    selectedDay: Binding(
+                        get: { controller.selectedDay },
+                        set: { controller.selectDay($0) }
+                    ),
+                    episodesByDay: controller.episodesByDay
+                )
+            }
+        }
+    }
+
+    private var selectedDaySection: some View {
+        contentSection(title: "Ausgewählter Tag") {
+            VStack(alignment: .leading, spacing: 12) {
+                daySummary
+
+                if controller.selectedDayEpisodes.isEmpty {
+                    ContentUnavailableView(
+                        "Noch keine Einträge an diesem Tag",
+                        systemImage: "calendar",
+                        description: Text("Für \(controller.selectedDay.formatted(date: .complete, time: .omitted)) ist noch nichts dokumentiert.")
+                    )
+                } else {
+                    ForEach(controller.selectedDayEpisodes) { episode in
+                        episodeLink(for: episode)
+                    }
+                }
+            }
         }
     }
 

--- a/MigraineTracker/Sources/Features/Home/HomeView.swift
+++ b/MigraineTracker/Sources/Features/Home/HomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeView: View {
     let appContainer: AppContainer
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var overview: HomeOverviewData = .init(latestEpisode: nil, episodeCount: 0)
     @State private var doctorHubController: DoctorHubController
@@ -16,119 +17,30 @@ struct HomeView: View {
     }
 
     var body: some View {
-        List {
-            Section {
-                DiaryWelcomeCard(overview: overview)
-                    .padding(.vertical, 6)
-
+        Group {
+            if horizontalSizeClass == .compact {
+                compactDashboard
+            } else {
+                regularDashboard
+            }
+        }
+        .navigationTitle("Schmerztagebuch")
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
                     isPresentingEpisodeEditor = true
                 } label: {
                     Label("Neuer Eintrag", systemImage: "plus.circle.fill")
-                        .frame(maxWidth: .infinity, alignment: .center)
                 }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
+                .keyboardShortcut("n", modifiers: .command)
 
-                NavigationLink {
-                    HistoryView(appContainer: appContainer)
-                } label: {
-                    Label("Tagebuch öffnen", systemImage: "book.closed")
-                        .frame(maxWidth: .infinity, alignment: .center)
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.large)
-            } header: {
-                Text("Tagebuch")
-            } footer: {
-                Text("Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten.")
-            }
-
-            Section {
                 Button {
                     isPresentingAppointmentFlow = true
                 } label: {
-                    Label("Termin hinzufügen", systemImage: "calendar.badge.plus")
+                    Label("Termin", systemImage: "calendar.badge.plus")
                 }
-
-                if doctorHubController.upcomingAppointments.isEmpty {
-                    ContentUnavailableView(
-                        "Keine kommenden Termine",
-                        systemImage: "calendar.badge.clock",
-                        description: Text("Lege einen Termin an. Falls noch keine Ärztin oder kein Arzt vorhanden ist, startet zuerst der Arzt-Flow.")
-                    )
-                } else {
-                    ForEach(doctorHubController.upcomingAppointments) { appointment in
-                        if let doctor = doctorHubController.doctors.first(where: { $0.id == appointment.doctorID }) {
-                            NavigationLink {
-                                DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
-                            } label: {
-                                AppointmentSummaryRow(appointment: appointment, doctor: doctor)
-                            }
-                        }
-                    }
-                }
-            } header: {
-                Text("Termine")
-            }
-
-            Section {
-                Button {
-                    isPresentingDoctorAddFlow = true
-                } label: {
-                    Label("Arzt hinzufügen", systemImage: "cross.case.fill")
-                }
-
-                Button {
-                    isPresentingManualDoctorAddFlow = true
-                } label: {
-                    Label("Arzt manuell hinzufügen", systemImage: "square.and.pencil")
-                }
-
-                if doctorHubController.doctors.isEmpty {
-                    ContentUnavailableView(
-                        "Noch keine Ärztinnen oder Ärzte",
-                        systemImage: "cross.case",
-                        description: Text("Nutze die ÖGK-Liste als Startpunkt oder lege eine Ärztin bzw. einen Arzt vollständig manuell an.")
-                    )
-                } else {
-                    ForEach(doctorHubController.doctors) { doctor in
-                        NavigationLink {
-                            DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
-                        } label: {
-                            DoctorSummaryRow(doctor: doctor)
-                        }
-                    }
-                }
-            } header: {
-                Text("Meine Ärzte")
-            } footer: {
-                Text(
-                    AppStoreScreenshotMode.isEnabled
-                    ? "Im Screenshot-Modus werden ausschließlich anonymisierte Musterärztinnen und Musterärzte angezeigt."
-                    : "Suchquelle: ÖGK Vertragspartner Fachärztinnen und Fachärzte. Fehlende Kontaktdaten können danach manuell ergänzt werden."
-                )
-            }
-
-            Section {
-                NavigationLink {
-                    SettingsView(appContainer: appContainer)
-                } label: {
-                    Label("Einstellungen", systemImage: "gearshape")
-                }
-
-                NavigationLink {
-                    ProductInformationView(mode: .standard)
-                } label: {
-                    Label("Datenschutz und Hinweise", systemImage: "hand.raised")
-                }
-            } header: {
-                Text("Mehr")
             }
         }
-        .listStyle(.insetGrouped)
-        .brandGroupedScreen()
-        .navigationTitle("Schmerztagebuch")
         .task {
             reload()
         }
@@ -169,9 +81,223 @@ struct HomeView: View {
         }
     }
 
+    private var compactDashboard: some View {
+        List {
+            Section {
+                DiaryWelcomeCard(overview: overview)
+                    .padding(.vertical, 6)
+
+                Button {
+                    isPresentingEpisodeEditor = true
+                } label: {
+                    Label("Neuer Eintrag", systemImage: "plus.circle.fill")
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+            } header: {
+                Text("Heute")
+            }
+
+            appointmentsSection
+            doctorsSection
+        }
+        .listStyle(.insetGrouped)
+        .brandGroupedScreen()
+    }
+
+    private var regularDashboard: some View {
+        ScrollView {
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(minimum: 360), spacing: AppTheme.dashboardSpacing, alignment: .top),
+                    GridItem(.flexible(minimum: 320), spacing: AppTheme.dashboardSpacing, alignment: .top)
+                ],
+                alignment: .leading,
+                spacing: AppTheme.dashboardSpacing
+            ) {
+                VStack(alignment: .leading, spacing: AppTheme.dashboardSpacing) {
+                    DiaryWelcomeCard(overview: overview)
+
+                    AdaptiveDashboardCard(title: "Schnellaktionen") {
+                        LazyVGrid(
+                            columns: [GridItem(.adaptive(minimum: 180), spacing: 12)],
+                            alignment: .leading,
+                            spacing: 12
+                        ) {
+                            QuickActionTile("Neuer Eintrag", systemImage: "plus.circle.fill") {
+                                isPresentingEpisodeEditor = true
+                            }
+
+                            QuickActionTile("Termin hinzufügen", systemImage: "calendar.badge.plus") {
+                                isPresentingAppointmentFlow = true
+                            }
+
+                            QuickActionTile("Arzt hinzufügen", systemImage: "cross.case.fill") {
+                                isPresentingDoctorAddFlow = true
+                            }
+
+                            QuickActionTile("Manuell anlegen", systemImage: "square.and.pencil") {
+                                isPresentingManualDoctorAddFlow = true
+                            }
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: AppTheme.dashboardSpacing) {
+                    AdaptiveDashboardCard(title: "Kommende Termine") {
+                        appointmentContent
+                    }
+
+                    AdaptiveDashboardCard(title: "Meine Ärzte") {
+                        doctorContent
+                    }
+                }
+            }
+            .padding(24)
+            .wideContent()
+        }
+        .brandScreen()
+        .refreshable {
+            reload()
+        }
+    }
+
+    private var appointmentsSection: some View {
+        Section {
+            Button {
+                isPresentingAppointmentFlow = true
+            } label: {
+                Label("Termin hinzufügen", systemImage: "calendar.badge.plus")
+            }
+
+            appointmentContent
+        } header: {
+            Text("Termine")
+        }
+    }
+
+    private var doctorsSection: some View {
+        Section {
+            Button {
+                isPresentingDoctorAddFlow = true
+            } label: {
+                Label("Arzt hinzufügen", systemImage: "cross.case.fill")
+            }
+
+            Button {
+                isPresentingManualDoctorAddFlow = true
+            } label: {
+                Label("Arzt manuell hinzufügen", systemImage: "square.and.pencil")
+            }
+
+            doctorContent
+        } header: {
+            Text("Meine Ärzte")
+        } footer: {
+            Text(
+                AppStoreScreenshotMode.isEnabled
+                ? "Im Screenshot-Modus werden ausschließlich anonymisierte Musterärztinnen und Musterärzte angezeigt."
+                : "Suchquelle: ÖGK Vertragspartner Fachärztinnen und Fachärzte. Fehlende Kontaktdaten können danach manuell ergänzt werden."
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var appointmentContent: some View {
+        if doctorHubController.upcomingAppointments.isEmpty {
+            ContentUnavailableView(
+                "Keine kommenden Termine",
+                systemImage: "calendar.badge.clock",
+                description: Text("Lege einen Termin an. Falls noch keine Ärztin oder kein Arzt vorhanden ist, startet zuerst der Arzt-Flow.")
+            )
+        } else {
+            ForEach(doctorHubController.upcomingAppointments) { appointment in
+                if let doctor = doctorHubController.doctors.first(where: { $0.id == appointment.doctorID }) {
+                    NavigationLink {
+                        DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
+                    } label: {
+                        AppointmentSummaryRow(appointment: appointment, doctor: doctor)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var doctorContent: some View {
+        if doctorHubController.doctors.isEmpty {
+            ContentUnavailableView(
+                "Noch keine Ärztinnen oder Ärzte",
+                systemImage: "cross.case",
+                description: Text("Nutze die ÖGK-Liste als Startpunkt oder lege eine Ärztin bzw. einen Arzt vollständig manuell an.")
+            )
+        } else {
+            ForEach(doctorHubController.doctors.prefix(horizontalSizeClass == .compact ? 5 : 6)) { doctor in
+                NavigationLink {
+                    DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
+                } label: {
+                    DoctorSummaryRow(doctor: doctor)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
     private func reload() {
         overview = (try? LoadHomeOverviewUseCase(repository: appContainer.episodeRepository).execute()) ?? .init(latestEpisode: nil, episodeCount: 0)
         doctorHubController.reload()
+    }
+}
+
+struct AdaptiveDashboardCard<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(title)
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(alignment: .leading, spacing: 12) {
+                content
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .brandCard()
+    }
+}
+
+private struct QuickActionTile: View {
+    let title: String
+    let systemImage: String
+    let action: () -> Void
+
+    init(_ title: String, systemImage: String, action: @escaping () -> Void) {
+        self.title = title
+        self.systemImage = systemImage
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Label(title, systemImage: systemImage)
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity, minHeight: 54, alignment: .leading)
+                .padding(.horizontal, 14)
+                .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .hoverEffect(.highlight)
     }
 }
 

--- a/MigraineTracker/Sources/Shared/AppTheme.swift
+++ b/MigraineTracker/Sources/Shared/AppTheme.swift
@@ -4,6 +4,9 @@ enum AppTheme {
     static let groupedHorizontalInset: CGFloat = 20
     static let groupedTopInset: CGFloat = 12
     static let groupedRowInsets = EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20)
+    static let wideContentMaxWidth: CGFloat = 1180
+    static let readableContentMaxWidth: CGFloat = 760
+    static let dashboardSpacing: CGFloat = 20
 
     static let ink = Color(red: 0.04, green: 0.30, blue: 0.38)
     static let ocean = Color(red: 0.08, green: 0.56, blue: 0.62)
@@ -57,11 +60,27 @@ private struct BrandScreenModifier: ViewModifier {
 }
 
 private struct BrandGroupedScreenModifier: ViewModifier {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     func body(content: Content) -> some View {
         content
             .brandScreen()
-            .contentMargins(.horizontal, AppTheme.groupedHorizontalInset, for: .scrollContent)
+            .contentMargins(.horizontal, horizontalInset, for: .scrollContent)
             .contentMargins(.top, AppTheme.groupedTopInset, for: .scrollContent)
+    }
+
+    private var horizontalInset: CGFloat {
+        horizontalSizeClass == .compact ? AppTheme.groupedHorizontalInset : 36
+    }
+}
+
+private struct WideContentModifier: ViewModifier {
+    let maxWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: maxWidth, alignment: .center)
+            .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 
@@ -85,6 +104,10 @@ extension View {
 
     func brandGroupedScreen() -> some View {
         modifier(BrandGroupedScreenModifier())
+    }
+
+    func wideContent(maxWidth: CGFloat = AppTheme.wideContentMaxWidth) -> some View {
+        modifier(WideContentModifier(maxWidth: maxWidth))
     }
 
     func brandGroupedRow() -> some View {


### PR DESCRIPTION
## Zusammenfassung

- führt eine adaptive App-Shell mit Tabs auf iPhone und Sidebar auf iPad/Mac ein
- baut Home, Tagebuch und Ärzte/Termine auf breiten Displays zu echten Dashboard- bzw. Split-Layouts um
- korrigiert die reguläre Detailfläche für Export, Einstellungen und Hinweise, damit die Sidebar den Inhalt nicht überlagert

## Validierung

- `xcodebuild build -scheme MigraineTracker -destination 'generic/platform=iOS Simulator'`
- `xcodebuild test -scheme MigraineTrackerTests -destination 'platform=iOS Simulator,name=iPhone 17'`
- `xcodebuild test -scheme MigraineTrackerTests -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4)'`

Closes #64