### PR TITLE
[codex] Implement headache entry step

### DIFF
--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -16,6 +16,50 @@ enum EntryFlowSaveResult: Equatable, Sendable {
     case failed(String)
 }
 
+enum EntryStartedAtPreset: String, CaseIterable, Identifiable, Sendable {
+    case now
+    case oneHourAgo
+    case todayMorning
+    case custom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .now:
+            "Jetzt"
+        case .oneHourAgo:
+            "Vor 1 Std."
+        case .todayMorning:
+            "Heute Morgen"
+        case .custom:
+            "Anderer Zeitpunkt"
+        }
+    }
+
+    var dayPart: EpisodeDayPart? {
+        switch self {
+        case .todayMorning:
+            .morgens
+        case .now, .oneHourAgo, .custom:
+            nil
+        }
+    }
+
+    func date(relativeTo referenceDate: Date, calendar: Calendar = .current) -> Date {
+        switch self {
+        case .now:
+            referenceDate
+        case .oneHourAgo:
+            referenceDate.addingTimeInterval(-3_600)
+        case .todayMorning:
+            calendar.date(bySettingHour: 8, minute: 0, second: 0, of: referenceDate) ?? referenceDate
+        case .custom:
+            referenceDate
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class EntryFlowCoordinator {
@@ -30,6 +74,7 @@ final class EntryFlowCoordinator {
         "Pochen, Pulsieren"
     ]
     let triggerOptions = ["Stress", "Schlafmangel", "Alkohol", "Menstruation", "Bildschirmzeit"]
+    let painLocationOptions = ["Stirn", "Schläfen", "Nacken", "Einseitig", "Überall"]
     let medicationController: EpisodeMedicationSelectionController
 
     var draft: EpisodeDraft
@@ -128,6 +173,10 @@ final class EntryFlowCoordinator {
         save(resetAfterSave: false)
     }
 
+    func selectStartedAtPreset(_ preset: EntryStartedAtPreset, calendar: Calendar = .current) {
+        draft.startedAt = preset.date(relativeTo: .now, calendar: calendar)
+    }
+
     private var nextStep: EntryFlowStep? {
         guard let currentIndex = Self.steps.firstIndex(of: currentStep) else {
             return nil
@@ -142,6 +191,12 @@ final class EntryFlowCoordinator {
     }
 
     private func applyStepSideEffects() {
+        if currentStep == .headache {
+            draft.type = .headache
+            draft.intensity = draft.normalizedIntensity
+            draft.painLocation = draft.resolvedPainLocation
+        }
+
         if currentStep == .medication {
             draft.medications = medicationController.medications
         }

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -49,6 +49,47 @@ struct EpisodeRecord: Identifiable, Equatable, Sendable {
     nonisolated var isDeleted: Bool {
         deletedAt != nil
     }
+
+    nonisolated var dayPart: EpisodeDayPart {
+        EpisodeDayPart(date: startedAt)
+    }
+}
+
+enum EpisodeDayPart: String, CaseIterable, Codable, Identifiable, Sendable {
+    case morgens
+    case mittags
+    case abends
+    case nacht
+
+    nonisolated var id: String { rawValue }
+
+    nonisolated init(date: Date, calendar: Calendar = .current) {
+        let hour = calendar.component(.hour, from: date)
+
+        switch hour {
+        case 5 ..< 11:
+            self = .morgens
+        case 11 ..< 17:
+            self = .mittags
+        case 17 ..< 22:
+            self = .abends
+        default:
+            self = .nacht
+        }
+    }
+
+    nonisolated var label: String {
+        switch self {
+        case .morgens:
+            "Morgens"
+        case .mittags:
+            "Mittags"
+        case .abends:
+            "Abends"
+        case .nacht:
+            "Nacht"
+        }
+    }
 }
 
 struct MedicationDefinitionRecord: Identifiable, Equatable, Sendable {
@@ -166,6 +207,7 @@ struct EpisodeDraft: Equatable, Sendable {
     nonisolated var endedAtEnabled: Bool
     nonisolated var endedAt: Date
     nonisolated var painLocation: String
+    nonisolated var selectedPainLocations: Set<String> = []
     nonisolated var painCharacter: String
     nonisolated var notes: String
     nonisolated var functionalImpact: String
@@ -184,6 +226,7 @@ struct EpisodeDraft: Equatable, Sendable {
             endedAtEnabled: false,
             endedAt: startedAt,
             painLocation: "",
+            selectedPainLocations: [],
             painCharacter: "",
             notes: "",
             functionalImpact: "",
@@ -203,6 +246,7 @@ struct EpisodeDraft: Equatable, Sendable {
             endedAtEnabled: record.endedAt != nil,
             endedAt: record.endedAt ?? record.startedAt,
             painLocation: record.painLocation,
+            selectedPainLocations: Self.decodePainLocations(record.painLocation),
             painCharacter: record.painCharacter,
             notes: record.notes,
             functionalImpact: record.functionalImpact,
@@ -211,6 +255,33 @@ struct EpisodeDraft: Equatable, Sendable {
             selectedTriggers: Set(record.triggers),
             medications: record.medications.map(MedicationSelectionDraft.init(record:))
         )
+    }
+
+    nonisolated var resolvedPainLocation: String {
+        let selectedSummary = selectedPainLocations.sorted().joined(separator: ", ")
+        guard !selectedSummary.isEmpty else {
+            return painLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return selectedSummary
+    }
+
+    nonisolated var normalizedIntensity: Int {
+        min(max(intensity, 1), 10)
+    }
+
+    nonisolated private static func decodePainLocations(_ value: String) -> Set<String> {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return []
+        }
+
+        let parts = trimmed
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        return Set(parts.isEmpty ? [trimmed] : parts)
     }
 }
 

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -118,6 +118,8 @@ struct EntryFlowCoordinatorView: View {
 private struct EntryHeadacheStepView: View {
     let coordinator: EntryFlowCoordinator
 
+    @State private var selectedStartedAtPreset: EntryStartedAtPreset = .now
+
     var body: some View {
         @Bindable var coordinator = coordinator
 
@@ -125,40 +127,42 @@ private struct EntryHeadacheStepView: View {
             EntryStepHeader(step: .headache, currentIndex: coordinator.currentStepIndex)
 
             Section {
-                Picker("Typ", selection: $coordinator.draft.type) {
-                    ForEach(EpisodeType.allCases) { episodeType in
-                        Text(episodeType.rawValue).tag(episodeType)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Text("Intensität")
-                        Spacer()
-                        Text("\(coordinator.draft.intensity)/10")
-                            .font(.headline)
-                            .monospacedDigit()
-                    }
-
-                    IntensityPicker(value: Binding(
-                        get: { Double(coordinator.draft.intensity) },
-                        set: { coordinator.draft.intensity = Int($0) }
-                    ))
-                }
+                HeadacheIntensityCard(intensity: $coordinator.draft.intensity)
             } header: {
-                Text("Skala")
+                Text("Intensität")
             } footer: {
                 Text("Du kannst nach diesem Schritt direkt speichern oder weitere Details ergänzen.")
             }
 
+            Section("Schmerzort") {
+                MultiSelectGrid(
+                    options: coordinator.painLocationOptions,
+                    selection: $coordinator.draft.selectedPainLocations,
+                    colorToken: NewEntryStepCatalog.metadata(for: .headache).colorToken,
+                    accessibilityPrefix: "Schmerzort"
+                )
+            }
+
             Section("Zeitpunkt") {
+                Picker("Zeitpunkt", selection: $selectedStartedAtPreset) {
+                    ForEach(EntryStartedAtPreset.allCases) { preset in
+                        Text(preset.title).tag(preset)
+                    }
+                }
+                .pickerStyle(.inline)
+                .onChange(of: selectedStartedAtPreset) { _, preset in
+                    if preset != .custom {
+                        coordinator.selectStartedAtPreset(preset)
+                    }
+                }
+
                 DatePicker(
                     "Beginn",
                     selection: $coordinator.draft.startedAt,
                     in: ...Date.now,
                     displayedComponents: [.date, .hourAndMinute]
                 )
+                .disabled(selectedStartedAtPreset != .custom)
             }
 
             EntryStepActions(
@@ -173,6 +177,65 @@ private struct EntryHeadacheStepView: View {
         }
         .navigationTitle("Kopfschmerz")
         .brandGroupedScreen()
+        .onAppear {
+            coordinator.draft.type = .headache
+            coordinator.draft.intensity = coordinator.draft.normalizedIntensity
+        }
+    }
+}
+
+private struct HeadacheIntensityCard: View {
+    @Binding var intensity: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Wie stark ist es gerade?")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(summary)
+                        .font(.title2.weight(.bold))
+                        .monospacedDigit()
+                }
+
+                Spacer()
+
+                Text("\(normalizedIntensity)")
+                    .font(.system(size: 44, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(AppTheme.symiCoral)
+            }
+
+            IntensityPicker(value: Binding(
+                get: { Double(normalizedIntensity) },
+                set: { intensity = Int($0) }
+            ))
+        }
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Intensität \(normalizedIntensity) von 10, \(intensityLabel)")
+    }
+
+    private var normalizedIntensity: Int {
+        min(max(intensity, 1), 10)
+    }
+
+    private var summary: String {
+        "\(normalizedIntensity)/10 · \(intensityLabel)"
+    }
+
+    private var intensityLabel: String {
+        switch normalizedIntensity {
+        case 1 ... 3:
+            "Leicht"
+        case 4 ... 6:
+            "Mittel"
+        case 7 ... 8:
+            "Stark"
+        default:
+            "Sehr stark"
+        }
     }
 }
 

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -170,13 +170,13 @@ private struct EpisodeScaleSection: View {
                 HStack {
                     Text("Intensität")
                     Spacer()
-                    Text("\(draft.intensity)/10")
+                    Text("\(draft.normalizedIntensity)/10")
                         .font(.headline)
                         .monospacedDigit()
                 }
 
                 IntensityPicker(value: Binding(
-                    get: { Double(draft.intensity) },
+                    get: { Double(draft.normalizedIntensity) },
                     set: { draft.intensity = Int($0) }
                 ))
             }
@@ -494,7 +494,7 @@ struct IntensityPicker: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Slider(value: $value, in: 0 ... 10, step: 1)
+            Slider(value: $value, in: 1 ... 10, step: 1)
                 .tint(AppTheme.symiCoral)
                 .accessibilityLabel("Intensität")
                 .accessibilityValue("\(Int(value)) von 10")

--- a/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
+++ b/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
@@ -289,6 +289,7 @@ struct MultiSelectGrid: View {
                     toggle(option)
                 }
                 .accessibilityLabel("\(accessibilityPrefix): \(option)")
+                .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
                 .accessibilityHint(isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus.")
             }
         }

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -65,7 +65,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
         {
             target = existing
         } else {
-            target = Episode(startedAt: draft.startedAt, intensity: draft.intensity)
+            target = Episode(startedAt: draft.startedAt, intensity: draft.normalizedIntensity)
             context.insert(target)
         }
 
@@ -73,8 +73,8 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
         target.type = draft.type
         target.startedAt = draft.startedAt
         target.endedAt = draft.endedAtEnabled ? draft.endedAt : nil
-        target.intensity = draft.intensity
-        target.painLocation = draft.painLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+        target.intensity = draft.normalizedIntensity
+        target.painLocation = draft.resolvedPainLocation
         target.painCharacter = draft.painCharacter.trimmingCharacters(in: .whitespacesAndNewlines)
         target.notes = draft.notes.trimmingCharacters(in: .whitespacesAndNewlines)
         target.functionalImpact = draft.functionalImpact.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -51,15 +51,43 @@ struct EntryFlowCoordinatorTests {
     func headacheStepCanSaveDirectlyThroughRepository() async throws {
         let repository = EntryFlowEpisodeRepositoryMock()
         let coordinator = makeCoordinator(repository: repository)
-        coordinator.draft.type = .headache
+        coordinator.draft.type = .unclear
         coordinator.draft.intensity = 4
+        coordinator.draft.selectedPainLocations = ["Schläfen", "Stirn"]
 
         coordinator.saveHeadacheOnly()
         try await waitForSaveResult(on: coordinator)
 
         #expect(repository.lastSavedDraft?.type == .headache)
         #expect(repository.lastSavedDraft?.intensity == 4)
+        #expect(repository.lastSavedDraft?.resolvedPainLocation == "Schläfen, Stirn")
         #expect(coordinator.saveResult == .saved(repository.savedID))
+    }
+
+    @Test
+    func headacheStepNormalizesNewIntensityRange() async throws {
+        let repository = EntryFlowEpisodeRepositoryMock()
+        let coordinator = makeCoordinator(repository: repository)
+        coordinator.draft.intensity = 0
+
+        coordinator.saveHeadacheOnly()
+        try await waitForSaveResult(on: coordinator)
+
+        #expect(repository.lastSavedDraft?.intensity == 1)
+    }
+
+    @Test
+    func startedAtPresetsUpdateDraftTime() {
+        let calendar = Calendar(identifier: .gregorian)
+        let coordinator = makeCoordinator()
+        let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 26, hour: 15, minute: 30))!
+
+        coordinator.selectStartedAtPreset(.todayMorning, calendar: calendar)
+        let morningHour = calendar.component(.hour, from: coordinator.draft.startedAt)
+
+        #expect(EntryStartedAtPreset.todayMorning.dayPart == .morgens)
+        #expect(morningHour == 8)
+        #expect(EntryStartedAtPreset.oneHourAgo.date(relativeTo: referenceDate, calendar: calendar) == referenceDate.addingTimeInterval(-3_600))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Implementiert den Pflicht-Step `Kopfschmerz` für den neuen Eintrag.
- Ergänzt Intensität `1...10`, Schmerzort-Mehrfachauswahl, Zeitpunkt-Presets und Direkt-Speichern nach Schritt 1.
- Führt `EpisodeDayPart` als Core-Datenvertrag ein und verbessert VoiceOver-Auswahlzustände.

Closes #166

## Validation
- `xcodebuild test -scheme SymiTests -project Symi.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16'`