### PR TITLE
[codex] Roundtrip Health-Kontext in JSON5-Backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Die App bleibt klar migränefokussiert, fühlt sich aber bewusst nicht wie ein m
 ### 3. Export und Sicherung
 
 - PDF-Bericht für einen Zeitraum erzeugen und teilen
-- JSON5-Backup erzeugen oder importieren
+- JSON5-Backup erzeugen oder importieren; enthalten sind Einträge, Medikamente, Wetter-Snapshots und gespeicherter Apple-Health-Kontext
 
 ### 4. Optionale Synchronisation
 

--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -650,7 +650,7 @@
         }
       }
     },
-    "Das Backup enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.": {},
+    "Das Backup enthält alle Einträge, eigene Medikamentenvorlagen, Wetter-Snapshots und gespeicherten Apple-Health-Kontext, inklusive Papierkorb-Einträgen.": {},
     "Das Projekt steht unter der GNU GPL v3.": {
       "localizations": {
         "en": {

--- a/Symi/Sources/Features/Export/DataExportView.swift
+++ b/Symi/Sources/Features/Export/DataExportView.swift
@@ -60,7 +60,7 @@ struct DataExportView: View {
             }
 
             Section("Backup") {
-                Text("Das Backup enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.")
+                Text("Das Backup enthält alle Einträge, eigene Medikamentenvorlagen, Wetter-Snapshots und gespeicherten Apple-Health-Kontext, inklusive Papierkorb-Einträgen.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -76,7 +76,7 @@ struct DataTransferSnapshot: @preconcurrency Codable, Sendable {
         return snapshot
     }
 
-    nonisolated func merge(into context: ModelContext) throws {
+    nonisolated func merge(into context: ModelContext, healthContextStore: HealthContextStore) throws {
         let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
         let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
 
@@ -104,6 +104,13 @@ struct DataTransferSnapshot: @preconcurrency Codable, Sendable {
         }
 
         try context.save()
+        try mergeEpisodeSidecars(into: healthContextStore)
+    }
+
+    private nonisolated func mergeEpisodeSidecars(into healthContextStore: HealthContextStore) throws {
+        for payload in episodes {
+            try payload.applySidecars(to: healthContextStore)
+        }
     }
 
     private nonisolated static func fileDateString(from date: Date) -> String {
@@ -116,7 +123,7 @@ struct DataTransferSnapshot: @preconcurrency Codable, Sendable {
     }
 }
 
-struct EpisodePayload: @preconcurrency Codable, Sendable {
+struct EpisodePayload: Codable, Sendable {
     let id: UUID
     let startedAt: Date
     let endedAt: Date?
@@ -134,6 +141,27 @@ struct EpisodePayload: @preconcurrency Codable, Sendable {
     let medications: [MedicationEntryPayload]
     let weatherSnapshot: WeatherSnapshotPayload?
     let healthContext: HealthContextSnapshotData?
+    private let shouldImportHealthContext: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case startedAt
+        case endedAt
+        case updatedAt
+        case deletedAt
+        case type
+        case intensity
+        case painLocation
+        case painCharacter
+        case notes
+        case symptoms
+        case triggers
+        case functionalImpact
+        case menstruationStatus
+        case medications
+        case weatherSnapshot
+        case healthContext
+    }
 
     nonisolated init(episode: Episode, healthContext: HealthContextRecord? = nil) {
         self.id = episode.id
@@ -153,6 +181,55 @@ struct EpisodePayload: @preconcurrency Codable, Sendable {
         self.medications = episode.medications.map(MedicationEntryPayload.init)
         self.weatherSnapshot = episode.weatherSnapshot.map(WeatherSnapshotPayload.init)
         self.healthContext = healthContext.map(HealthContextSnapshotData.init)
+        self.shouldImportHealthContext = healthContext != nil
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.startedAt = try container.decode(Date.self, forKey: .startedAt)
+        self.endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
+        self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        self.deletedAt = try container.decodeIfPresent(Date.self, forKey: .deletedAt)
+        self.type = try container.decode(EpisodeType.self, forKey: .type)
+        self.intensity = try container.decode(Int.self, forKey: .intensity)
+        self.painLocation = try container.decode(String.self, forKey: .painLocation)
+        self.painCharacter = try container.decode(String.self, forKey: .painCharacter)
+        self.notes = try container.decode(String.self, forKey: .notes)
+        self.symptoms = try container.decode([String].self, forKey: .symptoms)
+        self.triggers = try container.decode([String].self, forKey: .triggers)
+        self.functionalImpact = try container.decode(String.self, forKey: .functionalImpact)
+        self.menstruationStatus = try container.decode(MenstruationStatus.self, forKey: .menstruationStatus)
+        self.medications = try container.decode([MedicationEntryPayload].self, forKey: .medications)
+        self.weatherSnapshot = try container.decodeIfPresent(WeatherSnapshotPayload.self, forKey: .weatherSnapshot)
+        self.shouldImportHealthContext = container.contains(.healthContext)
+        self.healthContext = try container.decodeIfPresent(HealthContextSnapshotData.self, forKey: .healthContext)
+    }
+
+    nonisolated func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(startedAt, forKey: .startedAt)
+        try container.encodeIfPresent(endedAt, forKey: .endedAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(deletedAt, forKey: .deletedAt)
+        try container.encode(type, forKey: .type)
+        try container.encode(intensity, forKey: .intensity)
+        try container.encode(painLocation, forKey: .painLocation)
+        try container.encode(painCharacter, forKey: .painCharacter)
+        try container.encode(notes, forKey: .notes)
+        try container.encode(symptoms, forKey: .symptoms)
+        try container.encode(triggers, forKey: .triggers)
+        try container.encode(functionalImpact, forKey: .functionalImpact)
+        try container.encode(menstruationStatus, forKey: .menstruationStatus)
+        try container.encode(medications, forKey: .medications)
+        try container.encodeIfPresent(weatherSnapshot, forKey: .weatherSnapshot)
+
+        if let healthContext {
+            try container.encode(healthContext, forKey: .healthContext)
+        } else if shouldImportHealthContext {
+            try container.encodeNil(forKey: .healthContext)
+        }
     }
 
     nonisolated func makeModel() -> Episode {
@@ -219,6 +296,14 @@ struct EpisodePayload: @preconcurrency Codable, Sendable {
             context.delete(existingWeatherSnapshot)
             episode.weatherSnapshot = nil
         }
+    }
+
+    nonisolated func applySidecars(to healthContextStore: HealthContextStore) throws {
+        guard shouldImportHealthContext else {
+            return
+        }
+
+        try healthContextStore.save(healthContext, for: id)
     }
 }
 

--- a/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
+++ b/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
@@ -14,19 +14,19 @@ final class HealthContextStore: @unchecked Sendable {
         decoder.dateDecodingStrategy = .iso8601
     }
 
-    nonisolated func save(_ snapshot: HealthContextSnapshotData?, for episodeID: UUID) {
+    nonisolated func save(_ snapshot: HealthContextSnapshotData?, for episodeID: UUID) throws {
         let url = fileURL(for: episodeID)
 
         guard let snapshot else {
-            try? FileManager.default.removeItem(at: url)
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
             return
         }
 
-        do {
-            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-            let data = try encoder.encode(snapshot)
-            try data.write(to: url, options: .atomic)
-        } catch {}
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let data = try encoder.encode(snapshot)
+        try data.write(to: url, options: .atomic)
     }
 
     nonisolated func load(for episodeID: UUID) -> HealthContextRecord? {

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -110,7 +110,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
         }
 
         try context.save()
-        healthContextStore.save(healthContext, for: target.id)
+        try healthContextStore.save(healthContext, for: target.id)
         return target.id
     }
 
@@ -301,7 +301,7 @@ final class SwiftDataExportRepository: ExportRepository, @unchecked Sendable {
     nonisolated func importBackup(from url: URL) throws {
         let snapshot = try DataTransferSnapshot.load(from: url)
         let context = writeContext()
-        try snapshot.merge(into: context)
+        try snapshot.merge(into: context, healthContextStore: healthContextStore)
     }
 
     nonisolated private func readContext() -> ModelContext {

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Symi
+
+@MainActor
+struct DataTransferHealthContextTests {
+    @Test
+    func backupRoundtripRestoresEpisodeMedicationWeatherAndHealthContext() throws {
+        let episodeID = UUID()
+        let healthContext = makeHealthContext()
+        let sourceContainer = try makeInMemoryContainer()
+        let sourceHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        try seedEpisode(id: episodeID, in: sourceContainer)
+        try sourceHealthStore.save(healthContext, for: episodeID)
+
+        let backupURL = try SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: sourceHealthStore
+        ).createBackup()
+        let backupText = try String(contentsOf: backupURL, encoding: .utf8)
+        #expect(backupText.contains("\"healthContext\""))
+
+        let targetContainer = try makeInMemoryContainer()
+        let targetHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        try SwiftDataExportRepository(
+            modelContainer: targetContainer,
+            healthContextStore: targetHealthStore
+        ).importBackup(from: backupURL)
+
+        let importedEpisodes = try ModelContext(targetContainer).fetch(FetchDescriptor<Episode>())
+        #expect(importedEpisodes.count == 1)
+        guard let importedEpisode = importedEpisodes.first else {
+            Issue.record("Importierte Episode fehlt.")
+            return
+        }
+
+        #expect(importedEpisode.id == episodeID)
+        #expect(importedEpisode.medications.count == 1)
+        #expect(importedEpisode.medications.first?.name == "Sumatriptan")
+        #expect(importedEpisode.weatherSnapshot?.condition == "Regen")
+        #expect(targetHealthStore.load(for: episodeID) == HealthContextRecord(snapshot: healthContext))
+    }
+
+    @Test
+    func importWithoutHealthContextKeyKeepsExistingContext() throws {
+        let episodeID = UUID()
+        let existingHealthContext = makeHealthContext(source: "Bestehender Kontext")
+        let sourceContainer = try makeInMemoryContainer()
+        let sourceHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        try seedEpisode(id: episodeID, notes: "Import ohne Health-Kontext", in: sourceContainer)
+
+        let backupURL = try SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: sourceHealthStore
+        ).createBackup()
+        let backupText = try String(contentsOf: backupURL, encoding: .utf8)
+        #expect(!backupText.contains("\"healthContext\""))
+
+        let targetContainer = try makeInMemoryContainer()
+        let targetHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        try seedEpisode(id: episodeID, notes: "Bestehender Eintrag", in: targetContainer)
+        try targetHealthStore.save(existingHealthContext, for: episodeID)
+
+        try SwiftDataExportRepository(
+            modelContainer: targetContainer,
+            healthContextStore: targetHealthStore
+        ).importBackup(from: backupURL)
+
+        let importedEpisode = try ModelContext(targetContainer).fetch(FetchDescriptor<Episode>()).first
+        #expect(importedEpisode?.notes == "Import ohne Health-Kontext")
+        #expect(targetHealthStore.load(for: episodeID) == HealthContextRecord(snapshot: existingHealthContext))
+    }
+
+    @Test
+    func explicitNullHealthContextRemovesExistingContext() throws {
+        let episodeID = UUID()
+        let sourceContainer = try makeInMemoryContainer()
+        let sourceHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        try seedEpisode(id: episodeID, in: sourceContainer)
+        let backupURL = try SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: sourceHealthStore
+        ).createBackup()
+        let explicitNullBackupURL = try backupURLByAddingExplicitNullHealthContext(to: backupURL)
+
+        let targetContainer = try makeInMemoryContainer()
+        let targetHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        try seedEpisode(id: episodeID, in: targetContainer)
+        try targetHealthStore.save(makeHealthContext(), for: episodeID)
+
+        try SwiftDataExportRepository(
+            modelContainer: targetContainer,
+            healthContextStore: targetHealthStore
+        ).importBackup(from: explicitNullBackupURL)
+
+        #expect(targetHealthStore.load(for: episodeID) == nil)
+    }
+
+    @Test
+    func importThrowsWhenHealthContextCannotBeWritten() throws {
+        let episodeID = UUID()
+        let sourceContainer = try makeInMemoryContainer()
+        let sourceHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        try seedEpisode(id: episodeID, in: sourceContainer)
+        try sourceHealthStore.save(makeHealthContext(), for: episodeID)
+        let backupURL = try SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: sourceHealthStore
+        ).createBackup()
+
+        let blockedBaseURL = try makeTemporaryDirectory()
+        try Data("blockiert".utf8).write(to: blockedBaseURL.appending(path: "Symi"))
+        let blockedHealthStore = HealthContextStore(baseURL: blockedBaseURL)
+
+        var didThrow = false
+        do {
+            try SwiftDataExportRepository(
+                modelContainer: try makeInMemoryContainer(),
+                healthContextStore: blockedHealthStore
+            ).importBackup(from: backupURL)
+        } catch {
+            didThrow = true
+        }
+
+        #expect(didThrow)
+    }
+}
+
+private func makeInMemoryContainer() throws -> ModelContainer {
+    let schema = Schema(versionedSchema: SymiSchemaV5.self)
+    let configuration = ModelConfiguration(
+        "test-\(UUID().uuidString)",
+        schema: schema,
+        isStoredInMemoryOnly: true,
+        cloudKitDatabase: .none
+    )
+    return try ModelContainer(for: schema, configurations: [configuration])
+}
+
+private func seedEpisode(id: UUID, notes: String = "Migräne nach Wetterwechsel", in container: ModelContainer) throws {
+    let context = ModelContext(container)
+    let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let episode = Episode(
+        id: id,
+        startedAt: startedAt,
+        endedAt: startedAt.addingTimeInterval(7_200),
+        updatedAt: startedAt.addingTimeInterval(60),
+        type: .migraine,
+        intensity: 7,
+        painLocation: "Stirn",
+        painCharacter: "Pulsierend",
+        notes: notes,
+        symptoms: ["Übelkeit"],
+        triggers: ["Stress"],
+        functionalImpact: "Arbeiten nur eingeschränkt möglich",
+        menstruationStatus: .none
+    )
+    let medication = MedicationEntry(
+        id: UUID(),
+        name: "Sumatriptan",
+        category: .triptan,
+        dosage: "50 mg",
+        quantity: 1,
+        takenAt: startedAt.addingTimeInterval(900),
+        effectiveness: .good,
+        reliefStartedAt: startedAt.addingTimeInterval(3_600),
+        episode: episode
+    )
+    episode.medications = [medication]
+    episode.weatherSnapshot = WeatherSnapshot(
+        id: UUID(),
+        recordedAt: startedAt,
+        temperature: 18.5,
+        condition: "Regen",
+        humidity: 72,
+        pressure: 1004,
+        precipitation: 1.4,
+        weatherCode: 63,
+        source: "Apple Weather",
+        episode: episode
+    )
+    context.insert(episode)
+    try context.save()
+}
+
+private func makeHealthContext(source: String = "Apple Health") -> HealthContextSnapshotData {
+    let recordedAt = Date(timeIntervalSince1970: 1_700_000_300)
+    return HealthContextSnapshotData(
+        recordedAt: recordedAt,
+        source: source,
+        sleepMinutes: 420,
+        stepCount: 3_200,
+        averageHeartRate: 78,
+        restingHeartRate: 62,
+        heartRateVariability: 41,
+        menstrualFlow: nil,
+        symptoms: [
+            HealthSymptomSampleData(
+                type: .headache,
+                severity: "Mittel",
+                startDate: recordedAt.addingTimeInterval(-1_800),
+                endDate: recordedAt,
+                source: "Health"
+            )
+        ]
+    )
+}
+
+private func backupURLByAddingExplicitNullHealthContext(to backupURL: URL) throws -> URL {
+    let data = try Data(contentsOf: backupURL)
+    guard var root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+          var episodes = root["episodes"] as? [[String: Any]],
+          !episodes.isEmpty else {
+        throw DataTransferError.invalidFormat
+    }
+
+    episodes[0]["healthContext"] = NSNull()
+    root["episodes"] = episodes
+
+    let explicitNullData = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+    let url = try makeTemporaryDirectory().appending(path: "explicit-null-health-context.json5")
+    try explicitNullData.write(to: url, options: .atomic)
+    return url
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}


### PR DESCRIPTION
## Zusammenfassung
- stellt `healthContext` beim JSON5-Import wieder im `HealthContextStore` her
- unterscheidet fehlenden `healthContext`-Key von explizitem `null`, damit bestehender Kontext nicht versehentlich gelöscht wird
- lässt Schreibfehler im Health-Kontext-Store sichtbar fehlschlagen statt stille Teilimporte zu erzeugen
- ergänzt Roundtrip-Tests für Episode, Medikamente, Wetter und Apple-Health-Kontext
- aktualisiert Backup-Hinweise in UI und README

## Ursache
`DataTransferSnapshot` exportierte `EpisodePayload.healthContext`, aber der Import schrieb diesen Sidecar-Kontext nicht zurück. Dadurch wirkte das Backup vollständig, verlor beim Import aber Apple-Health-Kontextdaten.

## Tests
- `xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16'`

Closes #152