### PR TITLE
Improve UI responsiveness for SwiftData-backed screens

### DIFF
--- a/MigraineTracker/Sources/App/AppShellView.swift
+++ b/MigraineTracker/Sources/App/AppShellView.swift
@@ -51,6 +51,10 @@ struct AppShellView: View {
         .toolbarBackground(AppTheme.ink.opacity(0.96), for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else {
+                return
+            }
             await appContainer.weatherBackfillService.runIfNeeded()
         }
     }

--- a/MigraineTracker/Sources/Core/Doctors/DoctorCore.swift
+++ b/MigraineTracker/Sources/Core/Doctors/DoctorCore.swift
@@ -75,6 +75,13 @@ struct DoctorDirectorySection: Identifiable, Equatable, Sendable {
     var id: String { title }
 }
 
+struct UpcomingAppointmentListItem: Identifiable, Equatable, Sendable {
+    let appointment: AppointmentRecord
+    let doctor: DoctorRecord
+
+    var id: UUID { appointment.id }
+}
+
 struct AppointmentRecord: Identifiable, Equatable, Sendable {
     let id: UUID
     let doctorID: UUID?
@@ -324,22 +331,45 @@ final class DoctorHubController {
     private let appointmentRepository: AppointmentRepository
 
     private(set) var doctors: [DoctorRecord] = []
+    private(set) var doctorsByID: [UUID: DoctorRecord] = [:]
     private(set) var upcomingAppointments: [AppointmentRecord] = []
+    private(set) var upcomingAppointmentItems: [UpcomingAppointmentListItem] = []
     var errorMessage: String?
 
     init(doctorRepository: DoctorRepository, appointmentRepository: AppointmentRepository) {
         self.doctorRepository = doctorRepository
         self.appointmentRepository = appointmentRepository
-        reload()
+        reloadAll()
     }
 
-    func reload() {
+    func reloadAll() {
         do {
-            doctors = try doctorRepository.fetchAll()
-            upcomingAppointments = try appointmentRepository.fetchUpcoming(limit: 20)
+            try reloadDoctors()
+            try reloadAppointments()
             errorMessage = nil
         } catch {
             errorMessage = "Ärzte und Termine konnten nicht geladen werden."
+        }
+    }
+
+    func reloadDoctors() throws {
+        doctors = try doctorRepository.fetchAll()
+        doctorsByID = Dictionary(uniqueKeysWithValues: doctors.map { ($0.id, $0) })
+        rebuildUpcomingAppointmentItems()
+    }
+
+    func reloadAppointments(limit: Int = 20) throws {
+        upcomingAppointments = try appointmentRepository.fetchUpcoming(limit: limit)
+        rebuildUpcomingAppointmentItems()
+    }
+
+    private func rebuildUpcomingAppointmentItems() {
+        upcomingAppointmentItems = upcomingAppointments.compactMap { appointment in
+            guard let doctorID = appointment.doctorID, let doctor = doctorsByID[doctorID] else {
+                return nil
+            }
+
+            return UpcomingAppointmentListItem(appointment: appointment, doctor: doctor)
         }
     }
 }
@@ -370,11 +400,13 @@ final class DoctorEditorController {
     var draft: DoctorDraft
     var searchText = ""
     private(set) var searchResults: [DoctorDirectoryRecord] = []
+    private(set) var groupedSearchResults: [DoctorDirectorySection] = []
     private(set) var sourceAttribution: (label: String, url: String)
     var validationMessage: String?
 
     private let saveDoctorUseCase: SaveDoctorUseCase
     private let directoryRepository: DoctorDirectoryRepository
+    private var searchTask: Task<Void, Never>?
 
     init(
         doctor: DoctorRecord?,
@@ -389,10 +421,23 @@ final class DoctorEditorController {
     }
 
     func refreshSearch() {
-        searchResults = (try? directoryRepository.fetchEntries(searchText: searchText)) ?? []
+        let results = (try? directoryRepository.fetchEntries(searchText: searchText)) ?? []
+        searchResults = results
+        groupedSearchResults = Self.makeGroupedSearchResults(from: results)
     }
 
-    var groupedSearchResults: [DoctorDirectorySection] {
+    func scheduleSearchRefresh() {
+        searchTask?.cancel()
+        searchTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            guard let self, !Task.isCancelled else {
+                return
+            }
+            self.refreshSearch()
+        }
+    }
+
+    private static func makeGroupedSearchResults(from searchResults: [DoctorDirectoryRecord]) -> [DoctorDirectorySection] {
         let grouped = Dictionary(grouping: searchResults) { entry in
             let trimmed = entry.specialty.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? "Sonstige Fachgebiete" : trimmed

--- a/MigraineTracker/Sources/Core/History/HistoryCore.swift
+++ b/MigraineTracker/Sources/Core/History/HistoryCore.swift
@@ -91,7 +91,7 @@ final class HistoryController {
         self.loadDayEpisodesUseCase = LoadDayEpisodesUseCase(repository: repository)
         self.deleteEpisodeUseCase = DeleteEpisodeUseCase(repository: repository)
         self.monthData = HistoryMonthData(month: calendar.startOfMonth(for: initialDay), episodesByDay: [:])
-        reload()
+        reloadAll()
     }
 
     var episodesByDay: [Date: [EpisodeRecord]] {
@@ -107,33 +107,62 @@ final class HistoryController {
         )
     }
 
-    func reload() {
+    func reloadAll() {
         do {
-            monthData = try loadHistoryMonthUseCase.execute(month: displayedMonth)
-            selectedDayEpisodes = try loadDayEpisodesUseCase.execute(day: selectedDay)
+            try reloadMonthData()
+            try reloadSelectedDayEpisodes()
             errorMessage = nil
         } catch {
             errorMessage = "Tagebuch konnte nicht geladen werden."
         }
     }
 
+    func reloadMonthData() throws {
+        monthData = try loadHistoryMonthUseCase.execute(month: displayedMonth)
+    }
+
+    func reloadSelectedDayEpisodes() throws {
+        selectedDayEpisodes = try loadDayEpisodesUseCase.execute(day: selectedDay)
+        syncSelectedDayIntoMonthData()
+    }
+
     func goToPreviousMonth() {
         displayedMonth = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth) ?? displayedMonth
-        reload()
+        do {
+            try reloadMonthData()
+            errorMessage = nil
+        } catch {
+            errorMessage = "Tagebuch konnte nicht geladen werden."
+        }
     }
 
     func goToNextMonth() {
         displayedMonth = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth) ?? displayedMonth
-        reload()
+        do {
+            try reloadMonthData()
+            errorMessage = nil
+        } catch {
+            errorMessage = "Tagebuch konnte nicht geladen werden."
+        }
     }
 
     func selectDay(_ day: Date) {
         selectedDay = day
         let month = Calendar.current.startOfMonth(for: day)
-        if !Calendar.current.isDate(month, equalTo: displayedMonth, toGranularity: .month) {
+        let didChangeMonth = !Calendar.current.isDate(month, equalTo: displayedMonth, toGranularity: .month)
+        if didChangeMonth {
             displayedMonth = month
         }
-        reload()
+
+        do {
+            if didChangeMonth {
+                try reloadMonthData()
+            }
+            try reloadSelectedDayEpisodes()
+            errorMessage = nil
+        } catch {
+            errorMessage = "Tagebuch konnte nicht geladen werden."
+        }
     }
 
     func deletePendingEpisode() {
@@ -144,9 +173,20 @@ final class HistoryController {
         do {
             try deleteEpisodeUseCase.execute(id: pendingDeletionID)
             self.pendingDeletionID = nil
-            reload()
+            try reloadSelectedDayEpisodes()
+            errorMessage = nil
         } catch {
             errorMessage = "Löschen fehlgeschlagen."
+        }
+    }
+
+    func handleSavedEpisode() {
+        do {
+            try reloadMonthData()
+            try reloadSelectedDayEpisodes()
+            errorMessage = nil
+        } catch {
+            errorMessage = "Tagebuch konnte nicht geladen werden."
         }
     }
 
@@ -160,5 +200,21 @@ final class HistoryController {
         }
 
         return calendar.date(bySettingHour: 12, minute: 0, second: 0, of: day) ?? day
+    }
+
+    private func syncSelectedDayIntoMonthData() {
+        let selectedMonth = Calendar.current.startOfMonth(for: selectedDay)
+        guard Calendar.current.isDate(selectedMonth, equalTo: displayedMonth, toGranularity: .month) else {
+            return
+        }
+
+        var updated = monthData.episodesByDay
+        let day = Calendar.current.startOfDay(for: selectedDay)
+        if selectedDayEpisodes.isEmpty {
+            updated.removeValue(forKey: day)
+        } else {
+            updated[day] = selectedDayEpisodes
+        }
+        monthData = HistoryMonthData(month: monthData.month, episodesByDay: updated)
     }
 }

--- a/MigraineTracker/Sources/Features/Doctors/DoctorsHubView.swift
+++ b/MigraineTracker/Sources/Features/Doctors/DoctorsHubView.swift
@@ -53,16 +53,16 @@ struct DoctorsHubView: View {
             }
         }
         .task {
-            reload()
+            reloadAll()
         }
         .refreshable {
-            reload()
+            reloadAll()
         }
         .sheet(item: $doctorAddMode) { mode in
             NavigationStack {
                 DoctorAddFlowView(appContainer: appContainer, startMode: mode) { doctorID in
                     doctorAddMode = nil
-                    reload(selecting: doctorID)
+                    reloadDoctors(selecting: doctorID)
                 }
             }
         }
@@ -70,7 +70,7 @@ struct DoctorsHubView: View {
             NavigationStack {
                 AppointmentCreationFlowView(appContainer: appContainer) {
                     isPresentingAppointmentFlow = false
-                    reload()
+                    reloadAppointments()
                 }
             }
         }
@@ -157,22 +157,20 @@ struct DoctorsHubView: View {
 
     @ViewBuilder
     private var appointmentRows: some View {
-        if controller.upcomingAppointments.isEmpty {
+        if controller.upcomingAppointmentItems.isEmpty {
             ContentUnavailableView(
                 "Keine kommenden Termine",
                 systemImage: "calendar.badge.clock",
                 description: Text("Lege einen Termin an, sobald du eine Ärztin oder einen Arzt erfasst hast.")
             )
         } else {
-            ForEach(controller.upcomingAppointments) { appointment in
-                if let doctor = controller.doctors.first(where: { $0.id == appointment.doctorID }) {
-                    NavigationLink {
-                        DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
-                    } label: {
-                        AppointmentSummaryRow(appointment: appointment, doctor: doctor)
-                    }
-                    .buttonStyle(.plain)
+            ForEach(controller.upcomingAppointmentItems) { item in
+                NavigationLink {
+                    DoctorDetailView(appContainer: appContainer, doctorID: item.doctor.id)
+                } label: {
+                    AppointmentSummaryRow(appointment: item.appointment, doctor: item.doctor)
                 }
+                .buttonStyle(.plain)
             }
         }
     }
@@ -216,12 +214,36 @@ struct DoctorsHubView: View {
         }
     }
 
-    private func reload(selecting doctorID: UUID? = nil) {
-        controller.reload()
+    private func reloadAll() {
+        controller.reloadAll()
+        updateSelection()
+    }
 
+    private func reloadDoctors(selecting doctorID: UUID? = nil) {
+        do {
+            try controller.reloadDoctors()
+            controller.errorMessage = nil
+        } catch {
+            controller.errorMessage = "Ärzte und Termine konnten nicht geladen werden."
+        }
         if let doctorID {
             selectedDoctorID = doctorID
-        } else if selectedDoctorID == nil {
+        }
+        updateSelection()
+    }
+
+    private func reloadAppointments() {
+        do {
+            try controller.reloadAppointments()
+            controller.errorMessage = nil
+        } catch {
+            controller.errorMessage = "Ärzte und Termine konnten nicht geladen werden."
+        }
+        updateSelection()
+    }
+
+    private func updateSelection() {
+        if selectedDoctorID == nil {
             selectedDoctorID = controller.doctors.first?.id
         } else if !controller.doctors.contains(where: { $0.id == selectedDoctorID }) {
             selectedDoctorID = controller.doctors.first?.id
@@ -557,7 +579,7 @@ private struct DoctorDirectoryPickerView: View {
                     .textInputAutocapitalization(.words)
                     .autocorrectionDisabled()
                     .onChange(of: controller.searchText) {
-                        controller.refreshSearch()
+                        controller.scheduleSearchRefresh()
                     }
 
                 Text("Quelle: \(controller.sourceAttribution.label)")

--- a/MigraineTracker/Sources/Features/History/HistoryView.swift
+++ b/MigraineTracker/Sources/Features/History/HistoryView.swift
@@ -54,7 +54,7 @@ struct HistoryView: View {
                     initialStartedAt: controller.defaultStartDateForSelectedDay(),
                     onSaved: {
                         controller.isPresentingNewEpisode = false
-                        controller.reload()
+                        controller.handleSavedEpisode()
                     }
                 )
             }
@@ -71,7 +71,7 @@ struct HistoryView: View {
                     episodeID: episodeID.id,
                     onSaved: {
                         controller.editingEpisodeID = nil
-                        controller.reload()
+                        controller.handleSavedEpisode()
                     }
                 )
             }

--- a/MigraineTracker/Sources/Features/Home/HomeView.swift
+++ b/MigraineTracker/Sources/Features/Home/HomeView.swift
@@ -42,16 +42,16 @@ struct HomeView: View {
             }
         }
         .task {
-            reload()
+            reloadAll()
         }
         .refreshable {
-            reload()
+            reloadAll()
         }
         .fullScreenCover(isPresented: $isPresentingEpisodeEditor) {
             NavigationStack {
                 EpisodeEditorView(appContainer: appContainer) {
                     isPresentingEpisodeEditor = false
-                    reload()
+                    reloadOverview()
                 }
             }
         }
@@ -59,7 +59,7 @@ struct HomeView: View {
             NavigationStack {
                 DoctorAddFlowView(appContainer: appContainer, startMode: .oegkDirectory) { _ in
                     isPresentingDoctorAddFlow = false
-                    reload()
+                    reloadDoctorData()
                 }
             }
         }
@@ -67,7 +67,7 @@ struct HomeView: View {
             NavigationStack {
                 DoctorAddFlowView(appContainer: appContainer, startMode: .manual) { _ in
                     isPresentingManualDoctorAddFlow = false
-                    reload()
+                    reloadDoctorData()
                 }
             }
         }
@@ -75,7 +75,7 @@ struct HomeView: View {
             NavigationStack {
                 AppointmentCreationFlowView(appContainer: appContainer) {
                     isPresentingAppointmentFlow = false
-                    reload()
+                    reloadAppointments()
                 }
             }
         }
@@ -159,7 +159,7 @@ struct HomeView: View {
         }
         .brandScreen()
         .refreshable {
-            reload()
+            reloadAll()
         }
     }
 
@@ -205,22 +205,20 @@ struct HomeView: View {
 
     @ViewBuilder
     private var appointmentContent: some View {
-        if doctorHubController.upcomingAppointments.isEmpty {
+        if doctorHubController.upcomingAppointmentItems.isEmpty {
             ContentUnavailableView(
                 "Keine kommenden Termine",
                 systemImage: "calendar.badge.clock",
                 description: Text("Lege einen Termin an. Falls noch keine Ärztin oder kein Arzt vorhanden ist, startet zuerst der Arzt-Flow.")
             )
         } else {
-            ForEach(doctorHubController.upcomingAppointments) { appointment in
-                if let doctor = doctorHubController.doctors.first(where: { $0.id == appointment.doctorID }) {
-                    NavigationLink {
-                        DoctorDetailView(appContainer: appContainer, doctorID: doctor.id)
-                    } label: {
-                        AppointmentSummaryRow(appointment: appointment, doctor: doctor)
-                    }
-                    .buttonStyle(.plain)
+            ForEach(doctorHubController.upcomingAppointmentItems) { item in
+                NavigationLink {
+                    DoctorDetailView(appContainer: appContainer, doctorID: item.doctor.id)
+                } label: {
+                    AppointmentSummaryRow(appointment: item.appointment, doctor: item.doctor)
                 }
+                .buttonStyle(.plain)
             }
         }
     }
@@ -245,9 +243,32 @@ struct HomeView: View {
         }
     }
 
-    private func reload() {
+    private func reloadAll() {
+        reloadOverview()
+        reloadDoctorData()
+    }
+
+    private func reloadOverview() {
         overview = (try? LoadHomeOverviewUseCase(repository: appContainer.episodeRepository).execute()) ?? .init(latestEpisode: nil, episodeCount: 0)
-        doctorHubController.reload()
+    }
+
+    private func reloadDoctorData() {
+        do {
+            try doctorHubController.reloadDoctors()
+            try doctorHubController.reloadAppointments()
+            doctorHubController.errorMessage = nil
+        } catch {
+            doctorHubController.errorMessage = "Ärzte und Termine konnten nicht geladen werden."
+        }
+    }
+
+    private func reloadAppointments() {
+        do {
+            try doctorHubController.reloadAppointments()
+            doctorHubController.errorMessage = nil
+        } catch {
+            doctorHubController.errorMessage = "Ärzte und Termine konnten nicht geladen werden."
+        }
     }
 }
 

--- a/MigraineTracker/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/MigraineTracker/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -12,9 +12,11 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
     }
 
     func fetchRecent() throws -> [EpisodeRecord] {
-        let descriptor = FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)])
-        return try context.fetch(descriptor)
-            .filter { !$0.isDeleted }
+        let descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]
+        )
+        return try readContext().fetch(descriptor)
             .map { EpisodeRecord(episode: $0, healthContextStore: healthContextStore) }
     }
 
@@ -24,12 +26,11 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
         let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
         let descriptor = FetchDescriptor<Episode>(
             predicate: #Predicate<Episode> { episode in
-                episode.startedAt >= start && episode.startedAt < end
+                episode.deletedAt == nil && episode.startedAt >= start && episode.startedAt < end
             },
             sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]
         )
-        return try context.fetch(descriptor)
-            .filter { !$0.isDeleted }
+        return try readContext().fetch(descriptor)
             .map { EpisodeRecord(episode: $0, healthContextStore: healthContextStore) }
     }
 
@@ -39,12 +40,11 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
         let end = calendar.date(byAdding: .month, value: 1, to: start) ?? start
         let descriptor = FetchDescriptor<Episode>(
             predicate: #Predicate<Episode> { episode in
-                episode.startedAt >= start && episode.startedAt < end
+                episode.deletedAt == nil && episode.startedAt >= start && episode.startedAt < end
             },
             sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]
         )
