### PR TITLE
Trigger und Wetterkontext für neue Einträge

### DIFF
--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -73,7 +73,7 @@ final class EntryFlowCoordinator {
         "Kiefer-/Aufbissschmerz",
         "Pochen, Pulsieren"
     ]
-    let triggerOptions = ["Stress", "Schlafmangel", "Alkohol", "Menstruation", "Bildschirmzeit"]
+    let triggerOptions = ["Wetter", "Stress", "Erhöhte Arbeitsbelastung", "Regel", "Schlafdauer", "Sport", "Ernährung", "Bildschirmzeit", "Bewegung", "Flüssigkeit"]
     let painLocationOptions = ["Stirn", "Schläfen", "Nacken", "Einseitig", "Überall"]
     let medicationController: EpisodeMedicationSelectionController
 

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -9,9 +9,48 @@ struct WeatherRecord: Equatable, Sendable {
     nonisolated let precipitation: Double?
     nonisolated let weatherCode: Int?
     nonisolated let source: String
+    nonisolated let dayRangeStart: Date?
+    nonisolated let dayRangeEnd: Date?
+    nonisolated let contextRangeStart: Date?
+    nonisolated let contextRangeEnd: Date?
+    nonisolated let contextPoints: [WeatherContextPointData]
+
+    nonisolated init(
+        recordedAt: Date,
+        condition: String,
+        temperature: Double?,
+        humidity: Double?,
+        pressure: Double?,
+        precipitation: Double?,
+        weatherCode: Int?,
+        source: String,
+        dayRangeStart: Date? = nil,
+        dayRangeEnd: Date? = nil,
+        contextRangeStart: Date? = nil,
+        contextRangeEnd: Date? = nil,
+        contextPoints: [WeatherContextPointData] = []
+    ) {
+        self.recordedAt = recordedAt
+        self.condition = condition
+        self.temperature = temperature
+        self.humidity = humidity
+        self.pressure = pressure
+        self.precipitation = precipitation
+        self.weatherCode = weatherCode
+        self.source = source
+        self.dayRangeStart = dayRangeStart
+        self.dayRangeEnd = dayRangeEnd
+        self.contextRangeStart = contextRangeStart
+        self.contextRangeEnd = contextRangeEnd
+        self.contextPoints = contextPoints
+    }
 
     nonisolated var isLegacySnapshot: Bool {
         source.localizedCaseInsensitiveContains("legacy") || source.localizedCaseInsensitiveContains("manuell")
+    }
+
+    nonisolated var hasExtendedContext: Bool {
+        contextRangeStart != nil || contextRangeEnd != nil || !contextPoints.isEmpty
     }
 }
 

--- a/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
@@ -340,7 +340,7 @@ final class EpisodeEditorController {
         "Kiefer-/Aufbissschmerz",
         "Pochen, Pulsieren"
     ]
