### PR TITLE
[codex] Make CloudKit sync robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Die App bleibt klar migränefokussiert, fühlt sich aber bewusst nicht wie ein m
 ### 4. Optionale Synchronisation
 
 - iCloud-Sync aktivieren oder deaktivieren
+- Sync bewusst manuell über `Jetzt synchronisieren` auslösen; CloudKit-Subscriptions werden derzeit nicht angelegt
 - Konflikte einsehen und auflösen
 - Cloud-Daten und Sync-Protokoll prüfen
 
@@ -71,7 +72,7 @@ Die App bleibt klar migränefokussiert, fühlt sich aber bewusst nicht wie ein m
 - Wetterdaten über `Apple Weather` mit `WeatherKit`
 - optionale Apple-Health-Integration mit versionsabhängigen HealthKit-Datentypen
 - PDF-Erzeugung lokal auf dem Gerät
-- optionale iCloud-Synchronisation getrennt von der lokalen Kernnutzung
+- optionale, manuell ausgelöste iCloud-Synchronisation getrennt von der lokalen Kernnutzung
 
 Interne technische Kennungen wie `Symi`, Bundle-ID, Scheme und iCloud-Container bestehen derzeit aus Migrations- und Release-Gründen weiter, obwohl die sichtbare Produktmarke auf `Symi` umgestellt ist.
 

--- a/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
+++ b/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
@@ -269,9 +269,19 @@ enum CloudKitRecordCodec {
         return decoder
     }()
 