-        return try context.fetch(descriptor)
-            .filter { !$0.isDeleted }
+        return try readContext().fetch(descriptor)
             .map { EpisodeRecord(episode: $0, healthContextStore: healthContextStore) }
     }
 
@@ -52,7 +52,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
         let descriptor = FetchDescriptor<Episode>(
             predicate: #Predicate<Episode> { $0.id == id }
         )
-        return try context.fetch(descriptor).first.map { EpisodeRecord(episode: $0, healthContextStore: healthContextStore) }
+        return try readContext().fetch(descriptor).first.map { EpisodeRecord(episode: $0, healthContextStore: healthContextStore) }
     }
 
     @discardableResult
@@ -66,7 +66,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
             target = existing
         } else {
             target = Episode(startedAt: draft.startedAt, intensity: draft.intensity)
-            context.insert(target)
+            mainContext.insert(target)
         }
 
         target.markUpdated()
@@ -83,11 +83,11 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
         target.triggers = Array(draft.selectedTriggers).sorted()
 
         for medication in target.medications {
-            context.delete(medication)
+            mainContext.delete(medication)
         }
 
         if let existingWeatherSnapshot = target.weatherSnapshot {
-            context.delete(existingWeatherSnapshot)
+            mainContext.delete(existingWeatherSnapshot)
             target.weatherSnapshot = nil
         }
 
