### PR TITLE
[codex] Datenverlust bei SwiftData-Store-Recovery verhindern

### DIFF
--- a/Symi/Sources/App/StoreRecovery.swift
+++ b/Symi/Sources/App/StoreRecovery.swift
@@ -1,0 +1,318 @@
+import Foundation
+import SwiftData
+import SwiftUI
+
+nonisolated enum PersistentStoreRecoveryReason: String, Equatable, Sendable {
+    case unknownModelVersion
+    case migrationFailure
+    case loadFailure
+
+    var headline: String {
+        switch self {
+        case .unknownModelVersion:
+            "Der lokale Datenspeicher stammt aus einer neueren oder unbekannten App-Version."
+        case .migrationFailure:
+            "Der lokale Datenspeicher konnte nicht migriert werden."
+        case .loadFailure:
+            "Der lokale Datenspeicher konnte nicht geöffnet werden."
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .unknownModelVersion:
+            "Symi hat den vorhandenen Store nicht ersetzt. Du kannst die Dateien sichern und später mit einer passenden App-Version erneut öffnen."
+        case .migrationFailure:
+            "Symi hat die Migration gestoppt und keine Store-Dateien gelöscht. Sichere die Dateien, bevor du weitere Schritte setzt."
+        case .loadFailure:
+            "Symi startet in einem geschützten Wiederherstellungsmodus. Der vorhandene Store bleibt unverändert, solange du keine Löschung bestätigst."
+        }
+    }
+}
+
+nonisolated struct PersistentStoreRecoveryContext: Equatable, Sendable {
+    let storeURL: URL
+    let reason: PersistentStoreRecoveryReason
+    let errorSummary: String
+}
+
+nonisolated enum PersistentStoreLoadError: Error, Equatable {
+    case recoveryRequired(PersistentStoreRecoveryContext)
+}
+
+nonisolated enum PersistentStoreRecoveryFileError: LocalizedError, Equatable {
+    case noStoreFilesFound
+
+    var errorDescription: String? {
+        switch self {
+        case .noStoreFilesFound:
+            "Es wurden keine Store-Dateien gefunden, die gesichert werden können."
+        }
+    }
+}
+
+nonisolated enum PersistentStoreRecoveryService {
+    static let unknownModelVersionErrorCode = 134504
+    static let migrationErrorCodeRange = 134100...134199
+
+    static func recoveryContext(for error: Error, storeURL: URL) -> PersistentStoreRecoveryContext {
+        PersistentStoreRecoveryContext(
+            storeURL: storeURL,
+            reason: recoveryReason(for: error),
+            errorSummary: sanitizedSummary(for: error)
+        )
+    }
+
+    static func recoveryReason(for error: Error) -> PersistentStoreRecoveryReason {
+        let nsError = error as NSError
+        let description = [
+            String(describing: error),
+            nsError.localizedDescription
+        ]
+        .joined(separator: " ")
+        .lowercased()
+
+        if nsError.domain == NSCocoaErrorDomain, nsError.code == unknownModelVersionErrorCode {
+            return .unknownModelVersion
+        }
+
+        if description.contains("unknown model version")
+            || description.contains("loadissuemodelcontainer")
+            || description.contains(String(unknownModelVersionErrorCode)) {
+            return .unknownModelVersion
+        }
+
+        if nsError.domain == NSCocoaErrorDomain, migrationErrorCodeRange.contains(nsError.code) {
+            return .migrationFailure
+        }
+
+        if description.contains("migration") || description.contains("migrate") || description.contains("incompatible version hash") {
+            return .migrationFailure
+        }
+
+        return .loadFailure
+    }
+
+    static func existingStoreFileURLs(for storeURL: URL, fileManager: FileManager = .default) -> [URL] {
+        storeFileCandidates(for: storeURL).filter { fileManager.fileExists(atPath: $0.path) }
+    }
+
+    static func copyStoreFilesForSharing(
+        from storeURL: URL,
+        fileManager: FileManager = .default,
+        now: Date = .now
+    ) throws -> [URL] {
+        let sourceURLs = existingStoreFileURLs(for: storeURL, fileManager: fileManager)
+        guard !sourceURLs.isEmpty else {
+            throw PersistentStoreRecoveryFileError.noStoreFilesFound
+        }
+
+        let targetDirectory = fileManager.temporaryDirectory
+            .appending(path: "Symi-Store-Sicherung-\(fileDateString(from: now))-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try fileManager.createDirectory(at: targetDirectory, withIntermediateDirectories: true)
+
+        return try sourceURLs.map { sourceURL in
+            let targetURL = targetDirectory.appending(path: sourceURL.lastPathComponent)
+            if fileManager.fileExists(atPath: targetURL.path) {
+                try fileManager.removeItem(at: targetURL)
+            }
+            try fileManager.copyItem(at: sourceURL, to: targetURL)
+            return targetURL
+        }
+    }
+
+    static func removeStoreFilesAfterUserConfirmation(
+        at storeURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        for url in existingStoreFileURLs(for: storeURL, fileManager: fileManager) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    private static func sanitizedSummary(for error: Error) -> String {
+        let nsError = error as NSError
+        return "\(nsError.domain) \(nsError.code)"
+    }
+
+    private static func storeFileCandidates(for storeURL: URL) -> [URL] {
+        let directoryURL = storeURL.deletingLastPathComponent()
+        let storeFileName = storeURL.lastPathComponent
+
+        return [
+            storeURL,
+            directoryURL.appending(path: "\(storeFileName)-shm"),
+            directoryURL.appending(path: "\(storeFileName)-wal"),
+            directoryURL.appending(path: "\(storeFileName)_SUPPORT", directoryHint: .isDirectory)
+        ]
+    }
+
+    private static func fileDateString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        return formatter.string(from: date)
+    }
+}
+
+struct StoreRecoveryView: View {
+    let context: PersistentStoreRecoveryContext
+    let prepareStoreBackup: () throws -> [URL]
+    let startEmptyStore: @MainActor () throws -> AppRuntimeEnvironment
+    let didRecover: @MainActor (AppRuntimeEnvironment) -> Void
+
+    @State private var backupFileURLs: [URL] = []
+    @State private var statusMessage: String?
+    @State private var errorMessage: String?
+    @State private var isPreparingBackup = false
+    @State private var isStartingEmptyStore = false
+    @State private var showsDestructiveConfirmation = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Label("Lokale Daten wurden nicht gelöscht", systemImage: "externaldrive.badge.exclamationmark")
+                            .font(.headline)
+                            .foregroundStyle(AppTheme.symiPetrol)
+
+                        Text(context.reason.headline)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiTextPrimary)
+
+                        Text(context.reason.explanation)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiTextSecondary)
+                    }
+                    .padding(.vertical, 6)
+                }
+
+                Section("Sicherung und Migration") {
+                    Text("Sichere die vorhandenen Store-Dateien, bevor du Symi mit einem leeren Store startest. Ohne Löschbestätigung bleiben die Dateien an ihrem aktuellen Ort.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Button {
+                        prepareBackup()
+                    } label: {
+                        Label(isPreparingBackup ? "Sicherung wird vorbereitet" : "Store-Dateien sichern", systemImage: "externaldrive.badge.plus")
+                    }
+                    .disabled(isPreparingBackup || isStartingEmptyStore)
+
+                    if !backupFileURLs.isEmpty {
+                        ShareLink(items: backupFileURLs) {
+                            Label("Sicherung teilen", systemImage: "square.and.arrow.up")
+                        }
+                    }
+
+                    Button {
+                        statusMessage = "Es wurde nichts geändert. Du kannst Symi nach einem Update erneut öffnen oder die Store-Dateien vorher sichern."
+                        errorMessage = nil
+                    } label: {
+                        Label("Später migrieren", systemImage: "clock.arrow.circlepath")
+                    }
+                    .disabled(isStartingEmptyStore)
+                }
+
+                Section("Leerer Neustart") {
+                    Text("Diese Option entfernt die lokalen Store-Dateien erst nach deiner Bestätigung und erstellt danach einen neuen leeren Store.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Button(role: .destructive) {
+                        showsDestructiveConfirmation = true
+                    } label: {
+                        Label(isStartingEmptyStore ? "Leerer Store wird erstellt" : "Mit leerem Store starten", systemImage: "trash")
+                    }
+                    .disabled(isPreparingBackup || isStartingEmptyStore)
+                }
+
+                if let statusMessage {
+                    Section {
+                        Text(statusMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiTextSecondary)
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiCoral)
+                    }
+                }
+            }
+            .navigationTitle("Daten wiederherstellen")
+            .brandGroupedScreen()
+            .confirmationDialog(
+                "Lokale Store-Dateien löschen?",
+                isPresented: $showsDestructiveConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Store-Dateien löschen und leer starten", role: .destructive) {
+                    startWithEmptyStore()
+                }
+                Button("Abbrechen", role: .cancel) {}
+            } message: {
+                Text("Diese Aktion löscht den lokalen SwiftData-Store auf diesem Gerät. Eine spätere Migration ist nur möglich, wenn du die Store-Dateien vorher gesichert hast.")
+            }
+        }
+    }
+
+    private func prepareBackup() {
+        isPreparingBackup = true
+        statusMessage = nil
+        errorMessage = nil
+
+        do {
+            backupFileURLs = try prepareStoreBackup()
+            statusMessage = "Die Store-Dateien wurden für die Sicherung vorbereitet."
+        } catch {
+            errorMessage = userFacingMessage(for: error)
+        }
+
+        isPreparingBackup = false
+    }
+
+    private func startWithEmptyStore() {
+        isStartingEmptyStore = true
+        statusMessage = nil
+        errorMessage = nil
+
+        do {
+            let environment = try startEmptyStore()
+            didRecover(environment)
+        } catch {
+            errorMessage = userFacingMessage(for: error)
+            isStartingEmptyStore = false
+        }
+    }
+
+    private func userFacingMessage(for error: Error) -> String {
+        if let localizedError = error as? LocalizedError, let description = localizedError.errorDescription {
+            return description
+        }
+
+        let nsError = error as NSError
+        return "Der Vorgang konnte nicht abgeschlossen werden. Fehlercode: \(nsError.domain) \(nsError.code)"
+    }
+}
+
+#Preview {
+    StoreRecoveryView(
+        context: PersistentStoreRecoveryContext(
+            storeURL: URL(fileURLWithPath: "/tmp/default.store"),
+            reason: .unknownModelVersion,
+            errorSummary: "NSCocoaErrorDomain \(PersistentStoreRecoveryService.unknownModelVersionErrorCode)"
+        ),
+        prepareStoreBackup: { [] },
+        startEmptyStore: {
+            throw PersistentStoreRecoveryFileError.noStoreFilesFound
+        },
+        didRecover: { _ in }
+    )
+}

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -3,23 +3,143 @@ import Sentry
 import TelemetryDeck
 
 import SwiftData