-    static func record(for envelope: SyncDocumentEnvelope, zoneID: CKRecordZone.ID, existingSystemFields: Data?) -> CKRecord? {
+    static func record(
+        for envelope: SyncDocumentEnvelope,
+        zoneID: CKRecordZone.ID,
+        existingSystemFields: Data?,
+        systemFieldsFallback: ((CloudKitRecordSystemFieldsFallbackReason) -> Void)? = nil
+    ) -> CKRecord? {
         let recordID = CKRecord.ID(recordName: envelope.documentID, zoneID: zoneID)
-        let record = existingRecord(for: recordID, systemFields: existingSystemFields) ?? CKRecord(
+        let restoredRecord = existingRecord(for: recordID, systemFields: existingSystemFields)
+        if let fallbackReason = restoredRecord.fallbackReason {
+            systemFieldsFallback?(fallbackReason)
+        }
+
+        let record = restoredRecord.record ?? CKRecord(
             recordType: SyncConfiguration.recordType,
             recordID: recordID
         )
@@ -310,19 +320,39 @@ enum CloudKitRecordCodec {
         return archiver.encodedData
     }
 
-    private static func existingRecord(for recordID: CKRecord.ID, systemFields: Data?) -> CKRecord? {
+    private static func existingRecord(
+        for recordID: CKRecord.ID,
+        systemFields: Data?
+    ) -> (record: CKRecord?, fallbackReason: CloudKitRecordSystemFieldsFallbackReason?) {
         guard let systemFields else {
-            return nil
+            return (nil, nil)
         }
 
-        let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: systemFields)
-        unarchiver?.requiresSecureCoding = true
-        let record = CKRecord(coder: unarchiver!)
-        unarchiver?.finishDecoding()
+        let unarchiver: NSKeyedUnarchiver
+        do {
+            unarchiver = try NSKeyedUnarchiver(forReadingFrom: systemFields)
+        } catch {
+            return (nil, .undecodableArchive)
+        }
+
+        unarchiver.requiresSecureCoding = true
+        let record = CKRecord(coder: unarchiver)
+        unarchiver.finishDecoding()
+
         guard let record else {
-            return nil
+            return (nil, .missingRecord)
         }
 
-        return record.recordID == recordID ? record : CKRecord(recordType: SyncConfiguration.recordType, recordID: recordID)
+        guard record.recordID == recordID else {
+            return (nil, .recordIDMismatch)
+        }
+
+        return (record, nil)
     }
+}
+
+enum CloudKitRecordSystemFieldsFallbackReason: String, Equatable, Sendable {
+    case undecodableArchive
+    case missingRecord
+    case recordIDMismatch
 }

--- a/Symi/Sources/Features/Sync/SyncCoordinator.swift
+++ b/Symi/Sources/Features/Sync/SyncCoordinator.swift
@@ -20,12 +20,18 @@ final class SyncCoordinator {
     private var provider: (any SyncProvider)?
     private let zoneID = SyncConfiguration.zoneID
 
-    init(modelContainer: ModelContainer, appLogStore: AppLogStore, autostart: Bool = true) {
+    init(
+        modelContainer: ModelContainer,
+        appLogStore: AppLogStore,
+        stateStore: SyncStateStore = SyncStateStore(),
+        deviceID: String? = nil,
+        autostart: Bool = true
+    ) {
         self.modelContainer = modelContainer
-        self.stateStore = SyncStateStore()
+        self.stateStore = stateStore
         self.appLogStore = appLogStore
         self.repository = LocalSyncRepository(modelContainer: modelContainer)
-        self.deviceID = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        self.deviceID = deviceID ?? UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
 
         guard autostart else {
             return
@@ -144,7 +150,11 @@ final class SyncCoordinator {
     func resolveConflictUsingRemote(_ conflict: SyncConflict) async {
         do {
             try repository.apply(remote: conflict.remote)
-            await stateStore.saveShadow(SyncShadow(envelope: conflict.remote), for: conflict.documentID)
+            let recordSystemFields = await stateStore.shadow(for: conflict.documentID)?.recordSystemFields
+            await stateStore.saveShadow(
+                SyncShadow(envelope: conflict.remote, recordSystemFields: recordSystemFields),
+                for: conflict.documentID
+            )
             await stateStore.removeConflict(documentID: conflict.documentID)
             conflicts = await stateStore.conflicts()
             await log(level: .info, operation: "coordinator.resolveConflictUsingRemote", message: "Cloud-Version eines Konflikts wurde übernommen.", metadata: [
@@ -207,11 +217,26 @@ final class SyncCoordinator {
 
         let shadow = await stateStore.shadow(for: envelope.documentID)
         await log(level: .debug, operation: "coordinator.recordForUpload", message: "Lokales Dokument wird für Upload codiert.", metadata: metadata(for: envelope, shadow: shadow))
-        return CloudKitRecordCodec.record(
+        var systemFieldsFallbackReason: CloudKitRecordSystemFieldsFallbackReason?
+        let record = CloudKitRecordCodec.record(
             for: envelope,
             zoneID: zoneID,
-            existingSystemFields: shadow?.recordSystemFields
+            existingSystemFields: shadow?.recordSystemFields,
+            systemFieldsFallback: { reason in
+                systemFieldsFallbackReason = reason
+            }
         )
+
+        if let systemFieldsFallbackReason {
+            await log(level: .warning, operation: "coordinator.recordForUpload.systemFieldsFallback", message: "Gespeicherte CloudKit-Systemfelder konnten nicht genutzt werden; Upload wird mit frischem Record vorbereitet.", metadata: [
+                "documentID": envelope.documentID,
+                "entityType": envelope.entityType.rawValue,
+                "recordID": recordID.recordName,
+                "reason": systemFieldsFallbackReason.rawValue
+            ])
+        }
+
+        return record
     }
 
     private func handleProviderEvent(_ event: SyncProviderEvent) async {
@@ -269,7 +294,7 @@ final class SyncCoordinator {
         status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
     }
 
-    private func applyRemoteRecord(_ record: CKRecord) async {
+    func applyRemoteRecord(_ record: CKRecord) async {
         guard let remoteEnvelope = CloudKitRecordCodec.envelope(from: record) else {
             await log(level: .warning, operation: "coordinator.applyRemoteRecord.decodeFailed", message: "Remote-Record konnte nicht decodiert werden.", metadata: [
                 "recordID": record.recordID.recordName
@@ -297,16 +322,19 @@ final class SyncCoordinator {
                     remote: remoteEnvelope
                 )
 
-                try repository.apply(remote: merge.merged)
-                await stateStore.saveShadow(
-                    SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
-                    for: remoteEnvelope.documentID
-                )
-
                 if merge.conflicts.isEmpty {
+                    try repository.apply(remote: merge.merged)
+                    await stateStore.saveShadow(
+                        SyncShadow(envelope: merge.merged, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
+                        for: remoteEnvelope.documentID
+                    )
                     await stateStore.removeConflict(documentID: remoteEnvelope.documentID)
-                    await log(level: .info, operation: "coordinator.applyRemoteRecord.merged", message: "Remote-Record wurde konfliktfrei gemergt.", metadata: metadata(for: remoteEnvelope, shadow: shadow))
+                    await log(level: .info, operation: "coordinator.applyRemoteRecord.merged", message: "Remote-Record wurde konfliktfrei gemergt.", metadata: metadata(for: merge.merged, shadow: shadow))
                 } else {
+                    await stateStore.saveShadow(
+                        SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
+                        for: remoteEnvelope.documentID
+                    )
                     await stateStore.saveConflict(
                         SyncConflict(
                             documentID: remoteEnvelope.documentID,
@@ -317,7 +345,7 @@ final class SyncCoordinator {
                             conflictingFields: merge.conflicts
                         )
                     )
-                    await log(level: .warning, operation: "coordinator.applyRemoteRecord.conflict", message: "Beim Mergen wurde ein Konflikt erkannt.", metadata: [
+                    await log(level: .warning, operation: "coordinator.applyRemoteRecord.conflict", message: "Beim Mergen wurde ein Konflikt erkannt. Der lokale Stand bleibt bis zur Entscheidung unverändert.", metadata: [
                         "documentID": remoteEnvelope.documentID,
                         "entityType": remoteEnvelope.entityType.rawValue,
                         "fields": merge.conflicts.joined(separator: ",")
@@ -464,8 +492,12 @@ final class SyncCoordinator {
             effectiveState = baseState
         }
 
-        let localCount = (try? repository.allEnvelopes(deviceID: deviceID).count) ?? 0
-        let unsyncedCount = max(localCount - shadows.count, 0) + conflictList.count
+        let localEnvelopes = (try? repository.allEnvelopes(deviceID: deviceID)) ?? []
+        let conflictIDs = Set(conflictList.map(\.documentID))
+        let unsyncedCount = localEnvelopes
+            .filter { !conflictIDs.contains($0.documentID) }
+            .filter { shadows[$0.documentID]?.envelope != $0 }
+            .count + conflictList.count
 
         return SyncStatusSnapshot(
             state: effectiveState,

--- a/Symi/Sources/Features/Sync/SyncStateStore.swift
+++ b/Symi/Sources/Features/Sync/SyncStateStore.swift
@@ -4,7 +4,6 @@ import Foundation
 enum SyncConfiguration {
     static let containerIdentifier = "iCloud.eu.mpwg.MigraineTracker"
     static let zoneName = "MigraineTrackerSync"
-    static let subscriptionID = "MigraineTrackerSyncSubscription"
     static let recordType = "SyncDocument"
 
     static let zoneID = CKRecordZone.ID(
@@ -29,12 +28,12 @@ actor SyncStateStore {
     private let decoder = JSONDecoder()
     private var state: PersistedSyncState
 
-    init(fileManager: FileManager = .default) {
+    init(fileManager: FileManager = .default, baseDirectoryURL: URL? = nil) {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         decoder.dateDecodingStrategy = .iso8601
         encoder.dateEncodingStrategy = .iso8601
 
-        let baseURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        let baseURL = baseDirectoryURL ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory
         let directory = baseURL.appendingPathComponent("Symi", isDirectory: true)
         try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -1,8 +1,94 @@
+import CloudKit
 import Foundation
+import SwiftData
 import Testing
 @testable import Symi
 
 struct SyncMergeEngineTests {
+    @Test
+    @MainActor
+    func corruptRecordSystemFieldsPrepareFreshRecordWithoutCrashing() throws {
+        let envelope = definitionEnvelope(name: "Sumatriptan", deletedAt: nil)
+        let corruptSystemFields = Data("keine gültigen Systemfelder".utf8)
+        var fallbackReason: CloudKitRecordSystemFieldsFallbackReason?
+
+        let record = try #require(
+            CloudKitRecordCodec.record(
+                for: envelope,
+                zoneID: syncTestZoneID,
+                existingSystemFields: corruptSystemFields,
+                systemFieldsFallback: { reason in
+                    fallbackReason = reason
+                }
+            )
+        )
+
+        #expect(record.recordID.recordName == envelope.documentID)
+        #expect(fallbackReason == .undecodableArchive)
+        #expect(CloudKitRecordCodec.envelope(from: record) == envelope)
+    }
+
+    @Test
+    @MainActor
+    func conflictFreeRemoteMergeStoresShadowForMergedState() async throws {
+        let stack = try makeSyncTestStack()
+        let documentID = try insertBaseEpisode(in: stack.container)
+        let baseEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        await stack.stateStore.saveShadow(SyncShadow(envelope: baseEnvelope), for: documentID)
+
+        try updateEpisode(documentID: documentID, in: stack.container) { episode in
+            episode.notes = "lokal"
+            episode.updatedAt = Date(timeIntervalSince1970: 2_000)
+        }
+        let localEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        let remoteEnvelope = episodeEnvelope(from: baseEnvelope, modifiedAt: Date(timeIntervalSince1970: 3_000)) { payload in
+            payload.symptoms = ["Aura", "Übelkeit"]
+        }
+        let expectedMerge = SyncMergeEngine.merge(base: baseEnvelope, local: localEnvelope, remote: remoteEnvelope)
+
+        await stack.coordinator.applyRemoteRecord(try record(from: remoteEnvelope))
+
+        let storedEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        let storedShadow = await stack.stateStore.shadow(for: documentID)
+        let conflicts = await stack.stateStore.conflicts()
+
+        #expect(expectedMerge.conflicts.isEmpty)
+        #expect(storedEnvelope == expectedMerge.merged)
+        #expect(storedShadow?.envelope == expectedMerge.merged)
+        #expect(conflicts.isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func conflictRemoteMergeLeavesLocalStateUntouchedUntilResolution() async throws {
+        let stack = try makeSyncTestStack()
+        let documentID = try insertBaseEpisode(in: stack.container)
+        let baseEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        await stack.stateStore.saveShadow(SyncShadow(envelope: baseEnvelope), for: documentID)
+
+        try updateEpisode(documentID: documentID, in: stack.container) { episode in
+            episode.notes = "lokal"
+            episode.updatedAt = Date(timeIntervalSince1970: 2_000)
+        }
+        let localEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        let remoteEnvelope = episodeEnvelope(from: baseEnvelope, modifiedAt: Date(timeIntervalSince1970: 3_000)) { payload in
+            payload.notes = "remote"
+        }
+
+        await stack.coordinator.applyRemoteRecord(try record(from: remoteEnvelope))
+
+        let storedEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        let storedShadow = await stack.stateStore.shadow(for: documentID)
+        let conflicts = await stack.stateStore.conflicts()
+        let conflict = try #require(conflicts.first)
+
+        #expect(storedEnvelope == localEnvelope)
+        #expect(storedShadow?.envelope == remoteEnvelope)
+        #expect(conflict.local == localEnvelope)
+        #expect(conflict.remote == remoteEnvelope)
+        #expect(conflict.conflictingFields == ["notes"])
+    }
+
     @Test
     func remoteOnlyChangeIsApplied() {
         let base = episodeEnvelope(notes: "alt", symptoms: ["Aura"])
@@ -121,7 +207,7 @@ struct SyncMergeEngineTests {
 private func episodeEnvelope(
     notes: String,
     symptoms: [String],
-        medications: [SyncMedicationEntryPayload] = []
+    medications: [SyncMedicationEntryPayload] = []
 ) -> SyncDocumentEnvelope {
     SyncDocumentEnvelope(
         documentID: "episode-1",
@@ -149,11 +235,116 @@ private func episodeEnvelope(
     )
 }
 
+private let syncTestDeviceID = "device-local"
+private let syncTestZoneID = CKRecordZone.ID(zoneName: "SyncTests", ownerName: CKCurrentUserDefaultName)
+
+@MainActor
+private func makeSyncTestStack() throws -> (
+    container: ModelContainer,
+    stateStore: SyncStateStore,
+    coordinator: SyncCoordinator,
+    repository: LocalSyncRepository
+) {
+    let schema = Schema(versionedSchema: SymiSchemaV5.self)
+    let configuration = ModelConfiguration(
+        "sync-tests-\(UUID().uuidString)",
+        schema: schema,
+        isStoredInMemoryOnly: true,
+        cloudKitDatabase: .none
+    )
+    let container = try ModelContainer(for: schema, configurations: [configuration])
+    let stateStore = SyncStateStore(baseDirectoryURL: try makeTemporaryDirectory())
+    let appLogStore = AppLogStore(baseDirectoryURL: try makeTemporaryDirectory())
+    let coordinator = SyncCoordinator(
+        modelContainer: container,
+        appLogStore: appLogStore,
+        stateStore: stateStore,
+        deviceID: syncTestDeviceID,
+        autostart: false
+    )
+    let repository = LocalSyncRepository(modelContainer: container)
+
+    return (container, stateStore, coordinator, repository)
+}
+
+@MainActor
+private func insertBaseEpisode(in container: ModelContainer) throws -> String {
+    let episodeID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE") ?? UUID()
+    let context = ModelContext(container)
+    let episode = Episode(
+        id: episodeID,
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        updatedAt: Date(timeIntervalSince1970: 1_000),
+        type: .migraine,
+        intensity: 5,
+        notes: "alt",
+        symptoms: ["Aura"]
+    )
+    context.insert(episode)
+    try context.save()
+    return "episode:\(episodeID.uuidString)"
+}
+
+@MainActor
+private func updateEpisode(
+    documentID: String,
+    in container: ModelContainer,
+    apply: (Episode) -> Void
+) throws {
+    let episodeID = try #require(UUID(uuidString: documentID.replacingOccurrences(of: "episode:", with: "")))
+    let context = ModelContext(container)
+    let episodes = try context.fetch(FetchDescriptor<Episode>())
+    let episode = try #require(episodes.first { $0.id == episodeID })
+    apply(episode)
+    try context.save()
+}
+
+private func episodeEnvelope(
+    from base: SyncDocumentEnvelope,
+    modifiedAt: Date,
+    update: (inout SyncEpisodePayload) -> Void
+) -> SyncDocumentEnvelope {
+    var envelope = base
+    envelope.modifiedAt = modifiedAt
+    envelope.authorDeviceID = "device-remote"
+
+    guard case .episode(var payload) = envelope.payload else {
+        return envelope
+    }
+
+    update(&payload)
+    envelope.payload = .episode(payload)
+    return envelope
+}
+
+@MainActor
+private func record(from envelope: SyncDocumentEnvelope) throws -> CKRecord {
+    try #require(
+        CloudKitRecordCodec.record(
+            for: envelope,
+            zoneID: syncTestZoneID,
+            existingSystemFields: nil
+        )
+    )
+}
+
+@MainActor
+private func requireEnvelope(from repository: LocalSyncRepository, documentID: String) throws -> SyncDocumentEnvelope {
+    let envelope = try repository.envelope(documentID: documentID, deviceID: syncTestDeviceID)
+    return try #require(envelope)
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+
 private func definitionEnvelope(name: String, deletedAt: Date?) -> SyncDocumentEnvelope {
     SyncDocumentEnvelope(
         documentID: "definition-1",
         entityType: .medicationDefinition,
-        modifiedAt: .now,
+        modifiedAt: Date(timeIntervalSince1970: 1_000),
         authorDeviceID: "device-a",
         deletedAt: deletedAt,
         payload: .medicationDefinition(


### PR DESCRIPTION
## Summary

Closes #153.

- makes CloudKit `recordSystemFields` decoding defensive so corrupted local metadata no longer crashes upload preparation
- stores the local shadow from the actually applied merged envelope after conflict-free remote merges
- keeps local records untouched when a conflict is detected until the user resolves it
- removes the unused subscription configuration and documents that sync is currently manually triggered
- adds regression coverage for corrupt system fields, merged shadow consistency, and conflict behavior

## Root Cause

Upload preparation force-unwrapped an optional `NSKeyedUnarchiver` while restoring saved CloudKit system fields. Separately, remote merges saved the shadow from the remote envelope even when the local store received `merge.merged`, so shadow state could diverge from the local record.

## Validation

- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=26.4.1'`