### PR TITLE
Modernisierung: Approachable Concurrency für Export/Settings (#140)

### DIFF
--- a/Symi/Sources/Core/Doctors/DoctorCore.swift
+++ b/Symi/Sources/Core/Doctors/DoctorCore.swift
@@ -459,8 +459,10 @@ final class DoctorEditorController {
 
     private let saveDoctorUseCase: SaveDoctorUseCase
     private let directoryRepository: DoctorDirectoryRepository
-    private var searchDebounceTask: Task<Void, Never>?
-    private var searchFetchTask: Task<Void, Never>?
+    @ObservationIgnored private var searchDebounceTask: Task<Void, Never>?
+    @ObservationIgnored private var searchFetchTask: Task<Void, Never>?
+    @ObservationIgnored private var sourceAttributionTask: Task<Void, Never>?
+    @ObservationIgnored private var saveTask: Task<Void, Never>?
 
     init(
         doctor: DoctorRecord?,
@@ -475,7 +477,9 @@ final class DoctorEditorController {
             "https://www.gesundheitskasse.at/cdscontent/?contentid=10007.884365"
         )
         refreshSearch()
-        Task { await refreshSourceAttribution() }
+        sourceAttributionTask = Task { [weak self] in
+            await self?.refreshSourceAttribution()
+        }
     }
 
     func refreshSearch() {
@@ -563,12 +567,19 @@ final class DoctorEditorController {
     }
 
     func save(onSaved: @escaping (UUID) -> Void) {
-        Task {
+        saveTask?.cancel()
+        let draft = draft
+        saveTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 let id = try await saveDoctorUseCase.execute(draft)
+                guard !Task.isCancelled else { return }
                 validationMessage = nil
                 onSaved(id)
+            } catch is CancellationError {
+                return
             } catch {
+                guard !Task.isCancelled else { return }
                 validationMessage = error.localizedDescription
             }
         }
@@ -584,6 +595,7 @@ final class AppointmentEditorController {
 
     private let saveAppointmentUseCase: SaveAppointmentUseCase
     private let appointmentRepository: AppointmentRepository
+    @ObservationIgnored private var saveTask: Task<Void, Never>?
 
     init(
         appointment: AppointmentRecord?,
@@ -613,18 +625,21 @@ final class AppointmentEditorController {
     }
 
     func save(onSaved: @escaping (UUID) -> Void) {
-        Task {
+        saveTask?.cancel()
+        let draft = draft
+        saveTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 let id = try await saveAppointmentUseCase.execute(draft)
-                await MainActor.run {
-                    validationMessage = nil
-                    saveMessageVisible = true
-                    onSaved(id)
-                }
+                guard !Task.isCancelled else { return }
+                validationMessage = nil
+                saveMessageVisible = true
+                onSaved(id)
+            } catch is CancellationError {
+                return
             } catch {
-                await MainActor.run {
-                    validationMessage = error.localizedDescription
-                }
+                guard !Task.isCancelled else { return }
+                validationMessage = error.localizedDescription
             }
         }
     }

--- a/Symi/Sources/Core/Export/ExportCore.swift
+++ b/Symi/Sources/Core/Export/ExportCore.swift
@@ -4,8 +4,8 @@ import Observation
 protocol ExportRepository: Sendable {
     nonisolated func buildSummary(startDate: Date, endDate: Date) throws -> ExportPeriodSummary
     nonisolated func createPDF(summary: ExportPeriodSummary, mode: PDFReportMode) throws -> URL
-    func createBackup() throws -> URL
-    func importBackup(from url: URL) throws
+    nonisolated func createBackup() throws -> URL
+    nonisolated func importBackup(from url: URL) throws
 }
 
 enum PDFReportMode: String, CaseIterable, Identifiable, Sendable {
@@ -48,20 +48,26 @@ struct CreatePDFExportUseCase {
 struct CreateBackupUseCase {
     let repository: ExportRepository
 
-    func execute() throws -> URL {
-        try PerformanceInstrumentation.measure("BackupExportCreate") {
-            try repository.createBackup()
-        }
+    func execute() async throws -> URL {
+        let repository = repository
+        return try await Task.detached(priority: .userInitiated) {
+            try PerformanceInstrumentation.measure("BackupExportCreate") {
+                try repository.createBackup()
+            }
+        }.value
     }
 }
 
 struct ImportBackupUseCase {
     let repository: ExportRepository
 
-    func execute(url: URL) throws {
-        try PerformanceInstrumentation.measure("BackupImport") {
-            try repository.importBackup(from: url)
-        }
+    func execute(url: URL) async throws {
+        let repository = repository
+        try await Task.detached(priority: .userInitiated) {
+            try PerformanceInstrumentation.measure("BackupImport") {
+                try repository.importBackup(from: url)
+            }
+        }.value
     }
 }
 
@@ -83,6 +89,8 @@ final class DataExportController {
     @ObservationIgnored private var hasLoadedInitialSummary = false
     @ObservationIgnored private var summaryReloadTask: Task<Void, Never>?
     @ObservationIgnored private var pdfPreparationTask: Task<Void, Never>?
+    @ObservationIgnored private var dataExportTask: Task<Void, Never>?
+    @ObservationIgnored private var dataImportTask: Task<Void, Never>?
     private let loadExportPreviewUseCase: LoadExportPreviewUseCase
     private let createPDFExportUseCase: CreatePDFExportUseCase
     private let createBackupUseCase: CreateBackupUseCase
@@ -237,35 +245,57 @@ final class DataExportController {
     }
 
     func createBackup() {
+        dataExportTask?.cancel()
         dataTransferMessage = nil
         dataExportURL = nil
 
-        Task {
-            PerformanceInstrumentation.measure("DataExportControllerCreateBackup") {
+        dataExportTask = Task { [weak self] in
+            await PerformanceInstrumentation.measure("DataExportControllerCreateBackup") {
+                guard let self else { return }
                 do {
-                    dataExportURL = try createBackupUseCase.execute()
-                    dataTransferMessage = "JSON5-Datei wurde lokal erstellt."
+                    let backupURL = try await self.createBackupUseCase.execute()
+                    guard !Task.isCancelled else { return }
+                    self.dataExportURL = backupURL
+                    self.dataTransferMessage = "JSON5-Datei wurde lokal erstellt."
+                } catch is CancellationError {
+                    return
                 } catch {
-                    dataTransferMessage = "Fehler beim Erstellen der JSON5-Datei."
+                    guard !Task.isCancelled else { return }
+                    self.dataTransferMessage = "Fehler beim Erstellen der JSON5-Datei."
                 }
             }
         }
     }
 
     func importBackup(from result: Result<URL, Error>) {
-        dataTransferMessage = nil
+        let url: URL
+        do {
+            url = try result.get()
+        } catch CocoaError.userCancelled {
+            return
+        } catch {
+            dataTransferMessage = "Fehler beim Import der JSON5-Datei."
+            return
+        }
 
-        Task {
+        dataImportTask?.cancel()
+        dataTransferMessage = nil
+        isImportingData = true
+
+        dataImportTask = Task { [weak self] in
             await PerformanceInstrumentation.measure("DataExportControllerImportBackup") {
+                guard let self else { return }
+                defer { self.isImportingData = false }
                 do {
-                    let url = try result.get()
-                    try importBackupUseCase.execute(url: url)
-                    dataTransferMessage = "JSON5-Daten wurden importiert."
-                    await reloadSummary()
-                } catch CocoaError.userCancelled {
+                    try await self.importBackupUseCase.execute(url: url)
+                    guard !Task.isCancelled else { return }
+                    self.dataTransferMessage = "JSON5-Daten wurden importiert."
+                    await self.reloadSummary()
+                } catch is CancellationError {
                     return
                 } catch {
-                    dataTransferMessage = "Fehler beim Import der JSON5-Datei."
+                    guard !Task.isCancelled else { return }
+                    self.dataTransferMessage = "Fehler beim Import der JSON5-Datei."
                 }
             }
         }

--- a/Symi/Sources/Core/Health/HealthCore.swift
+++ b/Symi/Sources/Core/Health/HealthCore.swift
@@ -169,7 +169,7 @@ protocol HealthService: AnyObject {
 }
 
 extension HealthContextSnapshotData {
-    init(record: HealthContextRecord) {
+    nonisolated init(record: HealthContextRecord) {
         self.init(
             recordedAt: record.recordedAt,
             source: record.source,

--- a/Symi/Sources/Core/Settings/SettingsCore.swift
+++ b/Symi/Sources/Core/Settings/SettingsCore.swift
@@ -99,6 +99,10 @@ final class SettingsController {
     private let syncService: SyncService
     private let appLogService: AppLogService
     private let healthService: HealthService
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
+    @ObservationIgnored private var restoreTask: Task<Void, Never>?
+    @ObservationIgnored private var logRefreshTask: Task<Void, Never>?
+    @ObservationIgnored private var logClearTask: Task<Void, Never>?
 
     init(
         episodeRepository: EpisodeRepository,
@@ -148,22 +152,29 @@ final class SettingsController {
     }
 
     func load() {
+        loadTask?.cancel()
         syncService.refreshStatus()
 
         let episodeRepository = episodeRepository
         let medicationRepository = medicationRepository
-        Task {
+        loadTask = Task { [weak self] in
+            guard let self else { return }
             do {
-                summary = try await loadSettingsUseCase.execute()
+                let loadedSummary = try await loadSettingsUseCase.execute()
                 let deleted = try await Task.detached(priority: .userInitiated) {
                     (
                         try episodeRepository.fetchDeleted(),
                         try medicationRepository.fetchDeletedDefinitions()
                     )
                 }.value
+                guard !Task.isCancelled else { return }
+                summary = loadedSummary
                 deletedEpisodes = deleted.0
                 deletedDefinitions = deleted.1
+            } catch is CancellationError {
+                return
             } catch {
+                guard !Task.isCancelled else { return }
                 summary = SettingsSummaryData(
                     activeEpisodeCount: 0,
                     trashCount: deletedEpisodes.count + deletedDefinitions.count,
@@ -199,37 +210,58 @@ final class SettingsController {
     }
 
     func restoreEpisode(id: UUID) {
-        Task {
-            try? await restoreDeletedItemUseCase.restoreEpisode(id: id)
+        restoreTask?.cancel()
+        restoreTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await restoreDeletedItemUseCase.restoreEpisode(id: id)
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
             load()
         }
     }
 
     func restoreMedicationDefinition(_ definition: MedicationDefinitionRecord) {
-        Task {
-            try? await restoreDeletedItemUseCase.restoreMedicationDefinition(definition)
+        restoreTask?.cancel()
+        restoreTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await restoreDeletedItemUseCase.restoreMedicationDefinition(definition)
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
             load()
         }
     }
 
     func refreshLog(limit: Int = 200) {
-        Task {
+        logRefreshTask?.cancel()
+        logRefreshTask = Task { [weak self] in
+            guard let self else { return }
             let entries = await appLogService.recentEntries(filter: logFilter, limit: limit)
             let shareURL = await appLogService.exportLogFileURL(filter: logFilter)
-            await MainActor.run {
-                self.logEntries = entries
-                self.logShareURL = shareURL
-            }
+            guard !Task.isCancelled else { return }
+            logEntries = entries
+            logShareURL = shareURL
         }
     }
 
     func clearLog() {
-        Task {
+        logClearTask?.cancel()
+        logRefreshTask?.cancel()
+        logClearTask = Task { [weak self] in
+            guard let self else { return }
             await appLogService.clear()
-            await MainActor.run {
-                self.logEntries = []
-                self.logShareURL = nil
-            }
+            guard !Task.isCancelled else { return }
+            logEntries = []
+            logShareURL = nil
         }
     }
 

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -17,13 +17,13 @@ enum DataTransferError: LocalizedError {
     }
 }
 
-struct DataTransferSnapshot:  Codable {
+struct DataTransferSnapshot: @preconcurrency Codable, Sendable {
     let formatVersion: Int
     let exportedAt: Date
     let episodes: [EpisodePayload]
     let customMedicationDefinitions: [MedicationDefinitionPayload]
 
-    init(
+    nonisolated init(
         formatVersion: Int = 1,
         exportedAt: Date = .now,
         episodes: [EpisodePayload],
@@ -35,19 +35,19 @@ struct DataTransferSnapshot:  Codable {
         self.customMedicationDefinitions = customMedicationDefinitions
     }
 
-    init(episodes: [Episode], customMedicationDefinitions: [MedicationDefinition], healthContextStore: HealthContextStore? = nil) {
+    nonisolated init(episodes: [Episode], customMedicationDefinitions: [MedicationDefinition], healthContextStore: HealthContextStore? = nil) {
         self.init(
             episodes: episodes.map { EpisodePayload(episode: $0, healthContext: healthContextStore?.load(for: $0.id)) },
             customMedicationDefinitions: customMedicationDefinitions.map(MedicationDefinitionPayload.init)
         )
     }
 
-    func writeToTemporaryFile() throws -> URL {
+    nonisolated func writeToTemporaryFile() throws -> URL {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
 
-        let fileName = "schmerztagebuch-export-\(Self.fileDateFormatter.string(from: exportedAt)).json5"
+        let fileName = "schmerztagebuch-export-\(Self.fileDateString(from: exportedAt)).json5"
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
         let data = try encoder.encode(self)
 
@@ -55,7 +55,7 @@ struct DataTransferSnapshot:  Codable {
         return url
     }
 
-    static func load(from url: URL) throws -> DataTransferSnapshot {
+    nonisolated static func load(from url: URL) throws -> DataTransferSnapshot {
         let shouldStopAccess = url.startAccessingSecurityScopedResource()
         defer {
             if shouldStopAccess {
@@ -76,7 +76,7 @@ struct DataTransferSnapshot:  Codable {
         return snapshot
     }
 
-    func merge(into context: ModelContext) throws {
+    nonisolated func merge(into context: ModelContext) throws {
         let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
         let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
 
@@ -106,17 +106,17 @@ struct DataTransferSnapshot:  Codable {
         try context.save()
     }
 
-    private static let fileDateFormatter: DateFormatter = {
+    private nonisolated static func fileDateString(from date: Date) -> String {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd-HHmmss"
-        return formatter
-    }()
+        return formatter.string(from: date)
+    }
 }
 
-struct EpisodePayload: Codable {
+struct EpisodePayload: @preconcurrency Codable, Sendable {
     let id: UUID
     let startedAt: Date
     let endedAt: Date?
@@ -135,7 +135,7 @@ struct EpisodePayload: Codable {
     let weatherSnapshot: WeatherSnapshotPayload?
     let healthContext: HealthContextSnapshotData?
 
-    init(episode: Episode, healthContext: HealthContextRecord? = nil) {
+    nonisolated init(episode: Episode, healthContext: HealthContextRecord? = nil) {
         self.id = episode.id
         self.startedAt = episode.startedAt
         self.endedAt = episode.endedAt
@@ -155,7 +155,7 @@ struct EpisodePayload: Codable {
         self.healthContext = healthContext.map(HealthContextSnapshotData.init)
     }
 
-    func makeModel() -> Episode {
+    nonisolated func makeModel() -> Episode {
         let episode = Episode(
             id: id,
             startedAt: startedAt,
@@ -178,7 +178,7 @@ struct EpisodePayload: Codable {
         return episode
     }
 
-    func apply(to episode: Episode, in context: ModelContext) {
+    nonisolated func apply(to episode: Episode, in context: ModelContext) {
         episode.startedAt = startedAt
         episode.endedAt = endedAt
         episode.updatedAt = updatedAt
@@ -222,7 +222,7 @@ struct EpisodePayload: Codable {
     }
 }
 
-struct MedicationEntryPayload: Codable {
+struct MedicationEntryPayload: @preconcurrency Codable, Sendable {
     let id: UUID
     let name: String
     let category: MedicationCategory
@@ -233,7 +233,7 @@ struct MedicationEntryPayload: Codable {
     let reliefStartedAt: Date?
     let isRepeatDose: Bool
 
-    init(entry: MedicationEntry) {
+    nonisolated init(entry: MedicationEntry) {
         self.id = entry.id
         self.name = entry.name
         self.category = entry.category
@@ -245,7 +245,7 @@ struct MedicationEntryPayload: Codable {
         self.isRepeatDose = entry.isRepeatDose
     }
 
-    func makeModel(for episode: Episode) -> MedicationEntry {
+    nonisolated func makeModel(for episode: Episode) -> MedicationEntry {
         MedicationEntry(
             id: id,
             name: name,
@@ -260,7 +260,7 @@ struct MedicationEntryPayload: Codable {
         )
     }
 
-    func apply(to entry: MedicationEntry, for episode: Episode) {
+    nonisolated func apply(to entry: MedicationEntry, for episode: Episode) {
         entry.name = name
         entry.category = category
         entry.dosage = dosage
@@ -273,7 +273,7 @@ struct MedicationEntryPayload: Codable {
     }
 }
 
-struct WeatherSnapshotPayload: Codable {
+struct WeatherSnapshotPayload: @preconcurrency Codable, Sendable {
     let id: UUID
     let recordedAt: Date
     let temperature: Double?
@@ -284,7 +284,7 @@ struct WeatherSnapshotPayload: Codable {
     let weatherCode: Int?
     let source: String
 
-    init(snapshot: WeatherSnapshot) {
+    nonisolated init(snapshot: WeatherSnapshot) {
         self.id = snapshot.id
         self.recordedAt = snapshot.recordedAt
         self.temperature = snapshot.temperature
@@ -296,7 +296,7 @@ struct WeatherSnapshotPayload: Codable {
         self.source = snapshot.source
     }
 
-    func makeModel(for episode: Episode) -> WeatherSnapshot {
+    nonisolated func makeModel(for episode: Episode) -> WeatherSnapshot {
         WeatherSnapshot(
             id: id,
             recordedAt: recordedAt,
@@ -311,7 +311,7 @@ struct WeatherSnapshotPayload: Codable {
         )
     }
 
-    func apply(to snapshot: WeatherSnapshot, for episode: Episode) {
+    nonisolated func apply(to snapshot: WeatherSnapshot, for episode: Episode) {
         snapshot.recordedAt = recordedAt
         snapshot.temperature = temperature
         snapshot.condition = condition
@@ -324,7 +324,7 @@ struct WeatherSnapshotPayload: Codable {
     }
 }
 
-struct MedicationDefinitionPayload: Codable {
+struct MedicationDefinitionPayload: @preconcurrency Codable, Sendable {
     let catalogKey: String
     let groupID: String
     let groupTitle: String
@@ -338,7 +338,7 @@ struct MedicationDefinitionPayload: Codable {
     let updatedAt: Date
     let deletedAt: Date?
 
-    init(definition: MedicationDefinition) {
+    nonisolated init(definition: MedicationDefinition) {
         self.catalogKey = definition.catalogKey
         self.groupID = definition.groupID
         self.groupTitle = definition.groupTitle
@@ -353,7 +353,7 @@ struct MedicationDefinitionPayload: Codable {
         self.deletedAt = definition.deletedAt
     }
 
-    func makeModel() -> MedicationDefinition {
+    nonisolated func makeModel() -> MedicationDefinition {
         MedicationDefinition(
             catalogKey: catalogKey,
             groupID: groupID,
@@ -370,7 +370,7 @@ struct MedicationDefinitionPayload: Codable {
         )
     }
 
-    func apply(to definition: MedicationDefinition) {
+    nonisolated func apply(to definition: MedicationDefinition) {
         definition.groupID = groupID
         definition.groupTitle = groupTitle
         definition.groupFooter = groupFooter

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -281,7 +281,7 @@ final class SwiftDataExportRepository: ExportRepository, @unchecked Sendable {
         try PDFExportWriter.write(summary: summary, mode: mode)
     }
 
-    func createBackup() throws -> URL {
+    nonisolated func createBackup() throws -> URL {
         let readContext = readContext()
         let episodes = try readContext.fetch(FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]))
         let definitions = try readContext.fetch(
@@ -298,7 +298,7 @@ final class SwiftDataExportRepository: ExportRepository, @unchecked Sendable {
         return try snapshot.writeToTemporaryFile()
     }
 
-    func importBackup(from url: URL) throws {
+    nonisolated func importBackup(from url: URL) throws {
         let snapshot = try DataTransferSnapshot.load(from: url)
         let context = writeContext()
         try snapshot.merge(into: context)


### PR DESCRIPTION
## Zusammenfassung
- ersetzt unstrukturierte Fire-and-Forget-Tasks in Settings-, Export- und Editor-Controllern durch cancelbare Task-Referenzen
- verschiebt Backup/Import in async Use-Cases mit strukturiertem Background-Work und sauberer Cancellation
- bereinigt MainActor-Isolation in Data-Transfer-/Repository-Pfaden mit expliziten nonisolated-Grenzen

## Tests
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination "platform=iOS Simulator,name=iPhone 17"

Closes #140