-import CoreData
 import OSLog
 
 @main
 struct SymiApp: App {
     private static let logger = Logger(subsystem: "Symi", category: "Persistence")
-    private let modelContainer: ModelContainer
-    private let appContainer: AppContainer
-    private let appLogStore: AppLogStore
     private let launchConfiguration: AppLaunchConfiguration
-    private let screenshotSeed: ScreenshotSeed?
-    @State private var syncCoordinator: SyncCoordinator
+    private let initialStartupState: AppStartupState
 
     init() {
         let launchConfiguration = AppLaunchConfiguration.current
         self.launchConfiguration = launchConfiguration
 
+        Self.configureTelemetry(for: launchConfiguration)
+        self.initialStartupState = Self.makeInitialStartupState(launchConfiguration: launchConfiguration)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            AppRootView(
+                launchConfiguration: launchConfiguration,
+                initialStartupState: initialStartupState
+            )
+        }
+    }
+
+    @MainActor
+    static func makeContainer(schema: Schema, configuration: ModelConfiguration) throws -> ModelContainer {
+        try makeContainer(schema: schema, configuration: configuration) {
+            try ModelContainer(
+                for: schema,
+                migrationPlan: SymiMigrationPlan.self,
+                configurations: [configuration]
+            )
+        }
+    }
+
+    @MainActor
+    static func makeContainer(
+        schema: Schema,
+        configuration: ModelConfiguration,
+        loadContainer: () throws -> ModelContainer
+    ) throws -> ModelContainer {
+        do {
+            logger.debug("Versuche ModelContainer für lokalen Store zu laden.")
+            return try loadContainer()
+        } catch {
+            let context = PersistentStoreRecoveryService.recoveryContext(for: error, storeURL: configuration.url)
+            logger.error(
+                "ModelContainer konnte nicht geladen werden. Recovery wird vorbereitet. Grund: \(context.reason.rawValue, privacy: .public), Fehler: \(context.errorSummary, privacy: .public)"
+            )
+            throw PersistentStoreLoadError.recoveryRequired(context)
+        }
+    }
+
+    @MainActor
+    static func makeAppRuntimeEnvironment(
+        launchConfiguration: AppLaunchConfiguration,
+        storeURL overrideStoreURL: URL? = nil
+    ) throws -> AppRuntimeEnvironment {
+        let schema = Schema(versionedSchema: SymiSchemaV5.self)
+        let storeURL = overrideStoreURL ?? (launchConfiguration.isRunningTests ? unitTestStoreURL() : defaultStoreURL())
+        let configuration = ModelConfiguration(
+            "default",
+            schema: schema,
+            url: storeURL,
+            cloudKitDatabase: .none
+        )
+
+        let container = try makeContainer(schema: schema, configuration: configuration)
+        let appLogStore = AppLogStore()
+        let syncCoordinator = SyncCoordinator(
+            modelContainer: container,
+            appLogStore: appLogStore,
+            autostart: !launchConfiguration.isRunningTests
+        )
+        let appContainer = AppContainer(
+            modelContainer: container,
+            syncCoordinator: syncCoordinator,
+            appLogStore: appLogStore
+        )
+
+        return AppRuntimeEnvironment(
+            modelContainer: container,
+            appContainer: appContainer,
+            appLogStore: appLogStore,
+            syncCoordinator: syncCoordinator,
+            screenshotSeed: nil
+        )
+    }
+
+    @MainActor
+    private static func makeInitialStartupState(launchConfiguration: AppLaunchConfiguration) -> AppStartupState {
+        do {
+            if launchConfiguration.isScreenshotMode {
+                let environment = try ScreenshotBootstrap.makeEnvironment(seedName: launchConfiguration.screenshotSeedName)
+                return .app(
+                    AppRuntimeEnvironment(
+                        modelContainer: environment.0,
+                        appContainer: environment.1,
+                        appLogStore: environment.2,
+                        syncCoordinator: environment.3,
+                        screenshotSeed: environment.4
+                    )
+                )
+            }
+
+            return .app(try makeAppRuntimeEnvironment(launchConfiguration: launchConfiguration))
+        } catch PersistentStoreLoadError.recoveryRequired(let context) {
+            do {
+                return .recovery(
+                    StoreRecoveryEnvironment(
+                        context: context,
+                        fallbackContainer: try makeRecoveryContainer()
+                    )
+                )
+            } catch {
+                fatalError("Recovery-Container konnte nicht erstellt werden: \(error)")
+            }
+        } catch {
+            fatalError("App-Start konnte nicht vorbereitet werden: \(error)")
+        }
+    }
+
+    @MainActor
+    private static func makeRecoveryContainer() throws -> ModelContainer {
+        let schema = Schema(versionedSchema: SymiSchemaV5.self)
+        let configuration = ModelConfiguration(
+            "recovery",
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    private static func configureTelemetry(for launchConfiguration: AppLaunchConfiguration) {
         if !launchConfiguration.isScreenshotMode, !launchConfiguration.isRunningTests, let sentryDSN = Self.sentryDSN {
             SentrySDK.start { options in
                 options.dsn = sentryDSN
@@ -40,115 +160,10 @@ struct SymiApp: App {
         } else {
             Self.logger.notice("Sentry ist deaktiviert, weil keine gültige DSN in der App-Konfiguration gefunden wurde.")
         }
+
         if !launchConfiguration.isScreenshotMode, !launchConfiguration.isRunningTests, let telemetryAppID = Self.telemetryAppID {
             TelemetryDeck.initialize(config: .init(appID: telemetryAppID))
         }
-        do {
-            if launchConfiguration.isScreenshotMode {
-                let environment = try ScreenshotBootstrap.makeEnvironment(seedName: launchConfiguration.screenshotSeedName)
-                self.modelContainer = environment.0
-                self.appContainer = environment.1
-                self.appLogStore = environment.2
-                self.screenshotSeed = environment.4
-                _syncCoordinator = State(initialValue: environment.3)
-            } else {
-                let schema = Schema(versionedSchema: SymiSchemaV5.self)
-                let storeURL = launchConfiguration.isRunningTests ? Self.unitTestStoreURL() : Self.defaultStoreURL()
-                let configuration = ModelConfiguration(
-                    "default",
-                    schema: schema,
-                    url: storeURL,
-                    cloudKitDatabase: .none
-                )
-
-                let container = try Self.makeContainer(schema: schema, configuration: configuration)
-                self.modelContainer = container
-                let appLogStore = AppLogStore()
-                self.appLogStore = appLogStore
-                let syncCoordinator = SyncCoordinator(
-                    modelContainer: container,
-                    appLogStore: appLogStore,
-                    autostart: !launchConfiguration.isRunningTests
-                )
-                _syncCoordinator = State(initialValue: syncCoordinator)
-                self.appContainer = AppContainer(
-                    modelContainer: container,
-                    syncCoordinator: syncCoordinator,
-                    appLogStore: appLogStore
-                )
-                self.screenshotSeed = nil
-            }
-        } catch {
-            fatalError("ModelContainer konnte nicht erstellt werden: \(error)")
-        }
-    }
-
-    var body: some Scene {
-        WindowGroup {
-            if launchConfiguration.isScreenshotMode, let screenshotSeed {
-                ScreenshotRootView(
-                    appContainer: appContainer,
-                    configuration: launchConfiguration,
-                    seed: screenshotSeed
-                )
-            } else {
-                AppShellView(appContainer: appContainer)
-            }
-        }
-        .modelContainer(modelContainer)
-    }
-
-    private static func makeContainer(schema: Schema, configuration: ModelConfiguration) throws -> ModelContainer {
-        do {
-            logger.debug("Versuche ModelContainer für Store unter \(configuration.url.path, privacy: .public) zu laden.")
-            return try ModelContainer(
-                for: schema,
-                migrationPlan: SymiMigrationPlan.self,
-                configurations: [configuration]
-            )
-        } catch {
-            let errorDescription = String(describing: error)
-            logger.error("Erster Ladeversuch des ModelContainer fehlgeschlagen: \(errorDescription, privacy: .public)")
-
-            guard isUnknownModelVersionError(error) else {
-                logger.error("Fehler wurde nicht als Reset-Fall erkannt. Beschreibung: \(errorDescription, privacy: .public)")
-                throw error
-            }
-
-            logger.warning("Unbekannte Modellversion erkannt. SwiftData-Store wird vollständig zurückgesetzt: \(configuration.url.path, privacy: .public)")
-            try resetPersistentStore(at: configuration.url)
-            logger.notice("SwiftData-Store wurde zurückgesetzt. Erneuter Aufbau des ModelContainer startet.")
-
-            return try ModelContainer(
-                for: schema,
-                migrationPlan: SymiMigrationPlan.self,
-                configurations: [configuration]
-            )
-        }
-    }
-
-    private static func isUnknownModelVersionError(_ error: Error) -> Bool {
-        let nsError = error as NSError
-        let description = String(describing: error).lowercased()
-        let localizedDescription = nsError.localizedDescription.lowercased()
-
-        if nsError.domain == NSCocoaErrorDomain && nsError.code == 134504 {
-            return true
-        }
-
-        if description.contains("loadissuemodelcontainer") {
-            return true
-        }
-
-        if description.contains("unknown model version") || localizedDescription.contains("unknown model version") {
-            return true
-        }
-
-        if description.contains("134504") || localizedDescription.contains("134504") {
-            return true
-        }
-
-        return false
     }
 
     private static func defaultStoreURL() -> URL {
@@ -184,14 +199,88 @@ struct SymiApp: App {
 
         return trimmed
     }
+}
 
-    private static func resetPersistentStore(at url: URL) throws {
-        let directoryURL = url.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+@MainActor
+enum AppStartupState {
+    case app(AppRuntimeEnvironment)
+    case recovery(StoreRecoveryEnvironment)
+}
 
-        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: NSManagedObjectModel())
-        logger.notice("Zerstöre Persistent Store unter \(url.path, privacy: .public)")
-        try coordinator.destroyPersistentStore(at: url, type: .sqlite)
-        logger.notice("Persistent Store unter \(url.path, privacy: .public) wurde per Core Data API zerstört.")
+@MainActor
+final class AppRuntimeEnvironment {
+    let modelContainer: ModelContainer
+    let appContainer: AppContainer
+    let appLogStore: AppLogStore
+    let syncCoordinator: SyncCoordinator
+    let screenshotSeed: ScreenshotSeed?
+
+    init(
+        modelContainer: ModelContainer,
+        appContainer: AppContainer,
+        appLogStore: AppLogStore,
+        syncCoordinator: SyncCoordinator,
+        screenshotSeed: ScreenshotSeed?
+    ) {
+        self.modelContainer = modelContainer
+        self.appContainer = appContainer
+        self.appLogStore = appLogStore
+        self.syncCoordinator = syncCoordinator
+        self.screenshotSeed = screenshotSeed
+    }
+}
+
+@MainActor
+struct StoreRecoveryEnvironment {
+    let context: PersistentStoreRecoveryContext
+    let fallbackContainer: ModelContainer
+}
+
+private struct AppRootView: View {
+    let launchConfiguration: AppLaunchConfiguration
+    @State private var startupState: AppStartupState
+
+    init(launchConfiguration: AppLaunchConfiguration, initialStartupState: AppStartupState) {
+        self.launchConfiguration = launchConfiguration
+        _startupState = State(initialValue: initialStartupState)
+    }
+
+    var body: some View {
+        switch startupState {
+        case .app(let environment):
+            appContent(environment: environment)
+                .modelContainer(environment.modelContainer)
+        case .recovery(let environment):
+            StoreRecoveryView(
+                context: environment.context,
+                prepareStoreBackup: {
+                    try PersistentStoreRecoveryService.copyStoreFilesForSharing(from: environment.context.storeURL)
+                },
+                startEmptyStore: {
+                    try PersistentStoreRecoveryService.removeStoreFilesAfterUserConfirmation(at: environment.context.storeURL)
+                    return try SymiApp.makeAppRuntimeEnvironment(
+                        launchConfiguration: launchConfiguration,
+                        storeURL: environment.context.storeURL
+                    )
+                },
+                didRecover: { recoveredEnvironment in
+                    startupState = .app(recoveredEnvironment)
+                }
+            )
+            .modelContainer(environment.fallbackContainer)
+        }
+    }
+
+    @ViewBuilder
+    private func appContent(environment: AppRuntimeEnvironment) -> some View {
+        if launchConfiguration.isScreenshotMode, let screenshotSeed = environment.screenshotSeed {
+            ScreenshotRootView(
+                appContainer: environment.appContainer,
+                configuration: launchConfiguration,
+                seed: screenshotSeed
+            )
+        } else {
+            AppShellView(appContainer: environment.appContainer)
+        }
     }
 }

--- a/SymiTests/PersistentStoreRecoveryTests.swift
+++ b/SymiTests/PersistentStoreRecoveryTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Symi
+
+@MainActor
+struct PersistentStoreRecoveryTests {
+    @Test
+    func unknownModelVersionDoesNotDeleteStoreFiles() throws {
+        let directory = try makeTemporaryDirectory()
+        let storeURL = directory.appending(path: "default.store")
+        let walURL = directory.appending(path: "default.store-wal")
+        let shmURL = directory.appending(path: "default.store-shm")
+        let storeData = Data("store-sentinel".utf8)
+        let walData = Data("wal-sentinel".utf8)
+        let shmData = Data("shm-sentinel".utf8)
+        try storeData.write(to: storeURL)
+        try walData.write(to: walURL)
+        try shmData.write(to: shmURL)
+
+        let schema = Schema(versionedSchema: SymiSchemaV5.self)
+        let configuration = ModelConfiguration(
+            "default",
+            schema: schema,
+            url: storeURL,
+            cloudKitDatabase: .none
+        )
+        let unknownModelVersionError = NSError(
+            domain: NSCocoaErrorDomain,
+            code: PersistentStoreRecoveryService.unknownModelVersionErrorCode
+        )
+
+        do {
+            _ = try SymiApp.makeContainer(schema: schema, configuration: configuration) {
+                throw unknownModelVersionError
+            }
+            Issue.record("Ein unbekannter Modellversionsfehler muss in den Recovery-Zustand laufen.")
+        } catch PersistentStoreLoadError.recoveryRequired(let context) {
+            #expect(context.reason == .unknownModelVersion)
+            #expect(context.storeURL == storeURL)
+        } catch {
+            Issue.record("Unerwarteter Fehler: \(error)")
+        }
+
+        #expect(FileManager.default.fileExists(atPath: storeURL.path))
+        #expect(FileManager.default.fileExists(atPath: walURL.path))
+        #expect(FileManager.default.fileExists(atPath: shmURL.path))
+        #expect(try Data(contentsOf: storeURL) == storeData)
+        #expect(try Data(contentsOf: walURL) == walData)
+        #expect(try Data(contentsOf: shmURL) == shmData)
+    }
+
+    @Test
+    func migrationErrorsAreClassifiedForRecovery() {
+        let migrationError = NSError(
+            domain: NSCocoaErrorDomain,
+            code: PersistentStoreRecoveryService.migrationErrorCodeRange.lowerBound + 10
+        )
+
+        let reason = PersistentStoreRecoveryService.recoveryReason(for: migrationError)
+
+        #expect(reason == .migrationFailure)
+    }
+
+    @Test
+    func backupPreparationCopiesStoreFilesWithoutChangingOriginals() throws {
+        let directory = try makeTemporaryDirectory()
+        let storeURL = directory.appending(path: "default.store")
+        let walURL = directory.appending(path: "default.store-wal")
+        let storeData = Data("store-sentinel".utf8)
+        let walData = Data("wal-sentinel".utf8)
+        try storeData.write(to: storeURL)
+        try walData.write(to: walURL)
+
+        let backupURLs = try PersistentStoreRecoveryService.copyStoreFilesForSharing(
+            from: storeURL,
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+
+        #expect(backupURLs.count == 2)
+        #expect(try Data(contentsOf: storeURL) == storeData)
+        #expect(try Data(contentsOf: walURL) == walData)
+        #expect(backupURLs.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
+    }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}


### PR DESCRIPTION
## Änderungen

- entfernt den automatischen SwiftData-Store-Reset beim Laden des ModelContainers
- führt einen nicht-destruktiven Recovery-Start mit Fallback-Container ein
- ergänzt eine Recovery-UI zum Sichern der Store-Dateien, späteren Migrieren und explizit bestätigten leeren Neustart
- kapselt die Core-Data-/SwiftData-Fehlercodes als benannte Konstanten
- ergänzt Tests für unbekannte Modellversionen, Migrationserkennung und unveränderte Store-Dateien

## Warum

Ein unbekannter Modellstand oder ein Migrationsfehler darf lokale Nutzerdaten nicht automatisch zerstören. Die App hält den vorhandenen Store nun unverändert, bis Nutzerinnen oder Nutzer eine destruktive Aktion ausdrücklich bestätigen.

Closes #151

## Validierung

- `xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,id=BBB46871-5F30-4614-B64D-A5A07A328243'`