### PR TITLE
Ignore Symi local secrets config

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -8,6 +8,7 @@ on:
       - "Symi/**"
       - "SymiTests/**"
       - "Symi.xcodeproj/**"
+      - ".gitignore"
       - ".github/workflows/ios-ci.yml"
   push:
     branches:
@@ -16,6 +17,7 @@ on:
       - "Symi/**"
       - "SymiTests/**"
       - "Symi.xcodeproj/**"
+      - ".gitignore"
       - ".github/workflows/ios-ci.yml"
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ tmbootpicker.efi
 
 .sentryclirc
 
-MigraineTracker/Configs/LocalSecrets.xcconfig
+Symi/Configs/LocalSecrets.xcconfig
 # fastlane/report.xml
 # fastlane/Preview.html
 # fastlane/screenshots/test_output/


### PR DESCRIPTION
## Summary
- Updates the ignored local secrets config path from `MigraineTracker/Configs/LocalSecrets.xcconfig` to `Symi/Configs/LocalSecrets.xcconfig`.
- Includes `.gitignore` in the iOS CI path filters so required `build-and-test` runs for this maintenance change.

## Validation
- `git check-ignore -v Symi/Configs/LocalSecrets.xcconfig`