@@ -109,7 +109,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
             target.weatherSnapshot = WeatherSnapshot(snapshot: weatherSnapshot, episode: target)
         }
 
-        try context.save()
+        try mainContext.save()
         healthContextStore.save(healthContext, for: target.id)
         return target.id
     }
@@ -120,7 +120,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
         }
 
         episode.markDeleted()
-        try context.save()
+        try mainContext.save()
     }
 
     func restore(id: UUID) throws {
@@ -129,25 +129,31 @@ final class SwiftDataEpisodeRepository: EpisodeRepository {
         }
 
         episode.restore()
-        try context.save()
+        try mainContext.save()
     }
 
     func fetchDeleted() throws -> [EpisodeRecord] {
-        let descriptor = FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)])
-        return try context.fetch(descriptor)
-            .filter(\.isDeleted)
+        let descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.deletedAt != nil },
+            sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]
+        )
+        return try readContext().fetch(descriptor)
             .map { EpisodeRecord(episode: $0, healthContextStore: healthContextStore) }
     }
 
-    private var context: ModelContext {
+    private var mainContext: ModelContext {
         modelContainer.mainContext
+    }
+
+    private func readContext() -> ModelContext {
+        ModelContext(modelContainer)
     }
 
     private func fetchEpisode(id: UUID) throws -> Episode? {
         let descriptor = FetchDescriptor<Episode>(
             predicate: #Predicate<Episode> { $0.id == id }
         )
-        return try context.fetch(descriptor).first
+        return try mainContext.fetch(descriptor).first
     }
 }
 
