### PR TITLE
[codex] Move startup maintenance off launch path

### DIFF
--- a/MigraineTracker/Sources/App/AppContainer.swift
+++ b/MigraineTracker/Sources/App/AppContainer.swift
@@ -11,6 +11,7 @@ final class AppContainer {
     let healthService: HealthService
     let healthContextStore: HealthContextStore
     let weatherBackfillService: WeatherBackfillService
+    let startupMaintenanceService: StartupMaintenanceService
 
     let episodeRepository: EpisodeRepository
     let medicationCatalogRepository: MedicationCatalogRepository
@@ -44,6 +45,10 @@ final class AppContainer {
             weatherService: weatherService,
             locationService: locationService
         )
+        self.startupMaintenanceService = StartupMaintenanceService(
+            modelContainer: modelContainer,
+            weatherBackfillService: weatherBackfillService
+        )
         self.episodeRepository = SwiftDataEpisodeRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
         self.medicationCatalogRepository = SwiftDataMedicationCatalogRepository(modelContainer: modelContainer)
         self.exportRepository = SwiftDataExportRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
@@ -53,6 +58,10 @@ final class AppContainer {
         self.syncService = SyncServiceAdapter(coordinator: syncCoordinator)
         self.appLogService = appLogStore
         self.notificationService = notificationService
+    }
+
+    func startDeferredMaintenanceIfNeeded() {
+        startupMaintenanceService.startIfNeeded()
     }
 
     func makeEpisodeEditorController(episodeID: UUID? = nil, initialStartedAt: Date? = nil) -> EpisodeEditorController {

--- a/MigraineTracker/Sources/App/AppShellView.swift
+++ b/MigraineTracker/Sources/App/AppShellView.swift
@@ -51,11 +51,7 @@ struct AppShellView: View {
         .toolbarBackground(AppTheme.ink.opacity(0.96), for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
-            try? await Task.sleep(for: .seconds(2))
-            guard !Task.isCancelled else {
-                return
-            }
-            await appContainer.weatherBackfillService.runIfNeeded()
+            appContainer.startDeferredMaintenanceIfNeeded()
         }
     }
 

--- a/MigraineTracker/Sources/App/MigraineTrackerApp.swift
+++ b/MigraineTracker/Sources/App/MigraineTrackerApp.swift
@@ -69,10 +69,6 @@ struct MigraineTrackerApp: App {
                 )
 
                 let container = try Self.makeContainer(schema: schema, configuration: configuration)
-                if !launchConfiguration.isRunningTests {
-                    MedicationCatalog.importSeedDataIfNeeded(into: container)
-                    DoctorDirectoryCatalog.importSeedDataIfNeeded(into: container)
-                }
                 self.modelContainer = container
                 let appLogStore = AppLogStore()
                 self.appLogStore = appLogStore

--- a/MigraineTracker/Sources/App/StartupMaintenanceService.swift
+++ b/MigraineTracker/Sources/App/StartupMaintenanceService.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftData
+
+@MainActor
+final class StartupMaintenanceService {
+    private static let seedImportDelay: Duration = .milliseconds(500)
+    private static let weatherBackfillDelay: Duration = .seconds(4)
+
+    private let modelContainer: ModelContainer
+    private let weatherBackfillService: WeatherBackfillService
+    private var maintenanceTask: Task<Void, Never>?
+
+    init(modelContainer: ModelContainer, weatherBackfillService: WeatherBackfillService) {
+        self.modelContainer = modelContainer
+        self.weatherBackfillService = weatherBackfillService
+    }
+
+    func startIfNeeded() {
+        guard maintenanceTask == nil else {
+            return
+        }
+
+        let modelContainer = modelContainer
+        let weatherBackfillService = weatherBackfillService
+
+        maintenanceTask = Task(priority: .background) {
+            try? await Task.sleep(for: Self.seedImportDelay)
+            guard !Task.isCancelled else {
+                return
+            }
+
+            await Task.detached(priority: .utility) {
+                MedicationCatalog.importSeedDataIfNeeded(into: modelContainer)
+                DoctorDirectoryCatalog.importSeedDataIfNeeded(into: modelContainer)
+            }.value
+
+            try? await Task.sleep(for: Self.weatherBackfillDelay - Self.seedImportDelay)
+            guard !Task.isCancelled else {
+                return
+            }
+
+            await weatherBackfillService.runIfNeeded()
+        }
+    }
+
+    deinit {
+        maintenanceTask?.cancel()
+    }
+}

--- a/MigraineTracker/Sources/Models/DoctorDirectoryCatalog.swift
+++ b/MigraineTracker/Sources/Models/DoctorDirectoryCatalog.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SwiftData
 
-struct DoctorDirectoryCatalogPayload: Decodable {
-    struct Metadata: Decodable {
+nonisolated struct DoctorDirectoryCatalogPayload: Decodable, Sendable {
+    nonisolated struct Metadata: Decodable, Sendable {
         let title: String
         let sourceURL: String
         let sourcePDF: String
@@ -13,7 +13,7 @@ struct DoctorDirectoryCatalogPayload: Decodable {
     let entries: [DoctorDirectorySeedEntry]
 }
 
-struct DoctorDirectorySeedEntry: Identifiable, Codable {
+nonisolated struct DoctorDirectorySeedEntry: Identifiable, Codable, Sendable {
     let id: String
     let name: String
     let specialty: String
@@ -26,11 +26,15 @@ struct DoctorDirectorySeedEntry: Identifiable, Codable {
 }
 
 enum DoctorDirectoryCatalog {
-    private static let resourceName = "oegk-doctor-directory.at"
-    private static let resourceExtension = "json"
+    nonisolated private static let resourceName = "oegk-doctor-directory.at"
+    nonisolated private static let resourceExtension = "json"
 
-    static func importSeedDataIfNeeded(into container: ModelContainer) {
+    nonisolated static func importSeedDataIfNeeded(into container: ModelContainer) {
         let context = ModelContext(container)
+        guard !hasImportedEntries(in: context) else {
+            return
+        }
+
         let payload = loadCatalogPayload()
         let existingEntries = (try? context.fetch(FetchDescriptor<DoctorDirectoryEntry>())) ?? []
         let existingByID = Dictionary(uniqueKeysWithValues: existingEntries.map { ($0.id, $0) })
@@ -69,7 +73,13 @@ enum DoctorDirectoryCatalog {
         }
     }
 
-    private static func loadCatalogPayload(bundle: Bundle = .main) -> DoctorDirectoryCatalogPayload {
+    private nonisolated static func hasImportedEntries(in context: ModelContext) -> Bool {
+        var descriptor = FetchDescriptor<DoctorDirectoryEntry>()
+        descriptor.fetchLimit = 1
+        return ((try? context.fetch(descriptor)) ?? []).isEmpty == false
+    }
+
+    private nonisolated static func loadCatalogPayload(bundle: Bundle = .main) -> DoctorDirectoryCatalogPayload {
         let bundles = [bundle, Bundle(for: DoctorDirectoryBundleLocator.self)]
         let url = bundles.lazy.compactMap { candidate in
             candidate.url(
@@ -102,7 +112,7 @@ enum DoctorDirectoryCatalog {
         }
     }
 
-    private static func sourceTreeFallbackURL() -> URL? {
+    private nonisolated static func sourceTreeFallbackURL() -> URL? {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()

--- a/MigraineTracker/Sources/Models/MedicationCatalog.swift
+++ b/MigraineTracker/Sources/Models/MedicationCatalog.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftData
 
-struct MedicationCatalogEntry: Identifiable, Hashable, Codable {
+nonisolated struct MedicationCatalogEntry: Identifiable, Hashable, Codable {
     let id: String
     let name: String
     let category: MedicationCategory
@@ -9,7 +9,7 @@ struct MedicationCatalogEntry: Identifiable, Hashable, Codable {
     let note: String
 }
 
-struct MedicationCatalogGroup: Identifiable, Codable {
+nonisolated struct MedicationCatalogGroup: Identifiable, Codable {
     let id: String
     let title: String
     let footer: String?
@@ -17,11 +17,15 @@ struct MedicationCatalogGroup: Identifiable, Codable {
 }
 
 enum MedicationCatalog {
-    private static let resourceName = "medication-catalog.at"
-    private static let resourceExtension = "json5"
+    nonisolated private static let resourceName = "medication-catalog.at"
+    nonisolated private static let resourceExtension = "json5"
 
-    static func importSeedDataIfNeeded(into container: ModelContainer) {
+    nonisolated static func importSeedDataIfNeeded(into container: ModelContainer) {
         let context = ModelContext(container)
+        guard !hasImportedSeedDefinitions(in: context) else {
+            return
+        }
+
         let groups = loadAustrianCommonGroups()
         let existingDefinitions = (try? context.fetch(FetchDescriptor<MedicationDefinition>())) ?? []
         let definitionsByKey = Dictionary(uniqueKeysWithValues: existingDefinitions.map { ($0.catalogKey, $0) })
@@ -67,7 +71,17 @@ enum MedicationCatalog {
         }
     }
 
-    private static func loadAustrianCommonGroups(bundle: Bundle = .main) -> [MedicationCatalogGroup] {
+    private nonisolated static func hasImportedSeedDefinitions(in context: ModelContext) -> Bool {
+        var descriptor = FetchDescriptor<MedicationDefinition>(
+            predicate: #Predicate { definition in
+                definition.isCustom == false
+            }
+        )
+        descriptor.fetchLimit = 1
+        return ((try? context.fetch(descriptor)) ?? []).isEmpty == false
+    }
+
+    private nonisolated static func loadAustrianCommonGroups(bundle: Bundle = .main) -> [MedicationCatalogGroup] {
         let bundles = [bundle, Bundle(for: ResourceBundleLocator.self)]
         let url = bundles.lazy.compactMap { candidate in
             candidate.url(

--- a/MigraineTracker/Sources/Shared/WeatherIntegration.swift
+++ b/MigraineTracker/Sources/Shared/WeatherIntegration.swift
@@ -369,6 +369,16 @@ enum WeatherCodeMapper {
 }
 @MainActor
 final class WeatherBackfillService {
+    private struct BackfillCandidate {
+        let modelID: PersistentIdentifier
+        let startedAt: Date
+    }
+
+    private struct CandidatePage {
+        let scannedCount: Int
+        let candidates: [BackfillCandidate]
+    }
+
     private let modelContainer: ModelContainer
     private let weatherService: WeatherService
     private let locationService: LocationService
@@ -380,7 +390,7 @@ final class WeatherBackfillService {
         self.locationService = locationService
     }
 
-    func runIfNeeded(limit: Int = 10) async {
+    func runIfNeeded(limit: Int = 10, pageSize: Int = 5, maxScannedEpisodes: Int = 50) async {
         guard !hasAttemptedBackfill else {
             return
         }
@@ -388,11 +398,11 @@ final class WeatherBackfillService {
         hasAttemptedBackfill = true
 
         let context = modelContainer.mainContext
-        let descriptor = FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)])
-        guard
-            let episodes = try? context.fetch(descriptor).filter({ $0.weatherSnapshot?.source.localizedCaseInsensitiveContains("legacy") == true }),
-            !episodes.isEmpty
-        else {
+        let pageSize = max(1, pageSize)
+        let limit = max(0, limit)
+        let maxScannedEpisodes = max(pageSize, maxScannedEpisodes)
+
+        guard limit > 0, hasBackfillCandidates(in: context, pageSize: pageSize, maxScannedEpisodes: maxScannedEpisodes) else {
             return
         }
 
@@ -403,35 +413,117 @@ final class WeatherBackfillService {
             return
         }
 
-        for episode in episodes.prefix(limit) {
+        var scannedEpisodes = 0
+        var fetchOffset = 0
+        var attemptedBackfills = 0
+
+        while attemptedBackfills < limit, scannedEpisodes < maxScannedEpisodes {
             guard !Task.isCancelled else {
                 return
             }
 
-            do {
-                guard let snapshot = try await weatherService.fetchWeather(for: episode.startedAt, location: location) else {
+            let page = candidatePage(
+                in: context,
+                pageSize: min(pageSize, maxScannedEpisodes - scannedEpisodes),
+                fetchOffset: fetchOffset
+            )
+
+            guard page.scannedCount > 0 else {
+                break
+            }
+
+            scannedEpisodes += page.scannedCount
+            fetchOffset += page.scannedCount
+
+            for candidate in page.candidates {
+                guard attemptedBackfills < limit, !Task.isCancelled else {
+                    return
+                }
+
+                attemptedBackfills += 1
+
+                do {
+                    guard let snapshot = try await weatherService.fetchWeather(for: candidate.startedAt, location: location) else {
+                        continue
+                    }
+
+                    guard
+                        let episode = context.model(for: candidate.modelID) as? Episode,
+                        episode.weatherSnapshot?.source.localizedCaseInsensitiveContains("legacy") == true
+                    else {
+                        continue
+                    }
+
+                    if let existing = episode.weatherSnapshot {
+                        existing.recordedAt = snapshot.recordedAt
+                        existing.temperature = snapshot.temperature
+                        existing.condition = snapshot.condition
+                        existing.humidity = snapshot.humidity
+                        existing.pressure = snapshot.pressure
+                        existing.precipitation = snapshot.precipitation
+                        existing.weatherCode = snapshot.weatherCode
+                        existing.source = snapshot.source
+                    } else {
+                        episode.weatherSnapshot = WeatherSnapshot(snapshot: snapshot, episode: episode)
+                    }
+
+                    episode.markUpdated()
+                } catch {
                     continue
                 }
-
-                if let existing = episode.weatherSnapshot {
-                    existing.recordedAt = snapshot.recordedAt
-                    existing.temperature = snapshot.temperature
-                    existing.condition = snapshot.condition
-                    existing.humidity = snapshot.humidity
-                    existing.pressure = snapshot.pressure
-                    existing.precipitation = snapshot.precipitation
-                    existing.weatherCode = snapshot.weatherCode
-                    existing.source = snapshot.source
-                } else {
-                    episode.weatherSnapshot = WeatherSnapshot(snapshot: snapshot, episode: episode)
-                }
-
-                episode.markUpdated()
-            } catch {
-                continue
             }
+
+            if context.hasChanges {
+                try? context.save()
+            }
+
+            await Task.yield()
+        }
+    }
+
+    private func hasBackfillCandidates(in context: ModelContext, pageSize: Int, maxScannedEpisodes: Int) -> Bool {
+        var scannedEpisodes = 0
+        var fetchOffset = 0
+
+        while scannedEpisodes < maxScannedEpisodes {
+            let page = candidatePage(
+                in: context,
+                pageSize: min(pageSize, maxScannedEpisodes - scannedEpisodes),
+                fetchOffset: fetchOffset
+            )
+
+            guard page.scannedCount > 0 else {
+                return false
+            }
+
+            if !page.candidates.isEmpty {
+                return true
+            }
+
+            scannedEpisodes += page.scannedCount
+            fetchOffset += page.scannedCount
         }
 
-        try? context.save()
+        return false
+    }
+
+    private func candidatePage(in context: ModelContext, pageSize: Int, fetchOffset: Int) -> CandidatePage {
+        var descriptor = FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)])
+        descriptor.fetchLimit = pageSize
+        descriptor.fetchOffset = fetchOffset
+
+        guard let episodes = try? context.fetch(descriptor) else {
+            return CandidatePage(scannedCount: 0, candidates: [])
+        }
+
+        let candidates = episodes.compactMap { episode -> BackfillCandidate? in
+            guard episode.weatherSnapshot?.source.localizedCaseInsensitiveContains("legacy") == true else {
+                return nil
+            }
+
+            return BackfillCandidate(modelID: episode.persistentModelID, startedAt: episode.startedAt)
+        }
+
+        return CandidatePage(scannedCount: episodes.count, candidates: candidates)
     }
 }


### PR DESCRIPTION
## Summary
- moves seed imports out of `MigraineTrackerApp.init` into deferred start-up maintenance
- skips catalog resource loading when seed data already exists
- delays and bounds the Weather backfill with small paginated batches and cancellation checks

## Why
Issue #113 calls out synchronous start-up and root-view side work that can compete with the first render and initial taps. This keeps UI setup first and moves data maintenance after launch.

## Validation
- `xcodebuild test -project MigraineTracker.xcodeproj -scheme MigraineTrackerTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #113
