### PR TITLE
Neuer Eintrag: Medikation inkl. Dauermedikation

### DIFF
--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -16,6 +16,7 @@ final class AppContainer {
 
     let episodeRepository: EpisodeRepository
     let medicationCatalogRepository: MedicationCatalogRepository
+    let continuousMedicationRepository: ContinuousMedicationRepository
     let exportRepository: ExportRepository
     let syncService: SyncService
     let appLogService: AppLogService
@@ -51,6 +52,7 @@ final class AppContainer {
         )
         self.episodeRepository = SwiftDataEpisodeRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
         self.medicationCatalogRepository = SwiftDataMedicationCatalogRepository(modelContainer: modelContainer)
+        self.continuousMedicationRepository = SwiftDataContinuousMedicationRepository(modelContainer: modelContainer)
         self.exportRepository = SwiftDataExportRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
         self.syncService = SyncServiceAdapter(coordinator: syncCoordinator)
         self.appLogService = appLogStore
@@ -75,7 +77,8 @@ final class AppContainer {
         EntryFlowCoordinator(
             initialStartedAt: initialStartedAt,
             episodeRepository: episodeRepository,
-            medicationRepository: medicationCatalogRepository
+            medicationRepository: medicationCatalogRepository,
+            continuousMedicationRepository: continuousMedicationRepository
         )
     }
 
@@ -87,6 +90,7 @@ final class AppContainer {
         SettingsController(
             episodeRepository: episodeRepository,
             medicationRepository: medicationCatalogRepository,
+            continuousMedicationRepository: continuousMedicationRepository,
             syncService: syncService,
             appLogService: appLogService,
             healthService: healthService

--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -78,7 +78,7 @@ struct ScreenshotSeed {
 enum ScreenshotBootstrap {
     @MainActor
     static func makeEnvironment(seedName: String) throws -> (ModelContainer, AppContainer, AppLogStore, SyncCoordinator, ScreenshotSeed) {
-        let schema = Schema(versionedSchema: SymiSchemaV5.self)
+        let schema = Schema(versionedSchema: SymiSchemaV6.self)
         let storeURL = FileManager.default.temporaryDirectory.appending(path: "Symi-Screenshots-\(UUID().uuidString).store")
         let configuration = ModelConfiguration(
             "default",

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -66,7 +66,7 @@ struct SymiApp: App {
         launchConfiguration: AppLaunchConfiguration,
         storeURL overrideStoreURL: URL? = nil
     ) throws -> AppRuntimeEnvironment {
-        let schema = Schema(versionedSchema: SymiSchemaV5.self)
+        let schema = Schema(versionedSchema: SymiSchemaV6.self)
         let storeURL = overrideStoreURL ?? (launchConfiguration.isRunningTests ? unitTestStoreURL() : defaultStoreURL())
         let configuration = ModelConfiguration(
             "default",
@@ -132,7 +132,7 @@ struct SymiApp: App {
 
     @MainActor
     private static func makeRecoveryContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: SymiSchemaV5.self)
+        let schema = Schema(versionedSchema: SymiSchemaV6.self)
         let configuration = ModelConfiguration(
             "recovery",
             schema: schema,

--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -62,6 +62,36 @@ enum EntryStartedAtPreset: String, CaseIterable, Identifiable, Sendable {
 
 @MainActor
 @Observable
+final class EntryContinuousMedicationController {
+    private(set) var activeMedications: [ContinuousMedicationRecord] = []
+    private let repository: ContinuousMedicationRepository
+
+    init(repository: ContinuousMedicationRepository, autoload: Bool = true) {
+        self.repository = repository
+
+        guard autoload else {
+            return
+        }
+
+        Task {
+            await reload(for: .now)
+        }
+    }
+
+    func reload(for date: Date) async {
+        let repository = repository
+        activeMedications = await Task.detached(priority: .userInitiated) {
+            (try? repository.fetchActive(on: date)) ?? []
+        }.value
+    }
+
+    func makeDefaultChecks() -> [ContinuousMedicationCheckDraft] {
+        activeMedications.map { ContinuousMedicationCheckDraft(record: $0, wasTaken: true) }
+    }
+}
+
+@MainActor
+@Observable
 final class EntryFlowCoordinator {
     static let steps: [EntryFlowStep] = [.headache, .medication, .triggers, .note, .review]
 
@@ -76,6 +106,7 @@ final class EntryFlowCoordinator {
     let triggerOptions = ["Wetter", "Stress", "Erhöhte Arbeitsbelastung", "Regel", "Schlafdauer", "Sport", "Ernährung", "Bildschirmzeit", "Bewegung", "Flüssigkeit"]
     let painLocationOptions = ["Stirn", "Schläfen", "Nacken", "Einseitig", "Überall"]
     let medicationController: EpisodeMedicationSelectionController
+    let continuousMedicationController: EntryContinuousMedicationController
 
     var draft: EpisodeDraft
     var path: [EntryFlowStep] = []
@@ -90,12 +121,17 @@ final class EntryFlowCoordinator {
         initialStartedAt: Date? = nil,
         episodeRepository: EpisodeRepository,
         medicationRepository: MedicationCatalogRepository,
+        continuousMedicationRepository: ContinuousMedicationRepository,
         autoloadMedications: Bool = true
     ) {
         self.initialStartedAt = initialStartedAt
         self.draft = EpisodeDraft.makeNew(initialStartedAt: initialStartedAt)
         self.medicationController = EpisodeMedicationSelectionController(
             medicationRepository: medicationRepository,
+            autoload: autoloadMedications
+        )
+        self.continuousMedicationController = EntryContinuousMedicationController(
+            repository: continuousMedicationRepository,
             autoload: autoloadMedications
         )
         self.saveEpisodeUseCase = SaveEpisodeUseCase(repository: episodeRepository)
@@ -137,6 +173,7 @@ final class EntryFlowCoordinator {
         case .medication:
             medicationController.resetSelections()
             draft.medications = []
+            draft.continuousMedicationChecks = []
         case .triggers:
             draft.selectedTriggers = []
         case .note:
@@ -199,6 +236,9 @@ final class EntryFlowCoordinator {
 
         if currentStep == .medication {
             draft.medications = medicationController.medications
+            if draft.continuousMedicationChecks.isEmpty {
+                draft.continuousMedicationChecks = continuousMedicationController.makeDefaultChecks()
+            }
         }
     }
 

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -66,6 +66,48 @@ struct MedicationRecord: Identifiable, Equatable, Sendable {
     nonisolated let isRepeatDose: Bool
 }
 
+struct ContinuousMedicationRecord: Identifiable, Equatable, Sendable {
+    nonisolated let id: UUID
+    nonisolated let name: String
+    nonisolated let dosage: String
+    nonisolated let frequency: String
+    nonisolated let startDate: Date
+    nonisolated let endDate: Date?
+    nonisolated let createdAt: Date
+    nonisolated let updatedAt: Date
+
+    nonisolated var isActive: Bool {
+        guard let endDate else {
+            return true
+        }
+
+        return endDate >= Calendar.current.startOfDay(for: .now)
+    }
+
+    nonisolated var detailText: String {
+        [dosage, frequency]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+}
+
+struct ContinuousMedicationCheckRecord: Identifiable, Equatable, Sendable {
+    nonisolated let id: UUID
+    nonisolated let continuousMedicationID: UUID
+    nonisolated let name: String
+    nonisolated let dosage: String
+    nonisolated let frequency: String
+    nonisolated let wasTaken: Bool
+
+    nonisolated var detailText: String {
+        [dosage, frequency]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+}
+
 struct EpisodeRecord: Identifiable, Equatable, Sendable {
     nonisolated let id: UUID
     nonisolated let startedAt: Date
@@ -82,6 +124,7 @@ struct EpisodeRecord: Identifiable, Equatable, Sendable {
     nonisolated let functionalImpact: String
     nonisolated let menstruationStatus: MenstruationStatus
     nonisolated let medications: [MedicationRecord]
+    nonisolated let continuousMedicationChecks: [ContinuousMedicationCheckRecord]
     nonisolated let weather: WeatherRecord?
     nonisolated let healthContext: HealthContextRecord?
 
@@ -91,6 +134,88 @@ struct EpisodeRecord: Identifiable, Equatable, Sendable {
 
     nonisolated var dayPart: EpisodeDayPart {
         EpisodeDayPart(date: startedAt)
+    }
+}
+
+struct ContinuousMedicationDraft: Identifiable, Equatable, Sendable {
+    nonisolated var id: UUID?
+    nonisolated var name: String
+    nonisolated var dosage: String
+    nonisolated var frequency: String
+    nonisolated var startDate: Date
+    nonisolated var endDate: Date?
+
+    nonisolated var stableID: UUID {
+        id ?? UUID()
+    }
+
+    nonisolated init(
+        id: UUID? = nil,
+        name: String = "",
+        dosage: String = "",
+        frequency: String = "",
+        startDate: Date = .now,
+        endDate: Date? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.dosage = dosage
+        self.frequency = frequency
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+
+    nonisolated init(record: ContinuousMedicationRecord) {
+        self.init(
+            id: record.id,
+            name: record.name,
+            dosage: record.dosage,
+            frequency: record.frequency,
+            startDate: record.startDate,
+            endDate: record.endDate
+        )
+    }
+}
+
+struct ContinuousMedicationCheckDraft: Identifiable, Equatable, Sendable {
+    nonisolated let id: UUID
+    nonisolated let continuousMedicationID: UUID
+    nonisolated var name: String
+    nonisolated var dosage: String
+    nonisolated var frequency: String
+    nonisolated var wasTaken: Bool
+
+    nonisolated init(
+        id: UUID = UUID(),
+        continuousMedicationID: UUID,
+        name: String,
+        dosage: String = "",
+        frequency: String = "",
+        wasTaken: Bool = true
+    ) {
+        self.id = id
+        self.continuousMedicationID = continuousMedicationID
+        self.name = name
+        self.dosage = dosage
+        self.frequency = frequency
+        self.wasTaken = wasTaken
+    }
+
+    nonisolated init(record: ContinuousMedicationRecord, wasTaken: Bool = true) {
+        self.init(
+            continuousMedicationID: record.id,
+            name: record.name,
+            dosage: record.dosage,
+            frequency: record.frequency,
+            wasTaken: wasTaken
+        )
+    }
+
+    nonisolated var detailText: String {
+        [dosage, frequency]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
     }
 }
 
@@ -254,6 +379,7 @@ struct EpisodeDraft: Equatable, Sendable {
     nonisolated var selectedSymptoms: Set<String>
     nonisolated var selectedTriggers: Set<String>
     nonisolated var medications: [MedicationSelectionDraft]
+    nonisolated var continuousMedicationChecks: [ContinuousMedicationCheckDraft] = []
 
     nonisolated static func makeNew(initialStartedAt: Date? = nil) -> EpisodeDraft {
         let startedAt = initialStartedAt ?? .now
@@ -272,7 +398,8 @@ struct EpisodeDraft: Equatable, Sendable {
             menstruationStatus: .unknown,
             selectedSymptoms: [],
             selectedTriggers: [],
-            medications: []
+            medications: [],
+            continuousMedicationChecks: []
         )
     }
 
@@ -292,7 +419,17 @@ struct EpisodeDraft: Equatable, Sendable {
             menstruationStatus: record.menstruationStatus,
             selectedSymptoms: Set(record.symptoms),
             selectedTriggers: Set(record.triggers),
-            medications: record.medications.map(MedicationSelectionDraft.init(record:))
+            medications: record.medications.map(MedicationSelectionDraft.init(record:)),
+            continuousMedicationChecks: record.continuousMedicationChecks.map {
+                ContinuousMedicationCheckDraft(
+                    id: $0.id,
+                    continuousMedicationID: $0.continuousMedicationID,
+                    name: $0.name,
+                    dosage: $0.dosage,
+                    frequency: $0.frequency,
+                    wasTaken: $0.wasTaken
+                )
+            }
         )
     }
 
@@ -349,6 +486,14 @@ protocol MedicationCatalogRepository: Sendable {
     nonisolated func saveCustomDefinition(_ draft: CustomMedicationDefinitionDraft) throws -> MedicationDefinitionRecord
     nonisolated func softDeleteCustomDefinition(catalogKey: String) throws
     nonisolated func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord]
+}
+
+protocol ContinuousMedicationRepository: Sendable {
+    nonisolated func fetchAll() throws -> [ContinuousMedicationRecord]
+    nonisolated func fetchActive(on date: Date) throws -> [ContinuousMedicationRecord]
+    @discardableResult
+    nonisolated func save(_ draft: ContinuousMedicationDraft) throws -> ContinuousMedicationRecord
+    nonisolated func delete(id: UUID) throws
 }
 
 struct SaveEpisodeUseCase {

--- a/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
@@ -131,6 +131,12 @@ final class EpisodeMedicationSelectionController {
         selectedMedicationKeys.contains(definition.selectionKey)
     }
 
+    func isMedicationNameSelected(_ name: String) -> Bool {
+        medications.contains {
+            $0.isSelected && $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }
+    }
+
     func quantity(for definition: MedicationDefinitionRecord) -> Int {
         guard let index = medicationSelectionIndicesByKey[definition.selectionKey] else {
             return 1
@@ -145,6 +151,34 @@ final class EpisodeMedicationSelectionController {
             medications[index].quantity = max(1, medications[index].quantity)
         } else {
             medications.append(MedicationSelectionDraft(definition: definition))
+        }
+        rebuildCaches()
+    }
+
+    func toggleMedicationSelection(named name: String, fallbackCategory: MedicationCategory = .other, fallbackDosage: String = "") {
+        if let definition = medicationDefinitions.first(where: {
+            $0.name.compare(name, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }) {
+            toggleMedicationSelection(for: definition)
+            return
+        }
+
+        let selectionKey = MedicationSelectionDraft.makeSelectionKey(
+            name: name,
+            category: fallbackCategory,
+            dosage: fallbackDosage
+        )
+        if let index = medicationSelectionIndicesByKey[selectionKey] {
+            medications[index].isSelected.toggle()
+        } else {
+            medications.append(
+                MedicationSelectionDraft(
+                    selectionKey: selectionKey,
+                    name: name,
+                    category: fallbackCategory,
+                    dosage: fallbackDosage
+                )
+            )
         }
         rebuildCaches()
     }

--- a/Symi/Sources/Core/Settings/SettingsCore.swift
+++ b/Symi/Sources/Core/Settings/SettingsCore.swift
@@ -87,13 +87,17 @@ final class SettingsController {
     private(set) var summary = SettingsSummaryData(activeEpisodeCount: 0, trashCount: 0, conflictCount: 0)
     private(set) var deletedEpisodes: [EpisodeRecord] = []
     private(set) var deletedDefinitions: [MedicationDefinitionRecord] = []
+    private(set) var continuousMedications: [ContinuousMedicationRecord] = []
     private(set) var logEntries: [AppLogEntry] = []
     private(set) var logShareURL: URL?
     private(set) var healthSettingsRevision = 0
     var logFilter: AppLogFilter = .all
+    var continuousMedicationEditor: ContinuousMedicationDraft?
+    var continuousMedicationMessage: String?
 
     private let episodeRepository: EpisodeRepository
     private let medicationRepository: MedicationCatalogRepository
+    private let continuousMedicationRepository: ContinuousMedicationRepository
     private let loadSettingsUseCase: LoadSettingsUseCase
     private let restoreDeletedItemUseCase: RestoreDeletedItemUseCase
     private let syncService: SyncService
@@ -107,12 +111,14 @@ final class SettingsController {
     init(
         episodeRepository: EpisodeRepository,
         medicationRepository: MedicationCatalogRepository,
+        continuousMedicationRepository: ContinuousMedicationRepository,
         syncService: SyncService,
         appLogService: AppLogService,
         healthService: HealthService
     ) {
         self.episodeRepository = episodeRepository
         self.medicationRepository = medicationRepository
+        self.continuousMedicationRepository = continuousMedicationRepository
         self.syncService = syncService
         self.appLogService = appLogService
         self.healthService = healthService
@@ -157,6 +163,7 @@ final class SettingsController {
 
         let episodeRepository = episodeRepository
         let medicationRepository = medicationRepository
+        let continuousMedicationRepository = continuousMedicationRepository
         loadTask = Task { [weak self] in
             guard let self else { return }
             do {
@@ -164,13 +171,15 @@ final class SettingsController {
                 let deleted = try await Task.detached(priority: .userInitiated) {
                     (
                         try episodeRepository.fetchDeleted(),
-                        try medicationRepository.fetchDeletedDefinitions()
+                        try medicationRepository.fetchDeletedDefinitions(),
+                        try continuousMedicationRepository.fetchAll()
                     )
                 }.value
                 guard !Task.isCancelled else { return }
                 summary = loadedSummary
                 deletedEpisodes = deleted.0
                 deletedDefinitions = deleted.1
+                continuousMedications = deleted.2
             } catch is CancellationError {
                 return
             } catch {
@@ -238,6 +247,53 @@ final class SettingsController {
             }
             guard !Task.isCancelled else { return }
             load()
+        }
+    }
+
+    func presentContinuousMedicationEditor(for medication: ContinuousMedicationRecord?) {
+        continuousMedicationEditor = medication.map(ContinuousMedicationDraft.init(record:)) ?? ContinuousMedicationDraft()
+        continuousMedicationMessage = nil
+    }
+
+    func saveContinuousMedication(_ draft: ContinuousMedicationDraft) async {
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            continuousMedicationMessage = "Bitte gib ein Medikament an."
+            return
+        }
+
+        let repository = continuousMedicationRepository
+        var normalizedDraft = draft
+        normalizedDraft.name = trimmedName
+
+        do {
+            _ = try await Task.detached(priority: .userInitiated) {
+                try repository.save(normalizedDraft)
+            }.value
+            continuousMedicationEditor = nil
+            continuousMedicationMessage = nil
+            load()
+        } catch {
+            continuousMedicationMessage = "Dauermedikation konnte nicht gespeichert werden."
+        }
+    }
+
+    func endContinuousMedication(id: UUID) {
+        let repository = continuousMedicationRepository
+        Task { [weak self] in
+            guard let self else { return }
+            guard let medication = continuousMedications.first(where: { $0.id == id }) else { return }
+            var draft = ContinuousMedicationDraft(record: medication)
+            draft.endDate = .now
+
+            do {
+                _ = try await Task.detached(priority: .userInitiated) {
+                    try repository.save(draft)
+                }.value
+                load()
+            } catch {
+                continuousMedicationMessage = "Dauermedikation konnte nicht beendet werden."
+            }
         }
     }
 

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -243,24 +243,70 @@ private struct EntryMedicationStepView: View {
     let coordinator: EntryFlowCoordinator
 
     var body: some View {
+        @Bindable var coordinator = coordinator
         @Bindable var medicationController = coordinator.medicationController
 
         Form {
             EntryStepHeader(step: .medication, currentIndex: coordinator.currentStepIndex)
 
-            Section("Medikamente") {
-                TextField("Medikament nach Namen filtern", text: $medicationController.searchText)
-                    .textInputAutocapitalization(.words)
-                    .autocorrectionDisabled()
+            Section {
+                Text("Hast du etwas genommen?")
+                    .font(.headline)
+                Text("Übersichtlich. Schnell. Kontextbewusst.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
 
-                MedicationDefinitionGroupList(controller: coordinator.medicationController)
-                SelectedMedicationsSection(controller: coordinator.medicationController)
+            if !coordinator.draft.continuousMedicationChecks.isEmpty {
+                Section {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Label("Dauermedikation", systemImage: "pills.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(AppTheme.symiPetrol)
 
-                Button {
-                    medicationController.presentEditor(for: nil)
-                } label: {
-                    Label("Eigenes Medikament hinzufügen", systemImage: "plus")
+                        Text("Bestätige deine regelmäßige Medikation für heute.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+
+                        ForEach($coordinator.draft.continuousMedicationChecks) { $check in
+                            ContinuousMedicationCheckRow(check: $check)
+                        }
+
+                        Text("Du kannst dies jederzeit in den Einstellungen anpassen.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    Text("Heute genommen?")
                 }
+            }
+
+            Section {
+                MedicationQuickSelectionGrid(
+                    controller: coordinator.medicationController,
+                    hasContinuousMedication: !coordinator.draft.continuousMedicationChecks.isEmpty
+                )
+
+                DisclosureGroup("Weitere Medikamente") {
+                    TextField("Medikament nach Namen filtern", text: $medicationController.searchText)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled()
+
+                    MedicationDefinitionGroupList(controller: coordinator.medicationController)
+
+                    Button {
+                        medicationController.presentEditor(for: nil)
+                    } label: {
+                        Label("Eigenes Medikament hinzufügen", systemImage: "plus")
+                    }
+                }
+
+                SelectedMedicationsSection(controller: coordinator.medicationController)
+            } header: {
+                Text(coordinator.draft.continuousMedicationChecks.isEmpty ? "Zusätzlich etwas genommen?" : "Zusätzlich etwas genommen?")
+            } footer: {
+                Text("Dosierung ist optional und kann über Medikamentenvorlagen oder eigene Medikamente gespeichert werden.")
             }
 
             EntryStepActions(
@@ -275,6 +321,12 @@ private struct EntryMedicationStepView: View {
         }
         .navigationTitle("Medikation")
         .brandGroupedScreen()
+        .task {
+            await coordinator.continuousMedicationController.reload(for: coordinator.draft.startedAt)
+            if coordinator.draft.continuousMedicationChecks.isEmpty {
+                coordinator.draft.continuousMedicationChecks = coordinator.continuousMedicationController.makeDefaultChecks()
+            }
+        }
         .sheet(item: $medicationController.customMedicationEditor) { editorState in
             NavigationStack {
                 CustomMedicationEditorSheet(
@@ -311,6 +363,74 @@ private struct EntryMedicationStepView: View {
             }
         } message: { definition in
             Text("\(definition.name) wird aus SwiftData entfernt.")
+        }
+    }
+}
+
+private struct ContinuousMedicationCheckRow: View {
+    @Binding var check: ContinuousMedicationCheckDraft
+
+    var body: some View {
+        Toggle(isOn: $check.wasTaken) {
+            HStack(spacing: 12) {
+                Image(systemName: "pills")
+                    .foregroundStyle(AppTheme.symiPetrol)
+                    .frame(width: 28, height: 28)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(check.name)
+                        .font(.subheadline.weight(.semibold))
+                    if !check.detailText.isEmpty {
+                        Text(check.detailText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .toggleStyle(.button)
+        .buttonStyle(.bordered)
+        .controlSize(.large)
+        .accessibilityLabel("\(check.name) heute genommen")
+    }
+}
+
+private struct MedicationQuickSelectionGrid: View {
+    let controller: EpisodeMedicationSelectionController
+    let hasContinuousMedication: Bool
+
+    private let options: [(String, MedicationCategory, String)] = [
+        ("Ibuprofen", .nsar, "400 mg"),
+        ("Triptan", .triptan, ""),
+        ("Paracetamol", .paracetamol, "500 mg"),
+        ("Andere", .other, "")
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 10)], spacing: 10) {
+            ForEach(options, id: \.0) { option in
+                Button {
+                    controller.toggleMedicationSelection(
+                        named: option.0,
+                        fallbackCategory: option.1,
+                        fallbackDosage: option.2
+                    )
+                } label: {
+                    Label(option.0, systemImage: controller.isMedicationNameSelected(option.0) ? "checkmark.circle.fill" : "circle")
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .buttonStyle(.bordered)
+                .tint(controller.isMedicationNameSelected(option.0) ? AppTheme.symiPetrol : .secondary)
+            }
+
+            Button {
+                controller.resetSelections()
+            } label: {
+                Label(hasContinuousMedication ? "Keine weitere Medikation" : "Keine Medikation", systemImage: "slash.circle")
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .buttonStyle(.bordered)
         }
     }
 }
@@ -445,13 +565,19 @@ private struct EntryReviewStepView: View {
 
     private var medicationSummary: String {
         let selected = coordinator.medicationController.selectedMedications
-        guard !selected.isEmpty else {
+        let continuous = coordinator.draft.continuousMedicationChecks
+        guard !selected.isEmpty || !continuous.isEmpty else {
             return "Keine Medikation"
         }
 
-        return selected.map { medication in
+        let continuousSummary = continuous.map {
+            "\($0.name): \($0.wasTaken ? "genommen" : "nicht genommen")"
+        }
+        let acuteSummary = selected.map { medication in
             medication.quantity > 1 ? "\(medication.name) x\(medication.quantity)" : medication.name
-        }.joined(separator: ", ")
+        }
+
+        return (continuousSummary + acuteSummary).joined(separator: ", ")
     }
 
     private func listSummary(_ values: Set<String>) -> String {

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -17,28 +17,54 @@ enum DataTransferError: LocalizedError {
     }
 }
 
-struct DataTransferSnapshot: @preconcurrency Codable, Sendable {
+struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
     let formatVersion: Int
     let exportedAt: Date
     let episodes: [EpisodePayload]
     let customMedicationDefinitions: [MedicationDefinitionPayload]
+    let continuousMedications: [ContinuousMedicationPayload]
+
+    private enum CodingKeys: String, CodingKey {
+        case formatVersion
+        case exportedAt
+        case episodes
+        case customMedicationDefinitions
+        case continuousMedications
+    }
 
     nonisolated init(
         formatVersion: Int = 1,
         exportedAt: Date = .now,
         episodes: [EpisodePayload],
-        customMedicationDefinitions: [MedicationDefinitionPayload]
+        customMedicationDefinitions: [MedicationDefinitionPayload],
+        continuousMedications: [ContinuousMedicationPayload] = []
     ) {
         self.formatVersion = formatVersion
         self.exportedAt = exportedAt
         self.episodes = episodes
         self.customMedicationDefinitions = customMedicationDefinitions
+        self.continuousMedications = continuousMedications
     }
 
-    nonisolated init(episodes: [Episode], customMedicationDefinitions: [MedicationDefinition], healthContextStore: HealthContextStore? = nil) {
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.formatVersion = try container.decode(Int.self, forKey: .formatVersion)
+        self.exportedAt = try container.decode(Date.self, forKey: .exportedAt)
+        self.episodes = try container.decode([EpisodePayload].self, forKey: .episodes)
+        self.customMedicationDefinitions = try container.decode([MedicationDefinitionPayload].self, forKey: .customMedicationDefinitions)
+        self.continuousMedications = try container.decodeIfPresent([ContinuousMedicationPayload].self, forKey: .continuousMedications) ?? []
+    }
+
+    nonisolated init(
+        episodes: [Episode],
+        customMedicationDefinitions: [MedicationDefinition],
+        continuousMedications: [ContinuousMedication] = [],
+        healthContextStore: HealthContextStore? = nil
+    ) {
         self.init(
             episodes: episodes.map { EpisodePayload(episode: $0, healthContext: healthContextStore?.load(for: $0.id)) },
-            customMedicationDefinitions: customMedicationDefinitions.map(MedicationDefinitionPayload.init)
+            customMedicationDefinitions: customMedicationDefinitions.map(MedicationDefinitionPayload.init),
+            continuousMedications: continuousMedications.map(ContinuousMedicationPayload.init)
         )
     }
 
@@ -86,10 +112,20 @@ struct DataTransferSnapshot: @preconcurrency Codable, Sendable {
                 .filter(\.isCustom)
                 .map { ($0.catalogKey, $0) }
         )
+        let existingContinuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
+        let continuousMedicationsByID = Dictionary(uniqueKeysWithValues: existingContinuousMedications.map { ($0.id, $0) })
 
         for payload in customMedicationDefinitions {
             if let definition = customDefinitionsByKey[payload.catalogKey] {
                 payload.apply(to: definition)
+            } else {
+                context.insert(payload.makeModel())
+            }
+        }
+
+        for payload in continuousMedications {
+            if let medication = continuousMedicationsByID[payload.id] {
+                payload.apply(to: medication)
             } else {
                 context.insert(payload.makeModel())
             }
@@ -139,6 +175,7 @@ struct EpisodePayload: Codable, Sendable {
     let functionalImpact: String
     let menstruationStatus: MenstruationStatus
     let medications: [MedicationEntryPayload]
+    let continuousMedicationChecks: [ContinuousMedicationCheckPayload]
     let weatherSnapshot: WeatherSnapshotPayload?
     let healthContext: HealthContextSnapshotData?
     private let shouldImportHealthContext: Bool
@@ -159,6 +196,7 @@ struct EpisodePayload: Codable, Sendable {
         case functionalImpact
         case menstruationStatus
         case medications
+        case continuousMedicationChecks
         case weatherSnapshot
         case healthContext
     }
@@ -179,6 +217,7 @@ struct EpisodePayload: Codable, Sendable {
         self.functionalImpact = episode.functionalImpact
         self.menstruationStatus = episode.menstruationStatus
         self.medications = episode.medications.map(MedicationEntryPayload.init)
+        self.continuousMedicationChecks = episode.continuousMedicationChecks.map(ContinuousMedicationCheckPayload.init)
         self.weatherSnapshot = episode.weatherSnapshot.map(WeatherSnapshotPayload.init)
         self.healthContext = healthContext.map(HealthContextSnapshotData.init)
         self.shouldImportHealthContext = healthContext != nil
@@ -201,6 +240,10 @@ struct EpisodePayload: Codable, Sendable {
         self.functionalImpact = try container.decode(String.self, forKey: .functionalImpact)
         self.menstruationStatus = try container.decode(MenstruationStatus.self, forKey: .menstruationStatus)
         self.medications = try container.decode([MedicationEntryPayload].self, forKey: .medications)
+        self.continuousMedicationChecks = try container.decodeIfPresent(
+            [ContinuousMedicationCheckPayload].self,
+            forKey: .continuousMedicationChecks
+        ) ?? []
         self.weatherSnapshot = try container.decodeIfPresent(WeatherSnapshotPayload.self, forKey: .weatherSnapshot)
         self.shouldImportHealthContext = container.contains(.healthContext)
         self.healthContext = try container.decodeIfPresent(HealthContextSnapshotData.self, forKey: .healthContext)
@@ -223,6 +266,7 @@ struct EpisodePayload: Codable, Sendable {
         try container.encode(functionalImpact, forKey: .functionalImpact)
         try container.encode(menstruationStatus, forKey: .menstruationStatus)
         try container.encode(medications, forKey: .medications)
+        try container.encode(continuousMedicationChecks, forKey: .continuousMedicationChecks)
         try container.encodeIfPresent(weatherSnapshot, forKey: .weatherSnapshot)
 
         if let healthContext {
@@ -251,6 +295,7 @@ struct EpisodePayload: Codable, Sendable {
         )
 
         episode.medications = medications.map { $0.makeModel(for: episode) }
+        episode.continuousMedicationChecks = continuousMedicationChecks.map { $0.makeModel(for: episode) }
         episode.weatherSnapshot = weatherSnapshot?.makeModel(for: episode)
         return episode
     }
@@ -272,15 +317,30 @@ struct EpisodePayload: Codable, Sendable {
 
         let existingMedicationsByID = Dictionary(uniqueKeysWithValues: episode.medications.map { ($0.id, $0) })
         let importedMedicationIDs = Set(medications.map(\.id))
+        let existingChecksByID = Dictionary(uniqueKeysWithValues: episode.continuousMedicationChecks.map { ($0.id, $0) })
+        let importedCheckIDs = Set(continuousMedicationChecks.map(\.id))
 
         for medication in episode.medications where !importedMedicationIDs.contains(medication.id) {
             context.delete(medication)
+        }
+
+        for check in episode.continuousMedicationChecks where !importedCheckIDs.contains(check.id) {
+            context.delete(check)
         }
 
         episode.medications = medications.map { payload in
             if let medication = existingMedicationsByID[payload.id] {
                 payload.apply(to: medication, for: episode)
                 return medication
+            }
+
+            return payload.makeModel(for: episode)
+        }
+
+        episode.continuousMedicationChecks = continuousMedicationChecks.map { payload in
+            if let check = existingChecksByID[payload.id] {
+                payload.apply(to: check, for: episode)
+                return check
             }
 
             return payload.makeModel(for: episode)
@@ -355,6 +415,45 @@ struct MedicationEntryPayload: @preconcurrency Codable, Sendable {
         entry.reliefStartedAt = reliefStartedAt
         entry.isRepeatDose = isRepeatDose
         entry.episode = episode
+    }
+}
+
+struct ContinuousMedicationCheckPayload: Codable, Sendable {
+    let id: UUID
+    let continuousMedicationID: UUID
+    let name: String
+    let dosage: String
+    let frequency: String
+    let wasTaken: Bool
+
+    nonisolated init(check: ContinuousMedicationCheck) {
+        self.id = check.id
+        self.continuousMedicationID = check.continuousMedicationID
+        self.name = check.name
+        self.dosage = check.dosage
+        self.frequency = check.frequency
+        self.wasTaken = check.wasTaken
+    }
+
+    nonisolated func makeModel(for episode: Episode) -> ContinuousMedicationCheck {
+        ContinuousMedicationCheck(
+            id: id,
+            continuousMedicationID: continuousMedicationID,
+            name: name,
+            dosage: dosage,
+            frequency: frequency,
+            wasTaken: wasTaken,
+            episode: episode
+        )
+    }
+
+    nonisolated func apply(to check: ContinuousMedicationCheck, for episode: Episode) {
+        check.continuousMedicationID = continuousMedicationID
+        check.name = name
+        check.dosage = dosage
+        check.frequency = frequency
+        check.wasTaken = wasTaken
+        check.episode = episode
     }
 }
 
@@ -461,6 +560,51 @@ struct WeatherSnapshotPayload: Codable, Sendable {
         snapshot.contextRangeEnd = contextRangeEnd
         snapshot.contextPoints = contextPoints
         snapshot.episode = episode
+    }
+}
+
+struct ContinuousMedicationPayload: Codable, Sendable {
+    let id: UUID
+    let name: String
+    let dosage: String
+    let frequency: String
+    let startDate: Date
+    let endDate: Date?
+    let createdAt: Date
+    let updatedAt: Date
+
+    nonisolated init(medication: ContinuousMedication) {
+        self.id = medication.id
+        self.name = medication.name
+        self.dosage = medication.dosage
+        self.frequency = medication.frequency
+        self.startDate = medication.startDate
+        self.endDate = medication.endDate
+        self.createdAt = medication.createdAt
+        self.updatedAt = medication.updatedAt
+    }
+
+    nonisolated func makeModel() -> ContinuousMedication {
+        ContinuousMedication(
+            id: id,
+            name: name,
+            dosage: dosage,
+            frequency: frequency,
+            startDate: startDate,
+            endDate: endDate,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+
+    nonisolated func apply(to medication: ContinuousMedication) {
+        medication.name = name
+        medication.dosage = dosage
+        medication.frequency = frequency
+        medication.startDate = startDate
+        medication.endDate = endDate
+        medication.createdAt = createdAt
+        medication.updatedAt = updatedAt
     }
 }
 

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -95,6 +95,12 @@ struct SettingsView: View {
 
             Section("Allgemein") {
                 NavigationLink {
+                    ContinuousMedicationSettingsView(controller: controller)
+                } label: {
+                    Label("Dauermedikation", systemImage: "pills")
+                }
+
+                NavigationLink {
                     DataExportView(appContainer: appContainer)
                 } label: {
                     Label("Daten und Backup", systemImage: "square.and.arrow.up")
@@ -231,6 +237,201 @@ struct SettingsView: View {
         #else
         .topBarLeading
         #endif
+    }
+}
+
+private struct ContinuousMedicationSettingsView: View {
+    @Bindable var controller: SettingsController
+
+    var body: some View {
+        List {
+            Section {
+                Button {
+                    controller.presentContinuousMedicationEditor(for: nil)
+                } label: {
+                    Label("Dauermedikation hinzufügen", systemImage: "plus")
+                }
+            } footer: {
+                Text("Dauermedikationen sind ein eigener Verlaufskontext und bleiben von Akutmedikation in Einträgen getrennt.")
+            }
+
+            Section("Aktuell") {
+                let active = controller.continuousMedications.filter(\.isActive)
+                if active.isEmpty {
+                    Text("Keine aktive Dauermedikation.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(active) { medication in
+                        ContinuousMedicationSettingsRow(
+                            medication: medication,
+                            onEdit: { controller.presentContinuousMedicationEditor(for: medication) },
+                            onEnd: { controller.endContinuousMedication(id: medication.id) }
+                        )
+                    }
+                }
+            }
+
+            Section("Beendet") {
+                let ended = controller.continuousMedications.filter { !$0.isActive }
+                if ended.isEmpty {
+                    Text("Keine beendete Dauermedikation.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(ended) { medication in
+                        ContinuousMedicationSettingsRow(
+                            medication: medication,
+                            onEdit: { controller.presentContinuousMedicationEditor(for: medication) },
+                            onEnd: nil
+                        )
+                    }
+                }
+            }
+
+            if let message = controller.continuousMedicationMessage {
+                Section {
+                    Text(message)
+                        .foregroundStyle(AppTheme.symiCoral)
+                }
+            }
+        }
+        .navigationTitle("Dauermedikation")
+        .brandGroupedScreen()
+        .sheet(item: $controller.continuousMedicationEditor) { draft in
+            NavigationStack {
+                ContinuousMedicationEditorSheet(
+                    draft: draft,
+                    onCancel: { controller.continuousMedicationEditor = nil },
+                    onSave: { draft in
+                        Task {
+                            await controller.saveContinuousMedication(draft)
+                        }
+                    }
+                )
+            }
+            .presentationDetents([.medium, .large])
+        }
+        .task {
+            controller.load()
+        }
+        .refreshable {
+            controller.load()
+        }
+    }
+}
+
+private struct ContinuousMedicationSettingsRow: View {
+    let medication: ContinuousMedicationRecord
+    let onEdit: () -> Void
+    let onEnd: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(medication.name)
+                        .font(.headline)
+                    if !medication.detailText.isEmpty {
+                        Text(medication.detailText)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                Text(medication.isActive ? "Aktiv" : "Beendet")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(medication.isActive ? AppTheme.symiSage : .secondary)
+            }
+
+            Text(dateRangeText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Button("Bearbeiten", action: onEdit)
+                if let onEnd {
+                    Button("Beenden", role: .destructive, action: onEnd)
+                }
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.vertical, 4)
+        .brandGroupedRow()
+    }
+
+    private var dateRangeText: String {
+        let start = medication.startDate.formatted(date: .abbreviated, time: .omitted)
+        guard let endDate = medication.endDate else {
+            return "Seit \(start)"
+        }
+
+        return "\(start) bis \(endDate.formatted(date: .abbreviated, time: .omitted))"
+    }
+}
+
+private struct ContinuousMedicationEditorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: ContinuousMedicationDraft
+    @State private var hasEndDate: Bool
+
+    let onCancel: () -> Void
+    let onSave: (ContinuousMedicationDraft) -> Void
+
+    init(
+        draft: ContinuousMedicationDraft,
+        onCancel: @escaping () -> Void,
+        onSave: @escaping (ContinuousMedicationDraft) -> Void
+    ) {
+        _draft = State(initialValue: draft)
+        _hasEndDate = State(initialValue: draft.endDate != nil)
+        self.onCancel = onCancel
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        Form {
+            Section("Medikament") {
+                TextField("Name", text: $draft.name)
+                    .textInputAutocapitalization(.words)
+                TextField("Dosierung, optional", text: $draft.dosage)
+                TextField("Frequenz, optional", text: $draft.frequency)
+            }
+
+            Section("Zeitraum") {
+                DatePicker("Startdatum", selection: $draft.startDate, displayedComponents: .date)
+                Toggle("Enddatum setzen", isOn: $hasEndDate.animation())
+                if hasEndDate {
+                    DatePicker(
+                        "Enddatum",
+                        selection: Binding(
+                            get: { draft.endDate ?? draft.startDate },
+                            set: { draft.endDate = $0 }
+                        ),
+                        displayedComponents: .date
+                    )
+                }
+            }
+        }
+        .navigationTitle(draft.id == nil ? "Dauermedikation" : "Bearbeiten")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Abbrechen") {
+                    onCancel()
+                    dismiss()
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Sichern") {
+                    var normalizedDraft = draft
+                    if !hasEndDate {
+                        normalizedDraft.endDate = nil
+                    }
+                    onSave(normalizedDraft)
+                    dismiss()
+                }
+            }
+        }
     }
 }
 

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -86,6 +86,10 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
             context.delete(medication)
         }
 
+        for check in target.continuousMedicationChecks {
+            context.delete(check)
+        }
+
         if let existingWeatherSnapshot = target.weatherSnapshot {
             context.delete(existingWeatherSnapshot)
             target.weatherSnapshot = nil
@@ -101,6 +105,18 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
                     quantity: $0.quantity,
                     takenAt: draft.startedAt,
                     effectiveness: .partial,
+                    episode: target
+                )
+            }
+
+        target.continuousMedicationChecks = draft.continuousMedicationChecks
+            .map {
+                ContinuousMedicationCheck(
+                    continuousMedicationID: $0.continuousMedicationID,
+                    name: $0.name,
+                    dosage: $0.dosage,
+                    frequency: $0.frequency,
+                    wasTaken: $0.wasTaken,
                     episode: target
                 )
             }
@@ -154,6 +170,89 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
     nonisolated private func fetchEpisode(id: UUID, in context: ModelContext) throws -> Episode? {
         let descriptor = FetchDescriptor<Episode>(
             predicate: #Predicate<Episode> { $0.id == id }
+        )
+        return try context.fetch(descriptor).first
+    }
+}
+
+final class SwiftDataContinuousMedicationRepository: ContinuousMedicationRepository, @unchecked Sendable {
+    private let modelContainer: ModelContainer
+
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+    }
+
+    nonisolated func fetchAll() throws -> [ContinuousMedicationRecord] {
+        let descriptor = FetchDescriptor<ContinuousMedication>(
+            sortBy: [SortDescriptor(\ContinuousMedication.startDate, order: .reverse), SortDescriptor(\ContinuousMedication.name)]
+        )
+        return try readContext().fetch(descriptor).map(ContinuousMedicationRecord.init)
+    }
+
+    nonisolated func fetchActive(on date: Date) throws -> [ContinuousMedicationRecord] {
+        let dayStart = Calendar.current.startOfDay(for: date)
+        let descriptor = FetchDescriptor<ContinuousMedication>(
+            sortBy: [SortDescriptor(\ContinuousMedication.name)]
+        )
+        return try readContext().fetch(descriptor)
+            .filter { medication in
+                medication.startDate <= dayStart && (medication.endDate == nil || (medication.endDate ?? .distantPast) >= dayStart)
+            }
+            .map(ContinuousMedicationRecord.init)
+    }
+
+    @discardableResult
+    nonisolated func save(_ draft: ContinuousMedicationDraft) throws -> ContinuousMedicationRecord {
+        let context = writeContext()
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedDosage = draft.dosage.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedFrequency = draft.frequency.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let medication: ContinuousMedication
+        if let id = draft.id, let existing = try fetchMedication(id: id, in: context) {
+            medication = existing
+            medication.name = trimmedName
+            medication.dosage = trimmedDosage
+            medication.frequency = trimmedFrequency
+            medication.startDate = draft.startDate
+            medication.endDate = draft.endDate
+            medication.markUpdated()
+        } else {
+            medication = ContinuousMedication(
+                name: trimmedName,
+                dosage: trimmedDosage,
+                frequency: trimmedFrequency,
+                startDate: draft.startDate,
+                endDate: draft.endDate
+            )
+            context.insert(medication)
+        }
+
+        try context.save()
+        return ContinuousMedicationRecord(medication: medication)
+    }
+
+    nonisolated func delete(id: UUID) throws {
+        let context = writeContext()
+        guard let medication = try fetchMedication(id: id, in: context) else {
+            return
+        }
+
+        context.delete(medication)
+        try context.save()
+    }
+
+    nonisolated private func readContext() -> ModelContext {
+        ModelContext(modelContainer)
+    }
+
+    nonisolated private func writeContext() -> ModelContext {
+        ModelContext(modelContainer)
+    }
+
+    nonisolated private func fetchMedication(id: UUID, in context: ModelContext) throws -> ContinuousMedication? {
+        let descriptor = FetchDescriptor<ContinuousMedication>(
+            predicate: #Predicate<ContinuousMedication> { $0.id == id }
         )
         return try context.fetch(descriptor).first
     }
@@ -290,9 +389,15 @@ final class SwiftDataExportRepository: ExportRepository, @unchecked Sendable {
                 sortBy: [SortDescriptor(\MedicationDefinition.sortOrder)]
             )
         )
+        let continuousMedications = try readContext.fetch(
+            FetchDescriptor<ContinuousMedication>(
+                sortBy: [SortDescriptor(\ContinuousMedication.startDate, order: .reverse), SortDescriptor(\ContinuousMedication.name)]
+            )
+        )
         let snapshot = DataTransferSnapshot(
             episodes: episodes,
             customMedicationDefinitions: definitions,
+            continuousMedications: continuousMedications,
             healthContextStore: healthContextStore
         )
         return try snapshot.writeToTemporaryFile()
@@ -331,8 +436,37 @@ private extension EpisodeRecord {
             functionalImpact: episode.functionalImpact,
             menstruationStatus: episode.menstruationStatus,
             medications: episode.medications.map(MedicationRecord.init),
+            continuousMedicationChecks: episode.continuousMedicationChecks.map(ContinuousMedicationCheckRecord.init),
             weather: episode.weatherSnapshot.map(WeatherRecord.init),
             healthContext: healthContextStore.load(for: episode.id)
+        )
+    }
+}
+
+private extension ContinuousMedicationRecord {
+    nonisolated init(medication: ContinuousMedication) {
+        self.init(
+            id: medication.id,
+            name: medication.name,
+            dosage: medication.dosage,
+            frequency: medication.frequency,
+            startDate: medication.startDate,
+            endDate: medication.endDate,
+            createdAt: medication.createdAt,
+            updatedAt: medication.updatedAt
+        )
+    }
+}
+
+private extension ContinuousMedicationCheckRecord {
+    nonisolated init(check: ContinuousMedicationCheck) {
+        self.init(
+            id: check.id,
+            continuousMedicationID: check.continuousMedicationID,
+            name: check.name,
+            dosage: check.dosage,
+            frequency: check.frequency,
+            wasTaken: check.wasTaken
         )
     }
 }

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -51,7 +51,8 @@ extension Episode {
         triggers: [String] = [],
         functionalImpact: String = "",
         menstruationStatus: MenstruationStatus = .unknown,
-        medications: [MedicationEntry] = []
+        medications: [MedicationEntry] = [],
+        continuousMedicationChecks: [ContinuousMedicationCheck] = []
     ) {
         self.init(
             id: id,
@@ -68,7 +69,8 @@ extension Episode {
             triggersStorage: triggers.joined(separator: "|"),
             functionalImpact: functionalImpact,
             menstruationStatusRaw: menstruationStatus.rawValue,
-            medications: medications
+            medications: medications,
+            continuousMedicationChecks: continuousMedicationChecks
         )
     }
 
@@ -120,6 +122,28 @@ extension Episode {
             .split(separator: "|")
             .map { String($0) }
             .filter { !$0.isEmpty }
+    }
+}
+
+extension ContinuousMedication {
+    var isActive: Bool {
+        endDate == nil || (endDate ?? .distantPast) >= Calendar.current.startOfDay(for: .now)
+    }
+
+    var detailText: String {
+        [dosage, frequency]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+
+    func markUpdated(at date: Date = .now) {
+        updatedAt = date
+    }
+
+    func end(on date: Date = .now) {
+        endDate = date
+        updatedAt = date
     }
 }
 

--- a/Symi/Sources/Models/ModelSchema.swift
+++ b/Symi/Sources/Models/ModelSchema.swift
@@ -1092,6 +1092,281 @@ enum SymiSchemaV5: VersionedSchema {
 
 
 }
+
+enum SymiSchemaV6: VersionedSchema {
+    static let versionIdentifier = Schema.Version(6, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Episode.self,
+            MedicationEntry.self,
+            MedicationDefinition.self,
+            ContinuousMedication.self,
+            ContinuousMedicationCheck.self,
+            WeatherSnapshot.self,
+        ]
+    }
+
+    @Model
+    final class Episode {
+        @Attribute(.unique) var id: UUID
+        var startedAt: Date
+        var endedAt: Date?
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+        var typeRaw: String
+        var intensity: Int
+        var painLocation: String
+        var painCharacter: String
+        var notes: String
+        var symptomsStorage: String
+        var triggersStorage: String
+        var functionalImpact: String
+        var menstruationStatusRaw: String
+
+        @Relationship(deleteRule: .cascade, inverse: \MedicationEntry.episode)
+        var medications: [MedicationEntry]
+
+        @Relationship(deleteRule: .cascade, inverse: \ContinuousMedicationCheck.episode)
+        var continuousMedicationChecks: [ContinuousMedicationCheck]
+
+        @Relationship(deleteRule: .cascade, inverse: \WeatherSnapshot.episode)
+        var weatherSnapshot: WeatherSnapshot?
+
+        init(
+            id: UUID = UUID(),
+            startedAt: Date,
+            endedAt: Date? = nil,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil,
+            typeRaw: String,
+            intensity: Int,
+            painLocation: String = "",
+            painCharacter: String = "",
+            notes: String = "",
+            symptomsStorage: String = "",
+            triggersStorage: String = "",
+            functionalImpact: String = "",
+            menstruationStatusRaw: String = MenstruationStatus.unknown.rawValue,
+            medications: [MedicationEntry] = [],
+            continuousMedicationChecks: [ContinuousMedicationCheck] = []
+        ) {
+            self.id = id
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+            self.typeRaw = typeRaw
+            self.intensity = intensity
+            self.painLocation = painLocation
+            self.painCharacter = painCharacter
+            self.notes = notes
+            self.symptomsStorage = symptomsStorage
+            self.triggersStorage = triggersStorage
+            self.functionalImpact = functionalImpact
+            self.menstruationStatusRaw = menstruationStatusRaw
+            self.medications = medications
+            self.continuousMedicationChecks = continuousMedicationChecks
+        }
+    }
+
+    @Model
+    final class MedicationEntry {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var categoryRaw: String
+        var dosage: String
+        var quantity: Int
+        var takenAt: Date
+        var effectivenessRaw: String
+        var reliefStartedAt: Date?
+        var isRepeatDose: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            categoryRaw: String,
+            dosage: String,
+            quantity: Int = 1,
+            takenAt: Date,
+            effectivenessRaw: String,
+            reliefStartedAt: Date? = nil,
+            isRepeatDose: Bool = false,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.dosage = dosage
+            self.quantity = quantity
+            self.takenAt = takenAt
+            self.effectivenessRaw = effectivenessRaw
+            self.reliefStartedAt = reliefStartedAt
+            self.isRepeatDose = isRepeatDose
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class MedicationDefinition {
+        @Attribute(.unique) var catalogKey: String
+        var groupID: String
+        var groupTitle: String
+        var groupFooter: String?
+        var name: String
+        var categoryRaw: String
+        var suggestedDosage: String
+        var sortOrder: Int
+        var isCustom: Bool
+        var createdAt: Date
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+
+        init(
+            catalogKey: String,
+            groupID: String,
+            groupTitle: String,
+            groupFooter: String? = nil,
+            name: String,
+            categoryRaw: String,
+            suggestedDosage: String,
+            sortOrder: Int,
+            isCustom: Bool,
+            createdAt: Date = .now,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil
+        ) {
+            self.catalogKey = catalogKey
+            self.groupID = groupID
+            self.groupTitle = groupTitle
+            self.groupFooter = groupFooter
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.suggestedDosage = suggestedDosage
+            self.sortOrder = sortOrder
+            self.isCustom = isCustom
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+        }
+    }
+
+    @Model
+    final class ContinuousMedication {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var dosage: String
+        var frequency: String
+        var startDate: Date
+        var endDate: Date?
+        var createdAt: Date
+        var updatedAt: Date
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            dosage: String = "",
+            frequency: String = "",
+            startDate: Date,
+            endDate: Date? = nil,
+            createdAt: Date = .now,
+            updatedAt: Date = .now
+        ) {
+            self.id = id
+            self.name = name
+            self.dosage = dosage
+            self.frequency = frequency
+            self.startDate = startDate
+            self.endDate = endDate
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+        }
+    }
+
+    @Model
+    final class ContinuousMedicationCheck {
+        @Attribute(.unique) var id: UUID
+        var continuousMedicationID: UUID
+        var name: String
+        var dosage: String
+        var frequency: String
+        var wasTaken: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            continuousMedicationID: UUID,
+            name: String,
+            dosage: String = "",
+            frequency: String = "",
+            wasTaken: Bool,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.continuousMedicationID = continuousMedicationID
+            self.name = name
+            self.dosage = dosage
+            self.frequency = frequency
+            self.wasTaken = wasTaken
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class WeatherSnapshot {
+        @Attribute(.unique) var id: UUID
+        var recordedAt: Date
+        var temperature: Double?
+        var condition: String
+        var humidity: Double?
+        var pressure: Double?
+        var precipitation: Double?
+        var weatherCode: Int?
+        var source: String
+        var dayRangeStart: Date?
+        var dayRangeEnd: Date?
+        var contextRangeStart: Date?
+        var contextRangeEnd: Date?
+        var contextPointsStorage: String
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            recordedAt: Date,
+            temperature: Double? = nil,
+            condition: String = "",
+            humidity: Double? = nil,
+            pressure: Double? = nil,
+            precipitation: Double? = nil,
+            weatherCode: Int? = nil,
+            source: String = "",
+            dayRangeStart: Date? = nil,
+            dayRangeEnd: Date? = nil,
+            contextRangeStart: Date? = nil,
+            contextRangeEnd: Date? = nil,
+            contextPointsStorage: String = "",
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.recordedAt = recordedAt
+            self.temperature = temperature
+            self.condition = condition
+            self.humidity = humidity
+            self.pressure = pressure
+            self.precipitation = precipitation
+            self.weatherCode = weatherCode
+            self.source = source
+            self.dayRangeStart = dayRangeStart
+            self.dayRangeEnd = dayRangeEnd
+            self.contextRangeStart = contextRangeStart
+            self.contextRangeEnd = contextRangeEnd
+            self.contextPointsStorage = contextPointsStorage
+            self.episode = episode
+        }
+    }
+}
+
 enum SymiMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
         [
@@ -1100,6 +1375,7 @@ enum SymiMigrationPlan: SchemaMigrationPlan {
             SymiSchemaV3.self,
             SymiSchemaV4.self,
             SymiSchemaV5.self,
+            SymiSchemaV6.self,
         ]
     }
 
@@ -1173,13 +1449,19 @@ enum SymiMigrationPlan: SchemaMigrationPlan {
                     try context.save()
                 },
                 didMigrate: nil
+            ),
+            .lightweight(
+                fromVersion: SymiSchemaV5.self,
+                toVersion: SymiSchemaV6.self
             )
         ]
     }
 }
 
-typealias Episode = SymiSchemaV5.Episode
-typealias MedicationEntry = SymiSchemaV5.MedicationEntry
-typealias MedicationDefinition = SymiSchemaV5.MedicationDefinition
-typealias WeatherSnapshot = SymiSchemaV5.WeatherSnapshot
+typealias Episode = SymiSchemaV6.Episode
+typealias MedicationEntry = SymiSchemaV6.MedicationEntry
+typealias MedicationDefinition = SymiSchemaV6.MedicationDefinition
+typealias ContinuousMedication = SymiSchemaV6.ContinuousMedication
+typealias ContinuousMedicationCheck = SymiSchemaV6.ContinuousMedicationCheck
+typealias WeatherSnapshot = SymiSchemaV6.WeatherSnapshot
 // Doctor- und Terminmodelle wurden mit Schema V5 aus dem aktiven Datenmodell entfernt.

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -378,6 +378,7 @@ private func makeEpisode(id: UUID, startedAt: Date, intensity: Int, deletedAt: D
         functionalImpact: "",
         menstruationStatus: .unknown,
         medications: [],
+        continuousMedicationChecks: [],
         weather: nil,
         healthContext: nil
     )

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -12,6 +12,7 @@ struct DataTransferHealthContextTests {
         let sourceContainer = try makeInMemoryContainer()
         let sourceHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
         try seedEpisode(id: episodeID, in: sourceContainer)
+        try seedContinuousMedication(in: sourceContainer)
         try sourceHealthStore.save(healthContext, for: episodeID)
 
         let backupURL = try SwiftDataExportRepository(
@@ -20,6 +21,7 @@ struct DataTransferHealthContextTests {
         ).createBackup()
         let backupText = try String(contentsOf: backupURL, encoding: .utf8)
         #expect(backupText.contains("\"healthContext\""))
+        #expect(backupText.contains("\"continuousMedications\""))
 
         let targetContainer = try makeInMemoryContainer()
         let targetHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
@@ -38,8 +40,11 @@ struct DataTransferHealthContextTests {
         #expect(importedEpisode.id == episodeID)
         #expect(importedEpisode.medications.count == 1)
         #expect(importedEpisode.medications.first?.name == "Sumatriptan")
+        #expect(importedEpisode.continuousMedicationChecks.first?.name == "Metoprolol")
         #expect(importedEpisode.weatherSnapshot?.condition == "Regen")
         #expect(importedEpisode.weatherSnapshot?.contextPoints.count == 1)
+        let importedContinuousMedications = try ModelContext(targetContainer).fetch(FetchDescriptor<ContinuousMedication>())
+        #expect(importedContinuousMedications.first?.name == "Metoprolol")
         #expect(targetHealthStore.load(for: episodeID) == HealthContextRecord(snapshot: healthContext))
     }
 
@@ -129,7 +134,7 @@ struct DataTransferHealthContextTests {
 }
 
 private func makeInMemoryContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV5.self)
+    let schema = Schema(versionedSchema: SymiSchemaV6.self)
     let configuration = ModelConfiguration(
         "test-\(UUID().uuidString)",
         schema: schema,
@@ -169,6 +174,16 @@ private func seedEpisode(id: UUID, notes: String = "Migräne nach Wetterwechsel"
         episode: episode
     )
     episode.medications = [medication]
+    episode.continuousMedicationChecks = [
+        ContinuousMedicationCheck(
+            continuousMedicationID: UUID(uuidString: "10000000-0000-0000-0000-000000000001")!,
+            name: "Metoprolol",
+            dosage: "50 mg",
+            frequency: "täglich",
+            wasTaken: true,
+            episode: episode
+        )
+    ]
     episode.weatherSnapshot = WeatherSnapshot(
         id: UUID(),
         recordedAt: startedAt,
@@ -197,6 +212,21 @@ private func seedEpisode(id: UUID, notes: String = "Migräne nach Wetterwechsel"
         episode: episode
     )
     context.insert(episode)
+    try context.save()
+}
+
+private func seedContinuousMedication(in container: ModelContainer) throws {
+    let context = ModelContext(container)
+    context.insert(
+        ContinuousMedication(
+            id: UUID(uuidString: "10000000-0000-0000-0000-000000000001")!,
+            name: "Metoprolol",
+            dosage: "50 mg",
+            frequency: "täglich",
+            startDate: Date(timeIntervalSince1970: 1_699_000_000),
+            endDate: nil
+        )
+    )
     try context.save()
 }
 

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -41,6 +41,35 @@ struct EntryFlowCoordinatorTests {
 
         #expect(coordinator.currentStep == .triggers)
         #expect(coordinator.draft.medications.isEmpty)
+        #expect(coordinator.draft.continuousMedicationChecks.isEmpty)
+    }
+
+    @Test
+    func medicationStepStoresContinuousMedicationChecksSeparatelyFromAcuteMedication() async {
+        let repository = EntryFlowContinuousMedicationRepositoryMock(activeMedications: [
+            ContinuousMedicationRecord(
+                id: UUID(),
+                name: "Metoprolol",
+                dosage: "50 mg",
+                frequency: "täglich",
+                startDate: .now,
+                endDate: nil,
+                createdAt: .now,
+                updatedAt: .now
+            )
+        ])
+        let coordinator = makeCoordinator(continuousMedicationRepository: repository)
+        await coordinator.continuousMedicationController.reload(for: .now)
+        coordinator.draft.continuousMedicationChecks = coordinator.continuousMedicationController.makeDefaultChecks()
+        coordinator.draft.continuousMedicationChecks[0].wasTaken = false
+
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+
+        #expect(coordinator.draft.continuousMedicationChecks.count == 1)
+        #expect(coordinator.draft.continuousMedicationChecks[0].name == "Metoprolol")
+        #expect(coordinator.draft.continuousMedicationChecks[0].wasTaken == false)
+        #expect(coordinator.draft.medications.isEmpty)
     }
 
     @Test
@@ -115,11 +144,13 @@ struct EntryFlowCoordinatorTests {
 
     private func makeCoordinator(
         repository: EntryFlowEpisodeRepositoryMock = EntryFlowEpisodeRepositoryMock(),
-        medicationRepository: EntryFlowMedicationRepositoryMock = EntryFlowMedicationRepositoryMock()
+        medicationRepository: EntryFlowMedicationRepositoryMock = EntryFlowMedicationRepositoryMock(),
+        continuousMedicationRepository: EntryFlowContinuousMedicationRepositoryMock = EntryFlowContinuousMedicationRepositoryMock()
     ) -> EntryFlowCoordinator {
         EntryFlowCoordinator(
             episodeRepository: repository,
             medicationRepository: medicationRepository,
+            continuousMedicationRepository: continuousMedicationRepository,
             autoloadMedications: false
         )
     }
@@ -179,4 +210,28 @@ private final class EntryFlowMedicationRepositoryMock: MedicationCatalogReposito
 
     func softDeleteCustomDefinition(catalogKey: String) throws {}
     func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord] { [] }
+}
+
+private final class EntryFlowContinuousMedicationRepositoryMock: ContinuousMedicationRepository, @unchecked Sendable {
+    let activeMedications: [ContinuousMedicationRecord]
+
+    init(activeMedications: [ContinuousMedicationRecord] = []) {
+        self.activeMedications = activeMedications
+    }
+
+    func fetchAll() throws -> [ContinuousMedicationRecord] { [] }
+    func fetchActive(on date: Date) throws -> [ContinuousMedicationRecord] { activeMedications }
+    func save(_ draft: ContinuousMedicationDraft) throws -> ContinuousMedicationRecord {
+        ContinuousMedicationRecord(
+            id: draft.id ?? UUID(),
+            name: draft.name,
+            dosage: draft.dosage,
+            frequency: draft.frequency,
+            startDate: draft.startDate,
+            endDate: draft.endDate,
+            createdAt: .now,
+            updatedAt: .now
+        )
+    }
+    func delete(id: UUID) throws {}
 }

--- a/SymiTests/PersistentStoreRecoveryTests.swift
+++ b/SymiTests/PersistentStoreRecoveryTests.swift
@@ -18,7 +18,7 @@ struct PersistentStoreRecoveryTests {
         try walData.write(to: walURL)
         try shmData.write(to: shmURL)
 
-        let schema = Schema(versionedSchema: SymiSchemaV5.self)
+        let schema = Schema(versionedSchema: SymiSchemaV6.self)
         let configuration = ModelConfiguration(
             "default",
             schema: schema,

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -278,7 +278,7 @@ private func makeSyncTestStack() throws -> (
     coordinator: SyncCoordinator,
     repository: LocalSyncRepository
 ) {
-    let schema = Schema(versionedSchema: SymiSchemaV5.self)
+    let schema = Schema(versionedSchema: SymiSchemaV6.self)
     let configuration = ModelConfiguration(
         "sync-tests-\(UUID().uuidString)",
         schema: schema,


### PR DESCRIPTION
## Zusammenfassung
- ergänzt SwiftData V6 mit Dauermedikation und separaten Tagesbestätigungen im Eintrag
- baut Verwaltung für Dauermedikationen in den Einstellungen und kontextuelle "Heute genommen?"-Card im Medikation-Step
- erweitert JSON5-Backup/Import sowie Tests für getrennte Akut- und Dauermedikation

## Tests
- xcodebuild test -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 16'

Closes #167