@@ -160,20 +166,21 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository {
     }
 
     func fetchDefinitions(searchText: String?) throws -> [MedicationDefinitionRecord] {
+        let basePredicate: Predicate<MedicationDefinition>
+        if let searchText, !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            basePredicate = #Predicate<MedicationDefinition> {
+                $0.deletedAt == nil && $0.name.localizedStandardContains(searchText)
+            }
+        } else {
+            basePredicate = #Predicate<MedicationDefinition> { $0.deletedAt == nil }
+        }
+
         let descriptor = FetchDescriptor<MedicationDefinition>(
+            predicate: basePredicate,
             sortBy: [SortDescriptor(\MedicationDefinition.sortOrder), SortDescriptor(\MedicationDefinition.name)]
         )
 
-        let definitions = try context.fetch(descriptor)
-            .filter { !$0.isDeleted }
-
-        guard let searchText, !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return definitions.map(MedicationDefinitionRecord.init)
-        }
-
-        return definitions
-            .filter { $0.name.localizedCaseInsensitiveContains(searchText) }
-            .map(MedicationDefinitionRecord.init)
+        return try readContext().fetch(descriptor).map(MedicationDefinitionRecord.init)
     }
 
     func saveCustomDefinition(_ draft: CustomMedicationDefinitionDraft) throws -> MedicationDefinitionRecord {
@@ -188,7 +195,7 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository {
             definition.category = draft.category
             definition.suggestedDosage = trimmedDosage
         } else {
-            let nextSortOrder = ((try? context.fetch(FetchDescriptor<MedicationDefinition>())) ?? []).map(\.sortOrder).max() ?? 0
+            let nextSortOrder = ((try? mainContext.fetch(FetchDescriptor<MedicationDefinition>())) ?? []).map(\.sortOrder).max() ?? 0
             definition = MedicationDefinition(
                 catalogKey: draft.id.hasPrefix("custom:") ? draft.id : "custom:\(UUID().uuidString)",
                 groupID: "custom-medications",
@@ -200,10 +207,10 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository {
                 sortOrder: nextSortOrder + 1,
                 isCustom: true
             )
-            context.insert(definition)
+            mainContext.insert(definition)
         }
 
-        try context.save()
+        try mainContext.save()
         return MedicationDefinitionRecord(definition: definition)
     }
 
@@ -213,27 +220,30 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository {
         }
 
         definition.markDeleted()
-        try context.save()
+        try mainContext.save()
     }
 
     func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord] {
         let descriptor = FetchDescriptor<MedicationDefinition>(
+            predicate: #Predicate<MedicationDefinition> { $0.deletedAt != nil },
             sortBy: [SortDescriptor(\MedicationDefinition.updatedAt, order: .reverse)]
         )
-        return try context.fetch(descriptor)
-            .filter(\.isDeleted)
-            .map(MedicationDefinitionRecord.init)
+        return try readContext().fetch(descriptor).map(MedicationDefinitionRecord.init)
     }
 