-    let triggerOptions = ["Stress", "Schlafmangel", "Alkohol", "Menstruation", "Bildschirmzeit"]
+    let triggerOptions = ["Wetter", "Stress", "Erhöhte Arbeitsbelastung", "Regel", "Schlafdauer", "Sport", "Ernährung", "Bildschirmzeit", "Bewegung", "Flüssigkeit"]
     let medicationController: EpisodeMedicationSelectionController
 
     var draft: EpisodeDraft

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -324,13 +324,17 @@ private struct EntryTriggersStepView: View {
         Form {
             EntryStepHeader(step: .triggers, currentIndex: coordinator.currentStepIndex)
 
-            Section("Was könnte mitspielen?") {
+            Section {
                 MultiSelectGrid(
                     options: coordinator.triggerOptions,
                     selection: $coordinator.draft.selectedTriggers,
                     colorToken: NewEntryStepCatalog.metadata(for: .triggers).colorToken,
                     accessibilityPrefix: "Auslöser"
                 )
+            } header: {
+                Text("Was könnte eine Rolle gespielt haben?")
+            } footer: {
+                Text("Du kannst mehrere auswählen. Wetter als Auslöser bleibt getrennt vom automatisch gespeicherten Wetterkontext.")
             }
 
             EntryStepActions(

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -39,7 +39,8 @@ struct EpisodeEditorView: View {
                 colorToken: NewEntryStepCatalog.metadata(for: .headache).colorToken
             )
             EpisodeTagSection(
-                title: "Was könnte mitspielen?",
+                title: "Was könnte eine Rolle gespielt haben?",
+                footer: "Du kannst mehrere auswählen. Wetter als Auslöser bleibt getrennt vom automatisch gespeicherten Wetterkontext.",
                 options: controller.triggerOptions,
                 selection: $controller.draft.selectedTriggers,
                 colorToken: NewEntryStepCatalog.metadata(for: .triggers).colorToken
@@ -207,12 +208,13 @@ private struct EpisodeTimingSection: View {
 
 private struct EpisodeTagSection: View {
     let title: String
+    var footer: String?
     let options: [String]
     @Binding var selection: Set<String>
     let colorToken: NewEntryStepColorToken
 
     var body: some View {
-        Section(title) {
+        Section {
             MultiSelectGrid(
                 options: options,
                 selection: $selection,
@@ -220,6 +222,12 @@ private struct EpisodeTagSection: View {
                 accessibilityPrefix: title
             )
             .formAlignedRow()
+        } header: {
+            Text(title)
+        } footer: {
+            if let footer {
+                Text(footer)
+            }
         }
     }
 }
@@ -276,7 +284,7 @@ private struct EpisodeWeatherSection: View {
         } header: {
             Text("Wetter")
         } footer: {
-            Text("Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.")
+            Text("Das Wetter wird als Kontext mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.")
         }
     }
 }

--- a/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
+++ b/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
@@ -46,7 +46,7 @@ enum NewEntryStepCatalog {
         NewEntryStepMetadata(
             id: .triggers,
             title: "Auslöser",
-            subline: "Was könnte mitspielen?",
+            subline: "Was könnte eine Rolle gespielt haben?",
             symbolName: "brain.head.profile",
             colorToken: .blue,
             status: nil

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -358,7 +358,7 @@ struct MedicationEntryPayload: @preconcurrency Codable, Sendable {
     }
 }
 
-struct WeatherSnapshotPayload: @preconcurrency Codable, Sendable {
+struct WeatherSnapshotPayload: Codable, Sendable {
     let id: UUID
     let recordedAt: Date
     let temperature: Double?
@@ -368,6 +368,28 @@ struct WeatherSnapshotPayload: @preconcurrency Codable, Sendable {
     let precipitation: Double?
     let weatherCode: Int?
     let source: String
+    let dayRangeStart: Date?
+    let dayRangeEnd: Date?
+    let contextRangeStart: Date?
+    let contextRangeEnd: Date?
+    let contextPoints: [WeatherContextPointData]
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case recordedAt
+        case temperature
+        case condition
+        case humidity
+        case pressure
+        case precipitation
+        case weatherCode
+        case source
+        case dayRangeStart
+        case dayRangeEnd
+        case contextRangeStart
+        case contextRangeEnd
+        case contextPoints
+    }
 
     nonisolated init(snapshot: WeatherSnapshot) {
         self.id = snapshot.id
@@ -379,6 +401,29 @@ struct WeatherSnapshotPayload: @preconcurrency Codable, Sendable {
         self.precipitation = snapshot.precipitation
         self.weatherCode = snapshot.weatherCode
         self.source = snapshot.source
+        self.dayRangeStart = snapshot.dayRangeStart
+        self.dayRangeEnd = snapshot.dayRangeEnd
+        self.contextRangeStart = snapshot.contextRangeStart
+        self.contextRangeEnd = snapshot.contextRangeEnd
+        self.contextPoints = snapshot.contextPoints
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.recordedAt = try container.decode(Date.self, forKey: .recordedAt)
+        self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
+        self.condition = try container.decode(String.self, forKey: .condition)
+        self.humidity = try container.decodeIfPresent(Double.self, forKey: .humidity)
+        self.pressure = try container.decodeIfPresent(Double.self, forKey: .pressure)
+        self.precipitation = try container.decodeIfPresent(Double.self, forKey: .precipitation)
+        self.weatherCode = try container.decodeIfPresent(Int.self, forKey: .weatherCode)
+        self.source = try container.decode(String.self, forKey: .source)
+        self.dayRangeStart = try container.decodeIfPresent(Date.self, forKey: .dayRangeStart)
+        self.dayRangeEnd = try container.decodeIfPresent(Date.self, forKey: .dayRangeEnd)
+        self.contextRangeStart = try container.decodeIfPresent(Date.self, forKey: .contextRangeStart)
+        self.contextRangeEnd = try container.decodeIfPresent(Date.self, forKey: .contextRangeEnd)
+        self.contextPoints = try container.decodeIfPresent([WeatherContextPointData].self, forKey: .contextPoints) ?? []
     }
 
     nonisolated func makeModel(for episode: Episode) -> WeatherSnapshot {
@@ -392,6 +437,11 @@ struct WeatherSnapshotPayload: @preconcurrency Codable, Sendable {
             precipitation: precipitation,
             weatherCode: weatherCode,
             source: source,
+            dayRangeStart: dayRangeStart,
+            dayRangeEnd: dayRangeEnd,
+            contextRangeStart: contextRangeStart,
+            contextRangeEnd: contextRangeEnd,
+            contextPointsStorage: WeatherSnapshot.encodeContextPoints(contextPoints),
             episode: episode
         )
     }
@@ -405,6 +455,11 @@ struct WeatherSnapshotPayload: @preconcurrency Codable, Sendable {
         snapshot.precipitation = precipitation
         snapshot.weatherCode = weatherCode
         snapshot.source = source
+        snapshot.dayRangeStart = dayRangeStart
+        snapshot.dayRangeEnd = dayRangeEnd
+        snapshot.contextRangeStart = contextRangeStart
+        snapshot.contextRangeEnd = contextRangeEnd
+        snapshot.contextPoints = contextPoints
         snapshot.episode = episode
     }
 }

--- a/Symi/Sources/Features/Export/PDFExportWriter.swift
+++ b/Symi/Sources/Features/Export/PDFExportWriter.swift
@@ -177,6 +177,18 @@ nonisolated enum PDFExportWriter {
             if !weather.source.isEmpty {
                 parts.append(formatted("Quelle: %@", weather.source))
             }
+            if let start = weather.contextRangeStart, let end = weather.contextRangeEnd {
+                parts.append(
+                    formatted(
+                        "Kontext: %@ bis %@",
+                        start.formatted(date: .numeric, time: .shortened),
+                        end.formatted(date: .numeric, time: .shortened)
+                    )
+                )
+            }
+            if !weather.contextPoints.isEmpty {
+                parts.append(formatted("%lld stündliche Kontextwerte", Int64(weather.contextPoints.count)))
+            }
 
             if !parts.isEmpty {
                 lines.append(formatted("Wetter: %@", parts.joined(separator: ", ")))

--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -182,6 +182,12 @@ struct EpisodeDetailView: View {
                         if !weatherSnapshot.source.isEmpty {
                             detailRow("Quelle", weatherSnapshot.source)
                         }
+                        if let contextRange = weatherContextRangeText(for: weatherSnapshot) {
+                            detailRow("Kontextzeitraum", contextRange)
+                        }
+                        if !weatherSnapshot.contextPoints.isEmpty {
+                            detailRow("Kontextwerte", "\(weatherSnapshot.contextPoints.count) stündliche Werte")
+                        }
                         detailRow("Erfasst", weatherSnapshot.recordedAt.formatted(date: .abbreviated, time: .shortened))
                         WeatherAttributionView()
                             .padding(.vertical, 4)
@@ -284,6 +290,12 @@ struct EpisodeDetailView: View {
                             }
                             if let precipitation = weatherSnapshot.precipitation {
                                 detailValue("Niederschlag", precipitation.formatted(.number.precision(.fractionLength(1))) + " mm")
+                            }
+                            if let contextRange = weatherContextRangeText(for: weatherSnapshot) {
+                                detailValue("Kontextzeitraum", contextRange)
+                            }
+                            if !weatherSnapshot.contextPoints.isEmpty {
+                                detailValue("Kontextwerte", "\(weatherSnapshot.contextPoints.count) stündliche Werte")
                             }
                             detailValue("Erfasst", weatherSnapshot.recordedAt.formatted(date: .abbreviated, time: .shortened))
                             WeatherAttributionView()
@@ -400,6 +412,14 @@ struct EpisodeDetailView: View {
         }
 
         return "\(medication.category.rawValue) · \(medication.dosage)"
+    }
+
+    private func weatherContextRangeText(for weather: WeatherRecord) -> String? {
+        guard let start = weather.contextRangeStart, let end = weather.contextRangeEnd else {
+            return nil
+        }
+
+        return "\(start.formatted(date: .abbreviated, time: .shortened)) bis \(end.formatted(date: .abbreviated, time: .shortened))"
     }
 
     private func deleteEpisode() {

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -363,7 +363,12 @@ private extension WeatherRecord {
             pressure: snapshot.pressure,
             precipitation: snapshot.precipitation,
             weatherCode: snapshot.weatherCode,
-            source: snapshot.source
+            source: snapshot.source,
+            dayRangeStart: snapshot.dayRangeStart,
+            dayRangeEnd: snapshot.dayRangeEnd,
+            contextRangeStart: snapshot.contextRangeStart,
+            contextRangeEnd: snapshot.contextRangeEnd,
+            contextPoints: snapshot.contextPoints
         )
     }
 }

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -98,6 +98,11 @@ struct LocalSyncRepository {
                 precipitation: weather.precipitation,
                 weatherCode: weather.weatherCode,
                 source: weather.source,
+                dayRangeStart: weather.dayRangeStart,
+                dayRangeEnd: weather.dayRangeEnd,
+                contextRangeStart: weather.contextRangeStart,
+                contextRangeEnd: weather.contextRangeEnd,
+                contextPointsStorage: WeatherSnapshot.encodeContextPoints(weather.contextPoints),
                 episode: target
             )
         }
@@ -191,7 +196,12 @@ extension Episode {
                             pressure: $0.pressure,
                             precipitation: $0.precipitation,
                             weatherCode: $0.weatherCode,
-                            source: $0.source
+                            source: $0.source,
+                            dayRangeStart: $0.dayRangeStart,
+                            dayRangeEnd: $0.dayRangeEnd,
+                            contextRangeStart: $0.contextRangeStart,
+                            contextRangeEnd: $0.contextRangeEnd,
+                            contextPoints: $0.contextPoints
                         )
                     }
                 )

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -241,7 +241,49 @@ extension WeatherSnapshot {
             precipitation: snapshot.precipitation,
             weatherCode: snapshot.weatherCode,
             source: snapshot.source,
+            dayRangeStart: snapshot.dayRangeStart,
+            dayRangeEnd: snapshot.dayRangeEnd,
+            contextRangeStart: snapshot.contextRangeStart,
+            contextRangeEnd: snapshot.contextRangeEnd,
+            contextPointsStorage: Self.encodeContextPoints(snapshot.contextPoints),
             episode: episode
         )
+    }
+}
+
+extension WeatherSnapshot {
+    var contextPoints: [WeatherContextPointData] {
+        get { Self.decodeContextPoints(contextPointsStorage) }
+        set { contextPointsStorage = Self.encodeContextPoints(newValue) }
+    }
+
+    static func encodeContextPoints(_ points: [WeatherContextPointData]) -> String {
+        guard !points.isEmpty, let data = try? JSONEncoder.weatherContextEncoder.encode(points) else {
+            return ""
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func decodeContextPoints(_ storage: String) -> [WeatherContextPointData] {
+        guard !storage.isEmpty, let data = storage.data(using: .utf8) else {
+            return []
+        }
+        return (try? JSONDecoder.weatherContextDecoder.decode([WeatherContextPointData].self, from: data)) ?? []
+    }
+}
+
+private extension JSONEncoder {
+    nonisolated static var weatherContextEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    nonisolated static var weatherContextDecoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
     }
 }

--- a/Symi/Sources/Models/ExportModels.swift
+++ b/Symi/Sources/Models/ExportModels.swift
@@ -39,16 +39,21 @@ nonisolated struct EpisodeExportRecord: Identifiable, Sendable {
                 effectiveness: $0.effectiveness.rawValue
             )
         }
-        self.weather = episode.weatherSnapshot.map {
-            WeatherLine(
-                condition: $0.condition,
-                temperature: $0.temperature,
-                humidity: $0.humidity,
-                pressure: $0.pressure,
-                precipitation: $0.precipitation,
-                weatherCode: $0.weatherCode,
-                source: $0.source
+        if let weatherSnapshot = episode.weatherSnapshot {
+            self.weather = WeatherLine(
+                condition: weatherSnapshot.condition,
+                temperature: weatherSnapshot.temperature,
+                humidity: weatherSnapshot.humidity,
+                pressure: weatherSnapshot.pressure,
+                precipitation: weatherSnapshot.precipitation,
+                weatherCode: weatherSnapshot.weatherCode,
+                source: weatherSnapshot.source,
+                contextRangeStart: weatherSnapshot.contextRangeStart,
+                contextRangeEnd: weatherSnapshot.contextRangeEnd,
+                contextPoints: weatherSnapshot.contextPoints
             )
+        } else {
+            self.weather = nil
         }
         self.healthContext = healthContext.map(HealthLine.init)
     }
@@ -70,6 +75,9 @@ nonisolated struct EpisodeExportRecord: Identifiable, Sendable {
         let precipitation: Double?
         let weatherCode: Int?
         let source: String
+        let contextRangeStart: Date?
+        let contextRangeEnd: Date?
+        let contextPoints: [WeatherContextPointData]
     }
 
     nonisolated struct HealthLine: Sendable {

--- a/Symi/Sources/Models/ModelSchema.swift
+++ b/Symi/Sources/Models/ModelSchema.swift
@@ -1048,6 +1048,11 @@ enum SymiSchemaV5: VersionedSchema {
         var precipitation: Double?
         var weatherCode: Int?
         var source: String
+        var dayRangeStart: Date?
+        var dayRangeEnd: Date?
+        var contextRangeStart: Date?
+        var contextRangeEnd: Date?
+        var contextPointsStorage: String
         var episode: Episode?
 
         init(
@@ -1060,6 +1065,11 @@ enum SymiSchemaV5: VersionedSchema {
             precipitation: Double? = nil,
             weatherCode: Int? = nil,
             source: String = "",
+            dayRangeStart: Date? = nil,
+            dayRangeEnd: Date? = nil,
+            contextRangeStart: Date? = nil,
+            contextRangeEnd: Date? = nil,
+            contextPointsStorage: String = "",
             episode: Episode? = nil
         ) {
             self.id = id
@@ -1071,6 +1081,11 @@ enum SymiSchemaV5: VersionedSchema {
             self.precipitation = precipitation
             self.weatherCode = weatherCode
             self.source = source
+            self.dayRangeStart = dayRangeStart
+            self.dayRangeEnd = dayRangeEnd
+            self.contextRangeStart = contextRangeStart
+            self.contextRangeEnd = contextRangeEnd
+            self.contextPointsStorage = contextPointsStorage
             self.episode = episode
         }
     }

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -235,6 +235,28 @@ public struct SyncWeatherSnapshotPayload: Codable, Equatable, Sendable {
     public nonisolated var precipitation: Double?
     public nonisolated var weatherCode: Int?
     public nonisolated var source: String
+    public nonisolated var dayRangeStart: Date?
+    public nonisolated var dayRangeEnd: Date?
+    public nonisolated var contextRangeStart: Date?
+    public nonisolated var contextRangeEnd: Date?
+    public nonisolated var contextPoints: [WeatherContextPointData]
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case recordedAt
+        case temperature
+        case condition
+        case humidity
+        case pressure
+        case precipitation
+        case weatherCode
+        case source
+        case dayRangeStart
+        case dayRangeEnd
+        case contextRangeStart
+        case contextRangeEnd
+        case contextPoints
+    }
 
     public nonisolated init(
         id: String,
@@ -245,7 +267,12 @@ public struct SyncWeatherSnapshotPayload: Codable, Equatable, Sendable {
         pressure: Double?,
         precipitation: Double?,
         weatherCode: Int?,
-        source: String
+        source: String,
+        dayRangeStart: Date? = nil,
+        dayRangeEnd: Date? = nil,
+        contextRangeStart: Date? = nil,
+        contextRangeEnd: Date? = nil,
+        contextPoints: [WeatherContextPointData] = []
     ) {
         self.id = id
         self.recordedAt = recordedAt
@@ -256,6 +283,29 @@ public struct SyncWeatherSnapshotPayload: Codable, Equatable, Sendable {
         self.precipitation = precipitation
         self.weatherCode = weatherCode
         self.source = source
+        self.dayRangeStart = dayRangeStart
+        self.dayRangeEnd = dayRangeEnd
+        self.contextRangeStart = contextRangeStart
+        self.contextRangeEnd = contextRangeEnd
+        self.contextPoints = contextPoints
+    }
+
+    public nonisolated init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.recordedAt = try container.decode(Date.self, forKey: .recordedAt)
+        self.temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
+        self.condition = try container.decode(String.self, forKey: .condition)
+        self.humidity = try container.decodeIfPresent(Double.self, forKey: .humidity)
+        self.pressure = try container.decodeIfPresent(Double.self, forKey: .pressure)
+        self.precipitation = try container.decodeIfPresent(Double.self, forKey: .precipitation)
+        self.weatherCode = try container.decodeIfPresent(Int.self, forKey: .weatherCode)
+        self.source = try container.decode(String.self, forKey: .source)
+        self.dayRangeStart = try container.decodeIfPresent(Date.self, forKey: .dayRangeStart)
+        self.dayRangeEnd = try container.decodeIfPresent(Date.self, forKey: .dayRangeEnd)
+        self.contextRangeStart = try container.decodeIfPresent(Date.self, forKey: .contextRangeStart)
+        self.contextRangeEnd = try container.decodeIfPresent(Date.self, forKey: .contextRangeEnd)
+        self.contextPoints = try container.decodeIfPresent([WeatherContextPointData].self, forKey: .contextPoints) ?? []
     }
 
     public nonisolated static func == (lhs: SyncWeatherSnapshotPayload, rhs: SyncWeatherSnapshotPayload) -> Bool {
@@ -267,7 +317,12 @@ public struct SyncWeatherSnapshotPayload: Codable, Equatable, Sendable {
             lhs.pressure == rhs.pressure &&
             lhs.precipitation == rhs.precipitation &&
             lhs.weatherCode == rhs.weatherCode &&
-            lhs.source == rhs.source
+            lhs.source == rhs.source &&
+            lhs.dayRangeStart == rhs.dayRangeStart &&
+            lhs.dayRangeEnd == rhs.dayRangeEnd &&
+            lhs.contextRangeStart == rhs.contextRangeStart &&
+            lhs.contextRangeEnd == rhs.contextRangeEnd &&
+            lhs.contextPoints == rhs.contextPoints
     }
 }
 
@@ -561,7 +616,12 @@ public enum SyncMergeEngine {
                 pressure: mergedValue(field: "weather.pressure", base: base.pressure, local: local.pressure, remote: remote.pressure, conflicts: &conflicts).value,
                 precipitation: mergedValue(field: "weather.precipitation", base: base.precipitation, local: local.precipitation, remote: remote.precipitation, conflicts: &conflicts).value,
                 weatherCode: mergedValue(field: "weather.weatherCode", base: base.weatherCode, local: local.weatherCode, remote: remote.weatherCode, conflicts: &conflicts).value,
-                source: mergedValue(field: "weather.source", base: base.source, local: local.source, remote: remote.source, conflicts: &conflicts).value
+                source: mergedValue(field: "weather.source", base: base.source, local: local.source, remote: remote.source, conflicts: &conflicts).value,
+                dayRangeStart: mergedValue(field: "weather.dayRangeStart", base: base.dayRangeStart, local: local.dayRangeStart, remote: remote.dayRangeStart, conflicts: &conflicts).value,
+                dayRangeEnd: mergedValue(field: "weather.dayRangeEnd", base: base.dayRangeEnd, local: local.dayRangeEnd, remote: remote.dayRangeEnd, conflicts: &conflicts).value,
+                contextRangeStart: mergedValue(field: "weather.contextRangeStart", base: base.contextRangeStart, local: local.contextRangeStart, remote: remote.contextRangeStart, conflicts: &conflicts).value,
+                contextRangeEnd: mergedValue(field: "weather.contextRangeEnd", base: base.contextRangeEnd, local: local.contextRangeEnd, remote: remote.contextRangeEnd, conflicts: &conflicts).value,
+                contextPoints: mergedValue(field: "weather.contextPoints", base: base.contextPoints, local: local.contextPoints, remote: remote.contextPoints, conflicts: &conflicts).value
             )
         case let (nil, local?, nil):
             return local

--- a/Symi/Sources/Shared/WeatherIntegration.swift
+++ b/Symi/Sources/Shared/WeatherIntegration.swift
@@ -12,6 +12,11 @@ struct WeatherSnapshotData: Equatable, Sendable {
     let precipitation: Double?
     let weatherCode: Int?
     let source: String
+    let dayRangeStart: Date?
+    let dayRangeEnd: Date?
+    let contextRangeStart: Date?
+    let contextRangeEnd: Date?
+    let contextPoints: [WeatherContextPointData]
 
     init(
         recordedAt: Date,
@@ -21,7 +26,12 @@ struct WeatherSnapshotData: Equatable, Sendable {
         pressure: Double?,
         precipitation: Double?,
         weatherCode: Int?,
-        source: String
+        source: String,
+        dayRangeStart: Date? = nil,
+        dayRangeEnd: Date? = nil,
+        contextRangeStart: Date? = nil,
+        contextRangeEnd: Date? = nil,
+        contextPoints: [WeatherContextPointData] = []
     ) {
         self.recordedAt = recordedAt
         self.condition = condition
@@ -31,6 +41,11 @@ struct WeatherSnapshotData: Equatable, Sendable {
         self.precipitation = precipitation
         self.weatherCode = weatherCode
         self.source = source
+        self.dayRangeStart = dayRangeStart
+        self.dayRangeEnd = dayRangeEnd
+        self.contextRangeStart = contextRangeStart
+        self.contextRangeEnd = contextRangeEnd
+        self.contextPoints = contextPoints
     }
 
     init(record: WeatherRecord) {
@@ -42,8 +57,41 @@ struct WeatherSnapshotData: Equatable, Sendable {
             pressure: record.pressure,
             precipitation: record.precipitation,
             weatherCode: record.weatherCode,
-            source: record.source
+            source: record.source,
+            dayRangeStart: record.dayRangeStart,
+            dayRangeEnd: record.dayRangeEnd,
+            contextRangeStart: record.contextRangeStart,
+            contextRangeEnd: record.contextRangeEnd,
+            contextPoints: record.contextPoints
         )
+    }
+}
+
+nonisolated public struct WeatherContextPointData: Codable, Equatable, Sendable {
+    public let recordedAt: Date
+    public let condition: String
+    public let temperature: Double?
+    public let humidity: Double?
+    public let pressure: Double?
+    public let precipitation: Double?
+    public let weatherCode: Int?
+
+    public init(
+        recordedAt: Date,
+        condition: String,
+        temperature: Double?,
+        humidity: Double?,
+        pressure: Double?,
+        precipitation: Double?,
+        weatherCode: Int?
+    ) {
+        self.recordedAt = recordedAt
+        self.condition = condition
+        self.temperature = temperature
+        self.humidity = humidity
+        self.pressure = pressure
+        self.precipitation = precipitation
+        self.weatherCode = weatherCode
     }
 }
 
@@ -140,6 +188,10 @@ final class SystemLocationService: NSObject, LocationService, CLLocationManagerD
     }
 
     func requestApproximateLocation() async throws -> CLLocation {
+        guard continuation == nil else {
+            throw LocationServiceError.unableToDetermineLocation
+        }
+
         return try await withCheckedThrowingContinuation { continuation in
             self.continuation = continuation
 
@@ -220,12 +272,13 @@ struct AppleWeatherKitWeatherService: WeatherService {
                 return nil
             }
 
-            let interval = hourlyInterval(containing: date)
+            let dayInterval = dayInterval(containing: date)
+            let contextInterval = contextInterval(around: dayInterval)
             let hourlyForecast: Forecast<HourWeather>
             do {
                 hourlyForecast = try await service.weather(
                     for: location,
-                    including: .hourly(startDate: interval.start, endDate: interval.end)
+                    including: .hourly(startDate: contextInterval.start, endDate: contextInterval.end)
                 )
             } catch {
                 if isWeatherKitAuthenticationError(error) {
@@ -240,6 +293,18 @@ struct AppleWeatherKitWeatherService: WeatherService {
                 throw WeatherServiceError.noMatchingHour
             }
 
+            let contextPoints = hourlyForecast.forecast.map { hour in
+                WeatherContextPointData(
+                    recordedAt: hour.date,
+                    condition: WeatherConditionMapper.description(for: hour.condition),
+                    temperature: hour.temperature.converted(to: .celsius).value,
+                    humidity: hour.humidity * 100,
+                    pressure: hour.pressure.converted(to: .hectopascals).value,
+                    precipitation: hour.precipitationAmount.converted(to: .millimeters).value,
+                    weatherCode: nil
+                )
+            }
+
             return WeatherSnapshotData(
                 recordedAt: matchedHour.date,
                 condition: WeatherConditionMapper.description(for: matchedHour.condition),
@@ -248,16 +313,28 @@ struct AppleWeatherKitWeatherService: WeatherService {
                 pressure: matchedHour.pressure.converted(to: .hectopascals).value,
                 precipitation: matchedHour.precipitationAmount.converted(to: .millimeters).value,
                 weatherCode: nil,
-                source: WeatherAttribution.providerName
+                source: WeatherAttribution.providerName,
+                dayRangeStart: dayInterval.start,
+                dayRangeEnd: dayInterval.end,
+                contextRangeStart: contextInterval.start,
+                contextRangeEnd: contextInterval.end,
+                contextPoints: contextPoints
             )
         }
     }
 
-    private func hourlyInterval(containing date: Date) -> DateInterval {
+    private func dayInterval(containing date: Date) -> DateInterval {
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: date)
         let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? date.addingTimeInterval(86_400)
         return DateInterval(start: startOfDay, end: endOfDay)
+    }
+
+    private func contextInterval(around dayInterval: DateInterval) -> DateInterval {
+        DateInterval(
+            start: dayInterval.start.addingTimeInterval(-43_200),
+            end: dayInterval.end.addingTimeInterval(43_200)
+        )
     }
 
     private func isWeatherKitAuthenticationError(_ error: any Error) -> Bool {

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -39,6 +39,7 @@ struct DataTransferHealthContextTests {
         #expect(importedEpisode.medications.count == 1)
         #expect(importedEpisode.medications.first?.name == "Sumatriptan")
         #expect(importedEpisode.weatherSnapshot?.condition == "Regen")
+        #expect(importedEpisode.weatherSnapshot?.contextPoints.count == 1)
         #expect(targetHealthStore.load(for: episodeID) == HealthContextRecord(snapshot: healthContext))
     }
 
@@ -178,6 +179,21 @@ private func seedEpisode(id: UUID, notes: String = "Migräne nach Wetterwechsel"
         precipitation: 1.4,
         weatherCode: 63,
         source: "Apple Weather",
+        dayRangeStart: Calendar.current.startOfDay(for: startedAt),
+        dayRangeEnd: Calendar.current.startOfDay(for: startedAt).addingTimeInterval(86_400),
+        contextRangeStart: Calendar.current.startOfDay(for: startedAt).addingTimeInterval(-43_200),
+        contextRangeEnd: Calendar.current.startOfDay(for: startedAt).addingTimeInterval(129_600),
+        contextPointsStorage: WeatherSnapshot.encodeContextPoints([
+            WeatherContextPointData(
+                recordedAt: startedAt,
+                condition: "Regen",
+                temperature: 18.5,
+                humidity: 72,
+                pressure: 1004,
+                precipitation: 1.4,
+                weatherCode: 63
+            )
+        ]),
         episode: episode
     )
     context.insert(episode)

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -10,6 +10,16 @@ struct EntryFlowCoordinatorTests {
     }
 
     @Test
+    func triggerCatalogContainsRequiredContextOptions() {
+        let coordinator = makeCoordinator()
+        let requiredTriggers = ["Wetter", "Stress", "Erhöhte Arbeitsbelastung", "Regel", "Schlafdauer", "Sport"]
+
+        for trigger in requiredTriggers {
+            #expect(coordinator.triggerOptions.contains(trigger))
+        }
+    }
+
+    @Test
     func draftSurvivesForwardAndBackNavigation() {
         let coordinator = makeCoordinator()
         coordinator.draft.intensity = 8

--- a/SymiTests/NewEntryDesignSystemTests.swift
+++ b/SymiTests/NewEntryDesignSystemTests.swift
@@ -19,7 +19,7 @@ struct NewEntryDesignSystemTests {
         let expected: [NewEntryStepID: (String, String, String, NewEntryStepColorToken)] = [
             .headache: ("Kopfschmerz", "Wie stark ist es gerade?", "waveform.path.ecg", .coral),
             .medication: ("Medikation", "Was hast du genommen?", "pills.fill", .sageTeal),
-            .triggers: ("Auslöser", "Was könnte mitspielen?", "brain.head.profile", .blue),
+            .triggers: ("Auslöser", "Was könnte eine Rolle gespielt haben?", "brain.head.profile", .blue),
             .note: ("Notiz", "Was fällt dir auf?", "note.text", .warmAmber),
             .review: ("Eintrag prüfen", "Kurz ansehen und speichern.", "checkmark.seal.fill", .purple)
         ]


### PR DESCRIPTION
Closes #168

## Änderungen
- erweitert den Auslöser-Katalog im neuen Eintrag und Editor um die geforderten Mindest-Trigger
- speichert Wetter als Kontext mit Tages- und ±12h-Kontextzeitraum sowie stündlichen Kontextpunkten
- roundtrippt Wetterkontext über Detailansicht, PDF-Export, JSON-Backup und Sync-Payloads
- schützt parallele Location-Requests vor überschriebenen Continuations

## Tests
- xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16'