### PR TITLE
[codex] Implement entry review save flow

### DIFF
--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -78,7 +78,9 @@ final class AppContainer {
             initialStartedAt: initialStartedAt,
             episodeRepository: episodeRepository,
             medicationRepository: medicationCatalogRepository,
-            continuousMedicationRepository: continuousMedicationRepository
+            continuousMedicationRepository: continuousMedicationRepository,
+            weatherContextService: episodeWeatherContextService,
+            healthService: healthService
         )
     }
 

--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -112,16 +112,21 @@ final class EntryFlowCoordinator {
     var path: [EntryFlowStep] = []
     var isSaving = false
     var saveResult: EntryFlowSaveResult?
+    var weatherLoadState: WeatherLoadState = .idle
     private(set) var isCancelled = false
 
     private let initialStartedAt: Date?
     private let saveEpisodeUseCase: SaveEpisodeUseCase
+    private let weatherContextService: any EpisodeWeatherContextProviding
+    private let healthService: any HealthService
 
     init(
         initialStartedAt: Date? = nil,
         episodeRepository: EpisodeRepository,
         medicationRepository: MedicationCatalogRepository,
         continuousMedicationRepository: ContinuousMedicationRepository,
+        weatherContextService: any EpisodeWeatherContextProviding,
+        healthService: any HealthService,
         autoloadMedications: Bool = true
     ) {
         self.initialStartedAt = initialStartedAt
@@ -135,6 +140,8 @@ final class EntryFlowCoordinator {
             autoload: autoloadMedications
         )
         self.saveEpisodeUseCase = SaveEpisodeUseCase(repository: episodeRepository)
+        self.weatherContextService = weatherContextService
+        self.healthService = healthService
     }
 
     var currentStep: EntryFlowStep {
@@ -198,6 +205,7 @@ final class EntryFlowCoordinator {
         path = []
         draft = EpisodeDraft.makeNew(initialStartedAt: initialStartedAt)
         medicationController.resetSelections()
+        weatherLoadState = .idle
         saveResult = nil
         isSaving = false
     }
@@ -212,6 +220,20 @@ final class EntryFlowCoordinator {
 
     func selectStartedAtPreset(_ preset: EntryStartedAtPreset, calendar: Calendar = .current) {
         draft.startedAt = preset.date(relativeTo: .now, calendar: calendar)
+        weatherLoadState = .idle
+    }
+
+    func refreshWeatherIfNeeded() async {
+        guard weatherLoadState == .idle else {
+            return
+        }
+
+        weatherLoadState = .loading
+        weatherLoadState = await weatherContextService.loadWeather(
+            for: draft.startedAt,
+            originalStartedAt: nil,
+            originalSnapshot: nil
+        )
     }
 
     private var nextStep: EntryFlowStep? {
@@ -242,12 +264,27 @@ final class EntryFlowCoordinator {
         }
     }
 
+    private func makeDraftForSave() -> EpisodeDraft {
+        var draftForSave = draft
+        draftForSave.type = .headache
+        draftForSave.intensity = draftForSave.normalizedIntensity
+        draftForSave.painLocation = draftForSave.resolvedPainLocation
+        draftForSave.medications = medicationController.medications
+
+        if currentStep == .medication, draftForSave.continuousMedicationChecks.isEmpty {
+            draftForSave.continuousMedicationChecks = continuousMedicationController.makeDefaultChecks()
+        }
+
+        return draftForSave
+    }
+
     private func save(resetAfterSave: Bool) {
         guard !isSaving else {
             return
         }
 
-        applyStepSideEffects()
+        let draftForSave = makeDraftForSave()
+        draft = draftForSave
         saveResult = nil
         isSaving = true
 
@@ -255,7 +292,14 @@ final class EntryFlowCoordinator {
             defer { isSaving = false }
 
             do {
-                let savedID = try await saveEpisodeUseCase.execute(draft, weatherSnapshot: nil, healthContext: nil)
+                let weatherSnapshot = try await weatherSnapshotForSave(startedAt: draftForSave.startedAt)
+                let healthContext = await healthContextForSave(draft: draftForSave)
+                let savedID = try await saveEpisodeUseCase.execute(
+                    draftForSave,
+                    weatherSnapshot: weatherSnapshot,
+                    healthContext: healthContext
+                )
+                await writeHealthSampleIfNeeded(episodeID: savedID, draft: draftForSave)
                 saveResult = .saved(savedID)
 
                 if resetAfterSave {
@@ -263,8 +307,50 @@ final class EntryFlowCoordinator {
                     isCancelled = false
                 }
             } catch {
-                saveResult = .failed(error.localizedDescription)
+                saveResult = .failed(saveFailureMessage(for: error))
             }
         }
+    }
+
+    private func weatherSnapshotForSave(startedAt: Date) async throws -> WeatherSnapshotData? {
+        let resolution = try await weatherContextService.snapshotForSave(
+            startedAt: startedAt,
+            currentState: weatherLoadState,
+            originalStartedAt: nil,
+            originalSnapshot: nil
+        )
+        weatherLoadState = resolution.state
+        return resolution.snapshot
+    }
+
+    private func healthContextForSave(draft: EpisodeDraft) async -> HealthContextSnapshotData? {
+        do {
+            return try await healthService.contextSnapshot(for: draft)
+        } catch {
+            return nil
+        }
+    }
+
+    private func writeHealthSampleIfNeeded(episodeID: UUID, draft: EpisodeDraft) async {
+        do {
+            try await healthService.writeEpisode(id: episodeID, draft: draft)
+        } catch {}
+    }
+
+    private func saveFailureMessage(for error: Error) -> String {
+        if let episodeError = error as? EpisodeSaveError {
+            switch episodeError {
+            case .invalidDateRange:
+                return "Bitte prüfe Beginn und Ende deines Eintrags."
+            case .futureDate:
+                return "Bitte wähle einen Zeitpunkt, der nicht in der Zukunft liegt."
+            }
+        }
+
+        if let localizedError = error as? LocalizedError, let description = localizedError.errorDescription {
+            return description
+        }
+
+        return "Der Eintrag konnte gerade nicht gespeichert werden. Bitte versuche es noch einmal."
     }
 }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -527,25 +527,56 @@ private struct EntryReviewStepView: View {
     let coordinator: EntryFlowCoordinator
 
     var body: some View {
+        @Bindable var coordinator = coordinator
+
         Form {
             EntryStepHeader(step: .review, currentIndex: coordinator.currentStepIndex)
 
-            Section("Zusammenfassung") {
-                EntryReviewRow(title: "Kopfschmerz", value: "\(coordinator.draft.type.rawValue), \(coordinator.draft.intensity)/10") {
-                    coordinator.edit(.headache)
-                }
+            Section {
+                VStack(alignment: .leading, spacing: 14) {
+                    EntryReviewSummarySection(
+                        step: .headache,
+                        lines: headacheSummary,
+                        onEdit: { coordinator.edit(.headache) }
+                    )
 
-                EntryReviewRow(title: "Medikation", value: medicationSummary) {
-                    coordinator.edit(.medication)
-                }
+                    if shouldShowMedicationSummary {
+                        EntryReviewSummarySection(
+                            step: .medication,
+                            lines: medicationSummary,
+                            onEdit: { coordinator.edit(.medication) }
+                        )
+                    }
 
-                EntryReviewRow(title: "Auslöser", value: listSummary(coordinator.draft.selectedTriggers)) {
-                    coordinator.edit(.triggers)
-                }
+                    if !coordinator.draft.selectedTriggers.isEmpty {
+                        EntryReviewSummarySection(
+                            step: .triggers,
+                            lines: triggerSummary,
+                            onEdit: { coordinator.edit(.triggers) }
+                        )
+                    }
 
-                EntryReviewRow(title: "Notiz", value: coordinator.draft.notes.isEmpty ? "Keine Notiz" : coordinator.draft.notes) {
-                    coordinator.edit(.note)
+                    if let weatherSummary {
+                        EntryReviewSummarySection(
+                            step: .triggers,
+                            title: "Wetterkontext",
+                            lines: weatherSummary,
+                            onEdit: { coordinator.edit(.triggers) }
+                        )
+                    }
+
+                    if shouldShowNoteSummary {
+                        EntryReviewSummarySection(
+                            step: .note,
+                            title: "Notiz und Gefühl",
+                            lines: noteSummary,
+                            onEdit: { coordinator.edit(.note) }
+                        )
+                    }
                 }
+                .padding(.vertical, 4)
+            } footer: {
+                Text("Dein Eintrag hilft dir, Muster besser zu erkennen.")
             }
 
             Section {
@@ -557,35 +588,123 @@ private struct EntryReviewStepView: View {
                     }
                 }
                 .disabled(coordinator.isSaving)
+
+                Button("Bearbeiten") {
+                    coordinator.edit(.headache)
+                }
+                .disabled(coordinator.isSaving)
             }
         }
         .navigationTitle("Eintrag prüfen")
         .brandGroupedScreen()
+        .task {
+            await coordinator.refreshWeatherIfNeeded()
+        }
     }
 
-    private var medicationSummary: String {
+    private var headacheSummary: [String] {
+        let draft = coordinator.draft
+        return [
+            "Intensität \(draft.normalizedIntensity)/10 · \(intensityLabel(for: draft.normalizedIntensity))",
+            draft.resolvedPainLocation.isEmpty ? "Ort nicht angegeben" : "Ort: \(draft.resolvedPainLocation)",
+            "Zeitpunkt: \(draft.startedAt.formatted(date: .abbreviated, time: .shortened))"
+        ]
+    }
+
+    private var shouldShowMedicationSummary: Bool {
+        !coordinator.medicationController.selectedMedications.isEmpty ||
+        !coordinator.draft.continuousMedicationChecks.isEmpty
+    }
+
+    private var medicationSummary: [String] {
         let selected = coordinator.medicationController.selectedMedications
         let continuous = coordinator.draft.continuousMedicationChecks
-        guard !selected.isEmpty || !continuous.isEmpty else {
-            return "Keine Medikation"
-        }
 
         let continuousSummary = continuous.map {
-            "\($0.name): \($0.wasTaken ? "genommen" : "nicht genommen")"
+            let detail = $0.detailText.isEmpty ? "" : " · \($0.detailText)"
+            return "\($0.name)\(detail): \($0.wasTaken ? "genommen" : "nicht genommen")"
         }
         let acuteSummary = selected.map { medication in
-            medication.quantity > 1 ? "\(medication.name) x\(medication.quantity)" : medication.name
+            var parts = [medication.name]
+            if !medication.dosage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                parts.append(medication.dosage)
+            }
+            if medication.quantity > 1 {
+                parts.append("x\(medication.quantity)")
+            }
+            parts.append("Zeitpunkt: \(coordinator.draft.startedAt.formatted(date: .omitted, time: .shortened))")
+            return parts.joined(separator: " · ")
         }
 
-        return (continuousSummary + acuteSummary).joined(separator: ", ")
+        return continuousSummary + acuteSummary
     }
 
-    private func listSummary(_ values: Set<String>) -> String {
-        guard !values.isEmpty else {
-            return "Nichts ausgewählt"
+    private var triggerSummary: [String] {
+        coordinator.draft.selectedTriggers.sorted()
+    }
+
+    private var weatherSummary: [String]? {
+        switch coordinator.weatherLoadState {
+        case .loaded(let weather):
+            var lines = [weather.condition]
+            if let temperature = weather.temperature {
+                lines.append("Temperatur \(temperature.formatted(.number.precision(.fractionLength(1)))) °C")
+            }
+            if let pressure = weather.pressure {
+                lines.append("Luftdruck \(pressure.formatted(.number.precision(.fractionLength(0)))) hPa")
+            }
+            if let humidity = weather.humidity {
+                lines.append("Luftfeuchte \(humidity.formatted(.number.precision(.fractionLength(0)))) %")
+            }
+            if let precipitation = weather.precipitation {
+                lines.append("Niederschlag \(precipitation.formatted(.number.precision(.fractionLength(1)))) mm")
+            }
+            return lines
+        case .loading:
+            return ["Wetter wird gerade geladen."]
+        case .idle, .unavailable:
+            return nil
+        }
+    }
+
+    private var shouldShowNoteSummary: Bool {
+        !noteSummary.isEmpty
+    }
+
+    private var noteSummary: [String] {
+        let draft = coordinator.draft
+        var lines: [String] = []
+        let notes = draft.notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        let feeling = draft.painCharacter.trimmingCharacters(in: .whitespacesAndNewlines)
+        let impact = draft.functionalImpact.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !notes.isEmpty {
+            lines.append(notes)
+        }
+        if !feeling.isEmpty {
+            lines.append("Gefühl: \(feeling)")
+        }
+        if !impact.isEmpty {
+            lines.append("Einschränkung: \(impact)")
+        }
+        if draft.menstruationStatus != .unknown {
+            lines.append("Regel: \(draft.menstruationStatus.rawValue)")
         }
 
-        return values.sorted().joined(separator: ", ")
+        return lines
+    }
+
+    private func intensityLabel(for intensity: Int) -> String {
+        switch intensity {
+        case 1 ... 3:
+            "Leicht"
+        case 4 ... 6:
+            "Mittel"
+        case 7 ... 8:
+            "Stark"
+        default:
+            "Sehr stark"
+        }
     }
 }
 
@@ -644,27 +763,62 @@ private struct EntryStepActions: View {
     }
 }
 
-private struct EntryReviewRow: View {
-    let title: String
-    let value: String
+private struct EntryReviewSummarySection: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let step: EntryFlowStep
+    let title: String?
+    let lines: [String]
     let onEdit: () -> Void
 
+    init(
+        step: EntryFlowStep,
+        title: String? = nil,
+        lines: [String],
+        onEdit: @escaping () -> Void
+    ) {
+        self.step = step
+        self.title = title
+        self.lines = lines
+        self.onEdit = onEdit
+    }
+
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
+        let metadata = NewEntryStepCatalog.metadata(for: step.catalogID)
+
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 10) {
+                StepIcon(metadata)
+                    .frame(width: 36, height: 36)
+
+                Text(title ?? metadata.title)
                     .font(.subheadline.weight(.semibold))
-                Text(value)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(3)
+
+                Spacer(minLength: 8)
+
+                Button("Bearbeiten", action: onEdit)
+                    .font(.caption.weight(.semibold))
             }
 
-            Spacer(minLength: 12)
-
-            Button("Bearbeiten", action: onEdit)
-                .font(.subheadline.weight(.semibold))
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(lines, id: \.self) { line in
+                    Text(line)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(.leading, 46)
         }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(metadata.colorToken.softFill(for: colorScheme))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(metadata.colorToken.border(for: colorScheme), lineWidth: 1)
+        }
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
+++ b/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
@@ -62,7 +62,7 @@ enum NewEntryStepCatalog {
         NewEntryStepMetadata(
             id: .review,
             title: "Eintrag prüfen",
-            subline: "Kurz ansehen und speichern.",
+            subline: "Alles bereit zum Speichern.",
             symbolName: "checkmark.seal.fill",
             colorToken: .purple,
             status: nil

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -116,6 +116,36 @@ struct EntryFlowCoordinatorTests {
     }
 
     @Test
+    func reviewSaveFinalizesDraftWithWeatherAndHealthContext() async throws {
+        let repository = EntryFlowEpisodeRepositoryMock()
+        let weatherContext = EntryFlowWeatherContextMock(snapshot: makeWeatherSnapshot())
+        let healthService = EntryFlowHealthServiceMock(snapshot: makeHealthContext())
+        let coordinator = makeCoordinator(
+            repository: repository,
+            weatherContextService: weatherContext,
+            healthService: healthService
+        )
+        coordinator.draft.intensity = 7
+        coordinator.draft.selectedPainLocations = ["Stirn"]
+        coordinator.draft.selectedTriggers = ["Stress"]
+
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+        coordinator.continueToNextStep()
+        coordinator.saveFromReview()
+        try await waitForSaveResult(on: coordinator)
+
+        #expect(repository.saveCount == 1)
+        #expect(repository.lastSavedDraft?.type == .headache)
+        #expect(repository.lastSavedDraft?.intensity == 7)
+        #expect(repository.lastSavedDraft?.resolvedPainLocation == "Stirn")
+        #expect(repository.lastWeatherSnapshot == makeWeatherSnapshot())
+        #expect(repository.lastHealthContext == makeHealthContext())
+        #expect(healthService.writtenEpisodeID == repository.savedID)
+    }
+
+    @Test
     func startedAtPresetsUpdateDraftTime() {
         let calendar = Calendar(identifier: .gregorian)
         let coordinator = makeCoordinator()
@@ -145,13 +175,44 @@ struct EntryFlowCoordinatorTests {
     private func makeCoordinator(
         repository: EntryFlowEpisodeRepositoryMock = EntryFlowEpisodeRepositoryMock(),
         medicationRepository: EntryFlowMedicationRepositoryMock = EntryFlowMedicationRepositoryMock(),
-        continuousMedicationRepository: EntryFlowContinuousMedicationRepositoryMock = EntryFlowContinuousMedicationRepositoryMock()
+        continuousMedicationRepository: EntryFlowContinuousMedicationRepositoryMock = EntryFlowContinuousMedicationRepositoryMock(),
+        weatherContextService: EntryFlowWeatherContextMock = EntryFlowWeatherContextMock(),
+        healthService: EntryFlowHealthServiceMock = EntryFlowHealthServiceMock()
     ) -> EntryFlowCoordinator {
         EntryFlowCoordinator(
             episodeRepository: repository,
             medicationRepository: medicationRepository,
             continuousMedicationRepository: continuousMedicationRepository,
+            weatherContextService: weatherContextService,
+            healthService: healthService,
             autoloadMedications: false
+        )
+    }
+
+    private func makeWeatherSnapshot() -> WeatherSnapshotData {
+        WeatherSnapshotData(
+            recordedAt: Date(timeIntervalSince1970: 1_776_000_000),
+            condition: "Leichter Regen",
+            temperature: 12.5,
+            humidity: 72,
+            pressure: 1_013,
+            precipitation: 1.2,
+            weatherCode: 63,
+            source: "Test"
+        )
+    }
+
+    private func makeHealthContext() -> HealthContextSnapshotData {
+        HealthContextSnapshotData(
+            recordedAt: Date(timeIntervalSince1970: 1_776_000_000),
+            source: "Test",
+            sleepMinutes: 420,
+            stepCount: nil,
+            averageHeartRate: nil,
+            restingHeartRate: nil,
+            heartRateVariability: nil,
+            menstrualFlow: nil,
+            symptoms: []
         )
     }
 
@@ -174,6 +235,9 @@ private enum EntryFlowTestError: Error {
 private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, @unchecked Sendable {
     let savedID = UUID()
     var lastSavedDraft: EpisodeDraft?
+    var lastWeatherSnapshot: WeatherSnapshotData?
+    var lastHealthContext: HealthContextSnapshotData?
+    var saveCount = 0
 
     func fetchRecent() throws -> [EpisodeRecord] { [] }
     func fetchByDay(_ day: Date) throws -> [EpisodeRecord] { [] }
@@ -181,7 +245,10 @@ private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, @unchecke
     func load(id: UUID) throws -> EpisodeRecord? { nil }
 
     func save(draft: EpisodeDraft, weatherSnapshot: WeatherSnapshotData?, healthContext: HealthContextSnapshotData?) throws -> UUID {
+        saveCount += 1
         lastSavedDraft = draft
+        lastWeatherSnapshot = weatherSnapshot
+        lastHealthContext = healthContext
         return savedID
     }
 
@@ -234,4 +301,55 @@ private final class EntryFlowContinuousMedicationRepositoryMock: ContinuousMedic
         )
     }
     func delete(id: UUID) throws {}
+}
+
+@MainActor
+private final class EntryFlowWeatherContextMock: EpisodeWeatherContextProviding {
+    let snapshot: WeatherSnapshotData?
+
+    init(snapshot: WeatherSnapshotData? = nil) {
+        self.snapshot = snapshot
+    }
+
+    func loadWeather(
+        for startedAt: Date,
+        originalStartedAt: Date?,
+        originalSnapshot: WeatherSnapshotData?
+    ) async -> WeatherLoadState {
+        snapshot.map { .loaded($0) } ?? .unavailable("Kein Wetter verfügbar.")
+    }
+
+    func snapshotForSave(
+        startedAt: Date,
+        currentState: WeatherLoadState,
+        originalStartedAt: Date?,
+        originalSnapshot: WeatherSnapshotData?
+    ) async throws -> EpisodeWeatherSnapshotResolution {
+        EpisodeWeatherSnapshotResolution(
+            snapshot: snapshot,
+            state: snapshot.map { .loaded($0) } ?? .unavailable("Kein Wetter verfügbar.")
+        )
+    }
+}
+
+private final class EntryFlowHealthServiceMock: HealthService {
+    let snapshot: HealthContextSnapshotData?
+    var writtenEpisodeID: UUID?
+
+    init(snapshot: HealthContextSnapshotData? = nil) {
+        self.snapshot = snapshot
+    }
+
+    var readDefinitions: [HealthDataTypeDefinition] { [] }
+    var writeDefinitions: [HealthDataTypeDefinition] { [] }
+
+    func authorizationSnapshot() -> HealthAuthorizationSnapshot { .unavailable }
+    func setEnabled(_ enabled: Bool, for type: HealthDataTypeID, direction: HealthDataDirection) {}
+    func requestReadAuthorization() async throws {}
+    func requestWriteAuthorization() async throws {}
+    func contextSnapshot(for draft: EpisodeDraft) async throws -> HealthContextSnapshotData? { snapshot }
+
+    func writeEpisode(id: UUID, draft: EpisodeDraft) async throws {
+        writtenEpisodeID = id
+    }
 }

--- a/SymiTests/NewEntryDesignSystemTests.swift
+++ b/SymiTests/NewEntryDesignSystemTests.swift
@@ -21,7 +21,7 @@ struct NewEntryDesignSystemTests {
             .medication: ("Medikation", "Was hast du genommen?", "pills.fill", .sageTeal),
             .triggers: ("Auslöser", "Was könnte eine Rolle gespielt haben?", "brain.head.profile", .blue),
             .note: ("Notiz", "Was fällt dir auf?", "note.text", .warmAmber),
-            .review: ("Eintrag prüfen", "Kurz ansehen und speichern.", "checkmark.seal.fill", .purple)
+            .review: ("Eintrag prüfen", "Alles bereit zum Speichern.", "checkmark.seal.fill", .purple)
         ]
 
         for step in NewEntryStepCatalog.steps {


### PR DESCRIPTION
## Was geändert wurde

- Finaler Step `Eintrag prüfen` zeigt eine ruhige Summary-Card mit Step-Symbolen und Farben.
- Summary enthält Kopfschmerz, optionale Medikation, Auslöser, Wetterkontext sowie Notiz/Gefühl, wenn vorhanden.
- Review-Speichern überführt den Draft zentral in den finalen Eintrag und speichert Wetter-/Health-Kontext über den bestehenden Repository-Pfad.
- Fehler beim Speichern werden im neuen Flow freundlich formuliert.

## Validierung

- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination "platform=iOS Simulator,name=iPhone 16"`

Closes #169