-    private var context: ModelContext {
+    private var mainContext: ModelContext {
         modelContainer.mainContext
+    }
+
+    private func readContext() -> ModelContext {
+        ModelContext(modelContainer)
     }
 
     private func fetchDefinition(catalogKey: String) throws -> MedicationDefinition? {
         let descriptor = FetchDescriptor<MedicationDefinition>(
             predicate: #Predicate<MedicationDefinition> { $0.catalogKey == catalogKey }
         )
-        return try context.fetch(descriptor).first
+        return try mainContext.fetch(descriptor).first
     }
 }
 
@@ -248,12 +258,14 @@ final class SwiftDataExportRepository: ExportRepository {
     }
 
     func buildSummary(startDate: Date, endDate: Date) throws -> ExportPeriodSummary {
-        let episodes = try context.fetch(FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]))
-            .filter { !$0.isDeleted }
-
         let endOfDay = Calendar.current.date(bySettingHour: 23, minute: 59, second: 59, of: endDate) ?? endDate
-        let filtered = episodes
-            .filter { $0.startedAt >= startDate && $0.startedAt <= endOfDay }
+        let descriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { episode in
+                episode.deletedAt == nil && episode.startedAt >= startDate && episode.startedAt <= endOfDay
+            },
+            sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]
+        )
+        let filtered = try readContext().fetch(descriptor)
             .map { EpisodeExportRecord(episode: $0, healthContext: healthContextStore.load(for: $0.id)) }
 
         return ExportPeriodSummary(startDate: startDate, endDate: endDate, records: filtered)
