### PR TITLE
[codex] Implement entry flow state navigation

### DIFF
--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -71,6 +71,14 @@ final class AppContainer {
         )
     }
 
+    func makeEntryFlowCoordinator(initialStartedAt: Date? = nil) -> EntryFlowCoordinator {
+        EntryFlowCoordinator(
+            initialStartedAt: initialStartedAt,
+            episodeRepository: episodeRepository,
+            medicationRepository: medicationCatalogRepository
+        )
+    }
+
     func makeHistoryController() -> HistoryController {
         HistoryController(repository: episodeRepository)
     }

--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -252,9 +252,7 @@ struct ScreenshotRootView: View {
             }
 
         case .newEntry:
-            NavigationStack {
-                EpisodeEditorView(appContainer: appContainer, initialStartedAt: seed.newEntryDate)
-            }
+            EntryFlowCoordinatorView(appContainer: appContainer, initialStartedAt: seed.newEntryDate)
 
         case .history:
             NavigationStack {

--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Observation
+
+enum EntryFlowStep: String, CaseIterable, Identifiable, Hashable, Sendable {
+    case headache
+    case medication
+    case triggers
+    case note
+    case review
+
+    var id: String { rawValue }
+}
+
+enum EntryFlowSaveResult: Equatable, Sendable {
+    case saved(UUID)
+    case failed(String)
+}
+
+@MainActor
+@Observable
+final class EntryFlowCoordinator {
+    static let steps: [EntryFlowStep] = [.headache, .medication, .triggers, .note, .review]
+
+    let symptomOptions = [
+        "Übelkeit",
+        "Lichtempfindlichkeit",
+        "Geräuschempfindlichkeit",
+        "Aura",
+        "Kiefer-/Aufbissschmerz",
+        "Pochen, Pulsieren"
+    ]
+    let triggerOptions = ["Stress", "Schlafmangel", "Alkohol", "Menstruation", "Bildschirmzeit"]
+    let medicationController: EpisodeMedicationSelectionController
+
+    var draft: EpisodeDraft
+    var path: [EntryFlowStep] = []
+    var isSaving = false
+    var saveResult: EntryFlowSaveResult?
+    private(set) var isCancelled = false
+
+    private let initialStartedAt: Date?
+    private let saveEpisodeUseCase: SaveEpisodeUseCase
+
+    init(
+        initialStartedAt: Date? = nil,
+        episodeRepository: EpisodeRepository,
+        medicationRepository: MedicationCatalogRepository,
+        autoloadMedications: Bool = true
+    ) {
+        self.initialStartedAt = initialStartedAt
+        self.draft = EpisodeDraft.makeNew(initialStartedAt: initialStartedAt)
+        self.medicationController = EpisodeMedicationSelectionController(
+            medicationRepository: medicationRepository,
+            autoload: autoloadMedications
+        )
+        self.saveEpisodeUseCase = SaveEpisodeUseCase(repository: episodeRepository)
+    }
+
+    var currentStep: EntryFlowStep {
+        path.last ?? .headache
+    }
+
+    var currentStepIndex: Int {
+        Self.steps.firstIndex(of: currentStep).map { $0 + 1 } ?? 1
+    }
+
+    var canSkipCurrentStep: Bool {
+        switch currentStep {
+        case .headache, .review:
+            false
+        case .medication, .triggers, .note:
+            true
+        }
+    }
+
+    func continueToNextStep() {
+        applyStepSideEffects()
+
+        guard let nextStep else {
+            return
+        }
+
+        path.append(nextStep)
+    }
+
+    func skipCurrentStep() {
+        guard canSkipCurrentStep else {
+            return
+        }
+
+        switch currentStep {
+        case .medication:
+            medicationController.resetSelections()
+            draft.medications = []
+        case .triggers:
+            draft.selectedTriggers = []
+        case .note:
+            draft.notes = ""
+        case .headache, .review:
+            break
+        }
+
+        continueToNextStep()
+    }
+
+    func edit(_ step: EntryFlowStep) {
+        guard step != .review, Self.steps.contains(step) else {
+            return
+        }
+
+        path = Array(Self.steps.prefix { $0 != step }.dropFirst()) + [step]
+    }
+
+    func cancel() {
+        isCancelled = true
+        path = []
+        draft = EpisodeDraft.makeNew(initialStartedAt: initialStartedAt)
+        medicationController.resetSelections()
+        saveResult = nil
+        isSaving = false
+    }
+
+    func saveHeadacheOnly() {
+        save(resetAfterSave: false)
+    }
+
+    func saveFromReview() {
+        save(resetAfterSave: false)
+    }
+
+    private var nextStep: EntryFlowStep? {
+        guard let currentIndex = Self.steps.firstIndex(of: currentStep) else {
+            return nil
+        }
+
+        let nextIndex = currentIndex + 1
+        guard nextIndex < Self.steps.count else {
+            return nil
+        }
+
+        return Self.steps[nextIndex]
+    }
+
+    private func applyStepSideEffects() {
+        if currentStep == .medication {
+            draft.medications = medicationController.medications
+        }
+    }
+
+    private func save(resetAfterSave: Bool) {
+        guard !isSaving else {
+            return
+        }
+
+        applyStepSideEffects()
+        saveResult = nil
+        isSaving = true
+
+        Task {
+            defer { isSaving = false }
+
+            do {
+                let savedID = try await saveEpisodeUseCase.execute(draft, weatherSnapshot: nil, healthContext: nil)
+                saveResult = .saved(savedID)
+
+                if resetAfterSave {
+                    cancel()
+                    isCancelled = false
+                }
+            } catch {
+                saveResult = .failed(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/Symi/Sources/Features/Capture/CaptureView.swift
+++ b/Symi/Sources/Features/Capture/CaptureView.swift
@@ -4,7 +4,7 @@ struct CaptureView: View {
     let appContainer: AppContainer
 
     var body: some View {
-        EpisodeEditorView(appContainer: appContainer)
+        EntryFlowCoordinatorView(appContainer: appContainer)
     }
 }
 

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -1,0 +1,493 @@
+import SwiftUI
+
+struct EntryFlowCoordinatorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var coordinator: EntryFlowCoordinator
+
+    private let onSaved: (() -> Void)?
+
+    init(
+        appContainer: AppContainer,
+        initialStartedAt: Date? = nil,
+        onSaved: (() -> Void)? = nil
+    ) {
+        self.onSaved = onSaved
+        _coordinator = State(
+            initialValue: appContainer.makeEntryFlowCoordinator(initialStartedAt: initialStartedAt)
+        )
+    }
+
+    var body: some View {
+        @Bindable var coordinator = coordinator
+
+        NavigationStack(path: $coordinator.path) {
+            EntryHeadacheStepView(coordinator: coordinator)
+                .navigationDestination(for: EntryFlowStep.self) { step in
+                    destination(for: step)
+                }
+        }
+        .toolbar {
+            ToolbarItem(placement: dismissButtonPlacement) {
+                Button("Abbrechen", action: cancel)
+            }
+        }
+        .alert("Eintrag gespeichert", isPresented: savedBinding) {
+            Button("OK", role: .cancel, action: finishAfterSave)
+        } message: {
+            Text("Dein Eintrag wurde lokal gespeichert.")
+        }
+        .alert("Eintrag konnte nicht gespeichert werden", isPresented: failedBinding) {
+            Button("OK", role: .cancel) {
+                coordinator.saveResult = nil
+            }
+        } message: {
+            if case .failed(let message) = coordinator.saveResult {
+                Text(message)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func destination(for step: EntryFlowStep) -> some View {
+        switch step {
+        case .headache:
+            EntryHeadacheStepView(coordinator: coordinator)
+        case .medication:
+            EntryMedicationStepView(coordinator: coordinator)
+        case .triggers:
+            EntryTriggersStepView(coordinator: coordinator)
+        case .note:
+            EntryNoteStepView(coordinator: coordinator)
+        case .review:
+            EntryReviewStepView(coordinator: coordinator)
+        }
+    }
+
+    private var savedBinding: Binding<Bool> {
+        Binding(
+            get: {
+                if case .saved = coordinator.saveResult {
+                    return true
+                }
+                return false
+            },
+            set: { isPresented in
+                if !isPresented {
+                    coordinator.saveResult = nil
+                }
+            }
+        )
+    }
+
+    private var failedBinding: Binding<Bool> {
+        Binding(
+            get: {
+                if case .failed = coordinator.saveResult {
+                    return true
+                }
+                return false
+            },
+            set: { isPresented in
+                if !isPresented {
+                    coordinator.saveResult = nil
+                }
+            }
+        )
+    }
+
+    private var dismissButtonPlacement: ToolbarItemPlacement {
+        #if targetEnvironment(macCatalyst)
+        .topBarTrailing
+        #else
+        .topBarLeading
+        #endif
+    }
+
+    private func cancel() {
+        coordinator.cancel()
+        dismiss()
+    }
+
+    private func finishAfterSave() {
+        coordinator.saveResult = nil
+        onSaved?()
+        dismiss()
+    }
+}
+
+private struct EntryHeadacheStepView: View {
+    let coordinator: EntryFlowCoordinator
+
+    var body: some View {
+        @Bindable var coordinator = coordinator
+
+        Form {
+            EntryStepHeader(step: .headache, currentIndex: coordinator.currentStepIndex)
+
+            Section {
+                Picker("Typ", selection: $coordinator.draft.type) {
+                    ForEach(EpisodeType.allCases) { episodeType in
+                        Text(episodeType.rawValue).tag(episodeType)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("Intensität")
+                        Spacer()
+                        Text("\(coordinator.draft.intensity)/10")
+                            .font(.headline)
+                            .monospacedDigit()
+                    }
+
+                    IntensityPicker(value: Binding(
+                        get: { Double(coordinator.draft.intensity) },
+                        set: { coordinator.draft.intensity = Int($0) }
+                    ))
+                }
+            } header: {
+                Text("Skala")
+            } footer: {
+                Text("Du kannst nach diesem Schritt direkt speichern oder weitere Details ergänzen.")
+            }
+
+            Section("Zeitpunkt") {
+                DatePicker(
+                    "Beginn",
+                    selection: $coordinator.draft.startedAt,
+                    in: ...Date.now,
+                    displayedComponents: [.date, .hourAndMinute]
+                )
+            }
+
+            EntryStepActions(
+                isSaving: coordinator.isSaving,
+                showsSkip: false,
+                primaryTitle: "Weiter",
+                secondaryTitle: "Nur Kopfschmerz speichern",
+                onPrimary: coordinator.continueToNextStep,
+                onSecondary: coordinator.saveHeadacheOnly,
+                onSkip: {}
+            )
+        }
+        .navigationTitle("Kopfschmerz")
+        .brandGroupedScreen()
+    }
+}
+
+private struct EntryMedicationStepView: View {
+    let coordinator: EntryFlowCoordinator
+
+    var body: some View {
+        @Bindable var medicationController = coordinator.medicationController
+
+        Form {
+            EntryStepHeader(step: .medication, currentIndex: coordinator.currentStepIndex)
+
+            Section("Medikamente") {
+                TextField("Medikament nach Namen filtern", text: $medicationController.searchText)
+                    .textInputAutocapitalization(.words)
+                    .autocorrectionDisabled()
+
+                MedicationDefinitionGroupList(controller: coordinator.medicationController)
+                SelectedMedicationsSection(controller: coordinator.medicationController)
+
+                Button {
+                    medicationController.presentEditor(for: nil)
+                } label: {
+                    Label("Eigenes Medikament hinzufügen", systemImage: "plus")
+                }
+            }
+
+            EntryStepActions(
+                isSaving: coordinator.isSaving,
+                showsSkip: true,
+                primaryTitle: "Weiter",
+                secondaryTitle: nil,
+                onPrimary: coordinator.continueToNextStep,
+                onSecondary: nil,
+                onSkip: coordinator.skipCurrentStep
+            )
+        }
+        .navigationTitle("Medikation")
+        .brandGroupedScreen()
+        .sheet(item: $medicationController.customMedicationEditor) { editorState in
+            NavigationStack {
+                CustomMedicationEditorSheet(
+                    state: editorState,
+                    onCancel: { medicationController.customMedicationEditor = nil },
+                    onSave: { draft in
+                        Task {
+                            await medicationController.saveCustomMedication(from: draft)
+                        }
+                    }
+                )
+            }
+            .presentationDetents([.medium])
+        }
+        .alert(
+            "Eigenes Medikament löschen?",
+            isPresented: Binding(
+                get: { medicationController.pendingMedicationDeletion != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        medicationController.pendingMedicationDeletion = nil
+                    }
+                }
+            ),
+            presenting: medicationController.pendingMedicationDeletion
+        ) { definition in
+            Button("Löschen", role: .destructive) {
+                Task {
+                    await medicationController.deleteCustomMedication(definition)
+                }
+            }
+            Button("Abbrechen", role: .cancel) {
+                medicationController.pendingMedicationDeletion = nil
+            }
+        } message: { definition in
+            Text("\(definition.name) wird aus SwiftData entfernt.")
+        }
+    }
+}
+
+private struct EntryTriggersStepView: View {
+    let coordinator: EntryFlowCoordinator
+
+    var body: some View {
+        @Bindable var coordinator = coordinator
+
+        Form {
+            EntryStepHeader(step: .triggers, currentIndex: coordinator.currentStepIndex)
+
+            Section("Was könnte mitspielen?") {
+                MultiSelectGrid(
+                    options: coordinator.triggerOptions,
+                    selection: $coordinator.draft.selectedTriggers,
+                    colorToken: NewEntryStepCatalog.metadata(for: .triggers).colorToken,
+                    accessibilityPrefix: "Auslöser"
+                )
+            }
+
+            EntryStepActions(
+                isSaving: coordinator.isSaving,
+                showsSkip: true,
+                primaryTitle: "Weiter",
+                secondaryTitle: nil,
+                onPrimary: coordinator.continueToNextStep,
+                onSecondary: nil,
+                onSkip: coordinator.skipCurrentStep
+            )
+        }
+        .navigationTitle("Auslöser")
+        .brandGroupedScreen()
+    }
+}
+
+private struct EntryNoteStepView: View {
+    let coordinator: EntryFlowCoordinator
+
+    var body: some View {
+        @Bindable var coordinator = coordinator
+
+        Form {
+            EntryStepHeader(step: .note, currentIndex: coordinator.currentStepIndex)
+
+            Section("Notiz") {
+                TextField("Kurz notieren, was auffällt", text: $coordinator.draft.notes, axis: .vertical)
+                    .lineLimit(3 ... 8)
+            }
+
+            Section("Weitere Angaben") {
+                TextField("Schmerzlokalisation", text: $coordinator.draft.painLocation)
+                TextField("Schmerzcharakter", text: $coordinator.draft.painCharacter)
+                TextField("Funktionelle Einschränkung", text: $coordinator.draft.functionalImpact)
+
+                Picker("Menstruationsstatus", selection: $coordinator.draft.menstruationStatus) {
+                    ForEach(MenstruationStatus.allCases) { status in
+                        Text(status.rawValue).tag(status)
+                    }
+                }
+
+                Toggle("Ende angeben", isOn: $coordinator.draft.endedAtEnabled.animation())
+                if coordinator.draft.endedAtEnabled {
+                    DatePicker(
+                        "Ende",
+                        selection: $coordinator.draft.endedAt,
+                        in: coordinator.draft.startedAt...,
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+                }
+            }
+
+            EntryStepActions(
+                isSaving: coordinator.isSaving,
+                showsSkip: true,
+                primaryTitle: "Weiter",
+                secondaryTitle: nil,
+                onPrimary: coordinator.continueToNextStep,
+                onSecondary: nil,
+                onSkip: coordinator.skipCurrentStep
+            )
+        }
+        .navigationTitle("Notiz")
+        .brandGroupedScreen()
+    }
+}
+
+private struct EntryReviewStepView: View {
+    let coordinator: EntryFlowCoordinator
+
+    var body: some View {
+        Form {
+            EntryStepHeader(step: .review, currentIndex: coordinator.currentStepIndex)
+
+            Section("Zusammenfassung") {
+                EntryReviewRow(title: "Kopfschmerz", value: "\(coordinator.draft.type.rawValue), \(coordinator.draft.intensity)/10") {
+                    coordinator.edit(.headache)
+                }
+
+                EntryReviewRow(title: "Medikation", value: medicationSummary) {
+                    coordinator.edit(.medication)
+                }
+
+                EntryReviewRow(title: "Auslöser", value: listSummary(coordinator.draft.selectedTriggers)) {
+                    coordinator.edit(.triggers)
+                }
+
+                EntryReviewRow(title: "Notiz", value: coordinator.draft.notes.isEmpty ? "Keine Notiz" : coordinator.draft.notes) {
+                    coordinator.edit(.note)
+                }
+            }
+
+            Section {
+                PrimaryButton(action: coordinator.saveFromReview) {
+                    if coordinator.isSaving {
+                        ProgressView()
+                    } else {
+                        Text("Eintrag speichern")
+                    }
+                }
+                .disabled(coordinator.isSaving)
+            }
+        }
+        .navigationTitle("Eintrag prüfen")
+        .brandGroupedScreen()
+    }
+
+    private var medicationSummary: String {
+        let selected = coordinator.medicationController.selectedMedications
+        guard !selected.isEmpty else {
+            return "Keine Medikation"
+        }
+
+        return selected.map { medication in
+            medication.quantity > 1 ? "\(medication.name) x\(medication.quantity)" : medication.name
+        }.joined(separator: ", ")
+    }
+
+    private func listSummary(_ values: Set<String>) -> String {
+        guard !values.isEmpty else {
+            return "Nichts ausgewählt"
+        }
+
+        return values.sorted().joined(separator: ", ")
+    }
+}
+
+private struct EntryStepHeader: View {
+    let step: EntryFlowStep
+    let currentIndex: Int
+
+    var body: some View {
+        let metadata = NewEntryStepCatalog.metadata(for: step.catalogID)
+
+        Section {
+            HStack(spacing: 14) {
+                StepIcon(metadata)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(metadata.title)
+                        .font(.headline)
+                    Text(metadata.subline)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 4)
+
+            ProgressIndicator(currentStep: currentIndex, colorToken: metadata.colorToken)
+        }
+    }
+}
+
+private struct EntryStepActions: View {
+    let isSaving: Bool
+    let showsSkip: Bool
+    let primaryTitle: String
+    let secondaryTitle: String?
+    let onPrimary: () -> Void
+    let onSecondary: (() -> Void)?
+    let onSkip: () -> Void
+
+    var body: some View {
+        Section {
+            PrimaryButton(action: onPrimary) {
+                Text(primaryTitle)
+            }
+            .disabled(isSaving)
+
+            if let secondaryTitle, let onSecondary {
+                Button(secondaryTitle, action: onSecondary)
+                    .disabled(isSaving)
+            }
+
+            if showsSkip {
+                Button("Überspringen", action: onSkip)
+                    .disabled(isSaving)
+            }
+        }
+    }
+}
+
+private struct EntryReviewRow: View {
+    let title: String
+    let value: String
+    let onEdit: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(value)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+
+            Spacer(minLength: 12)
+
+            Button("Bearbeiten", action: onEdit)
+                .font(.subheadline.weight(.semibold))
+        }
+    }
+}
+
+private extension EntryFlowStep {
+    var catalogID: NewEntryStepID {
+        switch self {
+        case .headache:
+            .headache
+        case .medication:
+            .medication
+        case .triggers:
+            .triggers
+        case .note:
+            .note
+        case .review:
+            .review
+        }
+    }
+}

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -305,7 +305,7 @@ private struct EpisodeMedicationSection: View {
     }
 }
 
-private struct MedicationDefinitionGroupList: View {
+struct MedicationDefinitionGroupList: View {
     let controller: EpisodeMedicationSelectionController
 
     var body: some View {
@@ -366,7 +366,7 @@ private struct MedicationDefinitionGroupView: View {
     }
 }
 
-private struct SelectedMedicationsSection: View {
+struct SelectedMedicationsSection: View {
     let controller: EpisodeMedicationSelectionController
 
     var body: some View {
@@ -489,7 +489,7 @@ private enum AppSettingsURL {
     static let url = URL(string: "app-settings:")!
 }
 
-private struct IntensityPicker: View {
+struct IntensityPicker: View {
     @Binding var value: Double
 
     var body: some View {
@@ -609,7 +609,7 @@ private struct MedicationDefinitionRow: View {
     }
 }
 
-private struct CustomMedicationEditorSheet: View {
+struct CustomMedicationEditorSheet: View {
     let state: CustomMedicationEditorSheetState
     let onCancel: () -> Void
     let onSave: (CustomMedicationDefinitionDraft) -> Void

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -38,11 +38,9 @@ struct HomeView: View {
             await reloadAll()
         }
         .fullScreenCover(isPresented: $isPresentingEpisodeEditor) {
-            NavigationStack {
-                EpisodeEditorView(appContainer: appContainer) {
-                    isPresentingEpisodeEditor = false
-                    Task { await reloadOverview() }
-                }
+            EntryFlowCoordinatorView(appContainer: appContainer) {
+                isPresentingEpisodeEditor = false
+                Task { await reloadOverview() }
             }
         }
     }

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import Symi
+
+@MainActor
+struct EntryFlowCoordinatorTests {
+    @Test
+    func flowHasFiveOrderedSteps() {
+        #expect(EntryFlowCoordinator.steps == [.headache, .medication, .triggers, .note, .review])
+    }
+
+    @Test
+    func draftSurvivesForwardAndBackNavigation() {
+        let coordinator = makeCoordinator()
+        coordinator.draft.intensity = 8
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+
+        coordinator.path.removeLast()
+
+        #expect(coordinator.currentStep == .medication)
+        #expect(coordinator.draft.intensity == 8)
+    }
+
+    @Test
+    func optionalStepsCanBeSkipped() {
+        let coordinator = makeCoordinator()
+        coordinator.continueToNextStep()
+
+        coordinator.skipCurrentStep()
+
+        #expect(coordinator.currentStep == .triggers)
+        #expect(coordinator.draft.medications.isEmpty)
+    }
+
+    @Test
+    func reviewEditNavigatesBackToSelectedStep() {
+        let coordinator = makeCoordinator()
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+
+        coordinator.edit(.triggers)
+
+        #expect(coordinator.currentStep == .triggers)
+        #expect(coordinator.path == [.medication, .triggers])
+    }
+
+    @Test
+    func headacheStepCanSaveDirectlyThroughRepository() async throws {
+        let repository = EntryFlowEpisodeRepositoryMock()
+        let coordinator = makeCoordinator(repository: repository)
+        coordinator.draft.type = .headache
+        coordinator.draft.intensity = 4
+
+        coordinator.saveHeadacheOnly()
+        try await waitForSaveResult(on: coordinator)
+
+        #expect(repository.lastSavedDraft?.type == .headache)
+        #expect(repository.lastSavedDraft?.intensity == 4)
+        #expect(coordinator.saveResult == .saved(repository.savedID))
+    }
+
+    @Test
+    func cancelDiscardsDraftExplicitly() {
+        let coordinator = makeCoordinator()
+        coordinator.draft.intensity = 9
+        coordinator.continueToNextStep()
+
+        coordinator.cancel()
+
+        #expect(coordinator.isCancelled)
+        #expect(coordinator.path.isEmpty)
+        #expect(coordinator.draft.intensity == 5)
+    }
+
+    private func makeCoordinator(
+        repository: EntryFlowEpisodeRepositoryMock = EntryFlowEpisodeRepositoryMock(),
+        medicationRepository: EntryFlowMedicationRepositoryMock = EntryFlowMedicationRepositoryMock()
+    ) -> EntryFlowCoordinator {
+        EntryFlowCoordinator(
+            episodeRepository: repository,
+            medicationRepository: medicationRepository,
+            autoloadMedications: false
+        )
+    }
+
+    private func waitForSaveResult(on coordinator: EntryFlowCoordinator) async throws {
+        for _ in 0 ..< 100 {
+            if coordinator.saveResult != nil {
+                return
+            }
+            await Task.yield()
+        }
+
+        throw EntryFlowTestError.timedOut
+    }
+}
+
+private enum EntryFlowTestError: Error {
+    case timedOut
+}
+
+private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, @unchecked Sendable {
+    let savedID = UUID()
+    var lastSavedDraft: EpisodeDraft?
+
+    func fetchRecent() throws -> [EpisodeRecord] { [] }
+    func fetchByDay(_ day: Date) throws -> [EpisodeRecord] { [] }
+    func fetchByMonth(_ month: Date) throws -> [EpisodeRecord] { [] }
+    func load(id: UUID) throws -> EpisodeRecord? { nil }
+
+    func save(draft: EpisodeDraft, weatherSnapshot: WeatherSnapshotData?, healthContext: HealthContextSnapshotData?) throws -> UUID {
+        lastSavedDraft = draft
+        return savedID
+    }
+
+    func softDelete(id: UUID) throws {}
+    func restore(id: UUID) throws {}
+    func fetchDeleted() throws -> [EpisodeRecord] { [] }
+}
+
+private final class EntryFlowMedicationRepositoryMock: MedicationCatalogRepository, @unchecked Sendable {
+    func fetchDefinitions(searchText: String?) throws -> [MedicationDefinitionRecord] { [] }
+
+    func saveCustomDefinition(_ draft: CustomMedicationDefinitionDraft) throws -> MedicationDefinitionRecord {
+        MedicationDefinitionRecord(
+            catalogKey: draft.id,
+            groupID: "custom-medications",
+            groupTitle: "Eigene Medikamente",
+            groupFooter: nil,
+            name: draft.name,
+            category: draft.category,
+            suggestedDosage: draft.dosage,
+            sortOrder: 1,
+            isCustom: true,
+            isDeleted: false
+        )
+    }
+
+    func softDeleteCustomDefinition(catalogKey: String) throws {}
+    func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord] { [] }
+}


### PR DESCRIPTION
## Summary

- Adds a dedicated `EntryFlowCoordinator` with shared draft state for the new five-step entry flow.
- Adds a `NavigationStack`-based entry flow UI with next, skip, direct headache save, review editing, and explicit cancel handling.
- Routes new-entry entry points through the new flow while keeping the existing episode editor for edit flows.
- Adds unit tests for flow ordering, draft persistence, optional skips, review editing, cancellation, and direct save through the repository.

Closes #165.

## Validation

- `xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16'`