@@ -264,9 +276,14 @@ final class SwiftDataExportRepository: ExportRepository {
     }
 
     func createBackup() throws -> URL {
-        let episodes = try context.fetch(FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]))
-        let definitions = try context.fetch(FetchDescriptor<MedicationDefinition>(sortBy: [SortDescriptor(\MedicationDefinition.sortOrder)]))
-            .filter(\.isCustom)
+        let readContext = readContext()
+        let episodes = try readContext.fetch(FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]))
+        let definitions = try readContext.fetch(
+            FetchDescriptor<MedicationDefinition>(
+                predicate: #Predicate<MedicationDefinition> { $0.isCustom },
+                sortBy: [SortDescriptor(\MedicationDefinition.sortOrder)]
+            )
+        )
         let snapshot = DataTransferSnapshot(
             episodes: episodes,
             customMedicationDefinitions: definitions,
@@ -277,11 +294,15 @@ final class SwiftDataExportRepository: ExportRepository {
 
     func importBackup(from url: URL) throws {
         let snapshot = try DataTransferSnapshot.load(from: url)
-        try snapshot.merge(into: context)
+        try snapshot.merge(into: mainContext)
     }
 
-    private var context: ModelContext {
+    private var mainContext: ModelContext {
         modelContainer.mainContext
+    }
+
+    private func readContext() -> ModelContext {
+        ModelContext(modelContainer)
     }
 }
 
@@ -295,18 +316,17 @@ final class SwiftDataDoctorRepository: DoctorRepository {
 
     func fetchAll() throws -> [DoctorRecord] {
         let descriptor = FetchDescriptor<Doctor>(
+            predicate: #Predicate<Doctor> { $0.deletedAt == nil },
             sortBy: [SortDescriptor(\Doctor.name), SortDescriptor(\Doctor.specialty)]
         )
-        return try context.fetch(descriptor)
-            .filter { !$0.isDeleted }
-            .map(DoctorRecord.init)
+        return try readContext().fetch(descriptor).map(DoctorRecord.init)
     }
 
     func load(id: UUID) throws -> DoctorRecord? {
         let descriptor = FetchDescriptor<Doctor>(
             predicate: #Predicate<Doctor> { $0.id == id }
         )
-        return try context.fetch(descriptor).first.map(DoctorRecord.init)
+        return try readContext().fetch(descriptor).first.map(DoctorRecord.init)
     }
 
     @discardableResult
@@ -317,7 +337,7 @@ final class SwiftDataDoctorRepository: DoctorRepository {
             doctor = existing
         } else {
             doctor = Doctor(name: draft.name)
-            context.insert(doctor)
+            mainContext.insert(doctor)
         }
 
         doctor.markUpdated()
@@ -333,7 +353,7 @@ final class SwiftDataDoctorRepository: DoctorRepository {
         doctor.notes = draft.notes.trimmingCharacters(in: .whitespacesAndNewlines)
         doctor.source = draft.source
 
-        try context.save()
+        try mainContext.save()
         return doctor.id
     }
 
@@ -346,18 +366,22 @@ final class SwiftDataDoctorRepository: DoctorRepository {
         for appointment in doctor.appointments {
             appointment.markDeleted()
         }
-        try context.save()
+        try mainContext.save()
     }
 
-    private var context: ModelContext {
+    private var mainContext: ModelContext {
         modelContainer.mainContext
+    }
+
+    private func readContext() -> ModelContext {
+        ModelContext(modelContainer)
     }
 
     private func fetchDoctor(id: UUID) throws -> Doctor? {
         let descriptor = FetchDescriptor<Doctor>(
             predicate: #Predicate<Doctor> { $0.id == id }
         )
-        return try context.fetch(descriptor).first
+        return try mainContext.fetch(descriptor).first
     }
 }
 
@@ -370,34 +394,36 @@ final class SwiftDataDoctorDirectoryRepository: DoctorDirectoryRepository {
     }
 
     func fetchEntries(searchText: String?) throws -> [DoctorDirectoryRecord] {
-        let descriptor = FetchDescriptor<DoctorDirectoryEntry>(
-            sortBy: [SortDescriptor(\DoctorDirectoryEntry.name), SortDescriptor(\DoctorDirectoryEntry.city)]
-        )
-        let entries = try context.fetch(descriptor)
-        guard let searchText, !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return entries.map(DoctorDirectoryRecord.init)
+        let descriptor: FetchDescriptor<DoctorDirectoryEntry>
+        if let searchText, !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            descriptor = FetchDescriptor<DoctorDirectoryEntry>(
+                predicate: #Predicate<DoctorDirectoryEntry> {
+                    $0.name.localizedStandardContains(searchText)
+                        || $0.specialty.localizedStandardContains(searchText)
+                        || $0.city.localizedStandardContains(searchText)
+                        || $0.street.localizedStandardContains(searchText)
+                },
+                sortBy: [SortDescriptor(\DoctorDirectoryEntry.name), SortDescriptor(\DoctorDirectoryEntry.city)]
+            )
+        } else {
+            descriptor = FetchDescriptor<DoctorDirectoryEntry>(
+                sortBy: [SortDescriptor(\DoctorDirectoryEntry.name), SortDescriptor(\DoctorDirectoryEntry.city)]
+            )
         }
 
-        return entries
-            .filter {
-                $0.name.localizedCaseInsensitiveContains(searchText)
-                    || $0.specialty.localizedCaseInsensitiveContains(searchText)
-                    || $0.city.localizedCaseInsensitiveContains(searchText)
-                    || $0.street.localizedCaseInsensitiveContains(searchText)
-            }
-            .map(DoctorDirectoryRecord.init)
+        return try readContext().fetch(descriptor).map(DoctorDirectoryRecord.init)
     }
 
     func sourceAttribution() -> (label: String, url: String) {
-        let firstEntry = try? context.fetch(FetchDescriptor<DoctorDirectoryEntry>()).first
+        let firstEntry = try? readContext().fetch(FetchDescriptor<DoctorDirectoryEntry>()).first
         return (
             firstEntry?.sourceLabel ?? "ÖGK Vertragspartner Fachärztinnen und Fachärzte",
             firstEntry?.sourceURL ?? "https://www.gesundheitskasse.at/cdscontent/?contentid=10007.884365"
         )
     }
 
-    private var context: ModelContext {
-        modelContainer.mainContext
+    private func readContext() -> ModelContext {
+        ModelContext(modelContainer)
     }
 }
 
@@ -410,12 +436,12 @@ final class SwiftDataAppointmentRepository: AppointmentRepository {
     }
 
     func fetchUpcoming(limit: Int?) throws -> [AppointmentRecord] {
+        let now = Date.now
         let descriptor = FetchDescriptor<DoctorAppointment>(
+            predicate: #Predicate<DoctorAppointment> { $0.deletedAt == nil && $0.scheduledAt >= now },
             sortBy: [SortDescriptor(\DoctorAppointment.scheduledAt)]
         )
-        let records = try context.fetch(descriptor)
-            .filter { !$0.isDeleted && $0.scheduledAt >= .now }
-            .map(AppointmentRecord.init)
+        let records = try readContext().fetch(descriptor).map(AppointmentRecord.init)
 
         if let limit {
             return Array(records.prefix(limit))
@@ -425,11 +451,13 @@ final class SwiftDataAppointmentRepository: AppointmentRepository {
     }
 
     func fetchUpcoming(for doctorID: UUID) throws -> [AppointmentRecord] {
+        let now = Date.now
         let descriptor = FetchDescriptor<DoctorAppointment>(
+            predicate: #Predicate<DoctorAppointment> { $0.deletedAt == nil && $0.scheduledAt >= now },
             sortBy: [SortDescriptor(\DoctorAppointment.scheduledAt)]
         )
-        return try context.fetch(descriptor)
-            .filter { !$0.isDeleted && $0.doctor?.id == doctorID && $0.scheduledAt >= .now }
+        return try readContext().fetch(descriptor)
+            .filter { $0.doctor?.id == doctorID }
             .map(AppointmentRecord.init)
     }
 
@@ -437,7 +465,7 @@ final class SwiftDataAppointmentRepository: AppointmentRepository {
         let descriptor = FetchDescriptor<DoctorAppointment>(
             predicate: #Predicate<DoctorAppointment> { $0.id == id }
         )
-        return try context.fetch(descriptor).first.map(AppointmentRecord.init)
+        return try readContext().fetch(descriptor).first.map(AppointmentRecord.init)
     }
 
     @discardableResult
@@ -451,7 +479,7 @@ final class SwiftDataAppointmentRepository: AppointmentRepository {
             appointment = existing
         } else {
             appointment = DoctorAppointment(scheduledAt: draft.scheduledAt, doctor: doctor)
-            context.insert(appointment)
+            mainContext.insert(appointment)
         }
 
         appointment.markUpdated()
@@ -468,7 +496,7 @@ final class SwiftDataAppointmentRepository: AppointmentRepository {
             appointment.notificationRequestID = nil
         }
 
-        try context.save()
+        try mainContext.save()
         return appointment.id
     }
 
@@ -480,7 +508,7 @@ final class SwiftDataAppointmentRepository: AppointmentRepository {
         appointment.markUpdated()
         appointment.reminderStatus = status
         appointment.notificationRequestID = requestID
-        try context.save()
+        try mainContext.save()
     }
 
     func softDelete(id: UUID) throws {
@@ -490,25 +518,29 @@ final class SwiftDataAppointmentRepository: AppointmentRepository {
 
         appointment.markDeleted()
         appointment.notificationRequestID = nil
-        try context.save()
+        try mainContext.save()
     }
 
-    private var context: ModelContext {
+    private var mainContext: ModelContext {
         modelContainer.mainContext
+    }
+
+    private func readContext() -> ModelContext {
+        ModelContext(modelContainer)
     }
 
     private func fetchDoctor(id: UUID) throws -> Doctor? {
         let descriptor = FetchDescriptor<Doctor>(
             predicate: #Predicate<Doctor> { $0.id == id }
         )
-        return try context.fetch(descriptor).first
+        return try mainContext.fetch(descriptor).first
     }
 
     private func fetchAppointment(id: UUID) throws -> DoctorAppointment? {
         let descriptor = FetchDescriptor<DoctorAppointment>(
             predicate: #Predicate<DoctorAppointment> { $0.id == id }
         )
-        return try context.fetch(descriptor).first
+        return try mainContext.fetch(descriptor).first
     }
 }
 

--- a/MigraineTracker/Sources/Shared/WeatherIntegration.swift
+++ b/MigraineTracker/Sources/Shared/WeatherIntegration.swift
@@ -404,6 +404,10 @@ final class WeatherBackfillService {
         }
 
         for episode in episodes.prefix(limit) {
+            guard !Task.isCancelled else {
+                return
+            }
+
             do {
                 guard let snapshot = try await weatherService.fetchWeather(for: episode.startedAt, location: location) else {
                     continue


### PR DESCRIPTION
## Summary
- move several SwiftData read paths to fresh read contexts with tighter predicates
- reduce full reloads in History, Home and Doctors and cache appointment/doctor pairings for rendering
- debounce doctor directory search and delay/cancel root-level weather backfill work

## Testing
- xcodebuild -project MigraineTracker.xcodeproj -scheme MigraineTrackerTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16' test

Closes #112
Closes #116