### PR TITLE
Neuen Eintrag Flow barrierefrei absichern

### DIFF
--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -280,7 +280,11 @@ struct ScreenshotRootView: View {
 
 private struct ScreenshotWeatherService: WeatherService {
     func fetchWeather(for date: Date, location: CLLocation) async throws -> WeatherSnapshotData? {
-        WeatherSnapshotData(
+        if ProcessInfo.processInfo.arguments.contains("-mt_disable_weather") {
+            return nil
+        }
+
+        return WeatherSnapshotData(
             recordedAt: date,
             condition: "Leichter Regen",
             temperature: 16.3,

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -386,7 +386,7 @@ struct EpisodeDraft: Equatable, Sendable {
         return EpisodeDraft(
             id: nil,
             type: .unclear,
-            intensity: 5,
+            intensity: 4,
             startedAt: startedAt,
             endedAtEnabled: false,
             endedAt: startedAt,

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -21,16 +21,17 @@ struct EntryFlowCoordinatorView: View {
         @Bindable var coordinator = coordinator
 
         NavigationStack(path: $coordinator.path) {
-            EntryHeadacheStepView(coordinator: coordinator)
-                .navigationDestination(for: EntryFlowStep.self) { step in
-                    destination(for: step)
-                }
-        }
-        .toolbar {
-            ToolbarItem(placement: dismissButtonPlacement) {
-                Button("Abbrechen", action: cancel)
+            EntryHeadacheStepView(
+                coordinator: coordinator,
+                onBack: cancel,
+                onCancel: cancel
+            )
+            .navigationDestination(for: EntryFlowStep.self) { step in
+                destination(for: step)
             }
         }
+        .toolbar(.hidden, for: .navigationBar)
+        .tint(AppTheme.symiPetrol)
         .alert("Eintrag gespeichert", isPresented: savedBinding) {
             Button("OK", role: .cancel, action: finishAfterSave)
         } message: {
@@ -51,15 +52,35 @@ struct EntryFlowCoordinatorView: View {
     private func destination(for step: EntryFlowStep) -> some View {
         switch step {
         case .headache:
-            EntryHeadacheStepView(coordinator: coordinator)
+            EntryHeadacheStepView(
+                coordinator: coordinator,
+                onBack: cancel,
+                onCancel: cancel
+            )
         case .medication:
-            EntryMedicationStepView(coordinator: coordinator)
+            EntryMedicationStepView(
+                coordinator: coordinator,
+                onBack: goBack,
+                onCancel: cancel
+            )
         case .triggers:
-            EntryTriggersStepView(coordinator: coordinator)
+            EntryTriggersStepView(
+                coordinator: coordinator,
+                onBack: goBack,
+                onCancel: cancel
+            )
         case .note:
-            EntryNoteStepView(coordinator: coordinator)
+            EntryNoteStepView(
+                coordinator: coordinator,
+                onBack: goBack,
+                onCancel: cancel
+            )
         case .review:
-            EntryReviewStepView(coordinator: coordinator)
+            EntryReviewStepView(
+                coordinator: coordinator,
+                onBack: goBack,
+                onCancel: cancel
+            )
         }
     }
 
@@ -95,12 +116,12 @@ struct EntryFlowCoordinatorView: View {
         )
     }
 
-    private var dismissButtonPlacement: ToolbarItemPlacement {
-        #if targetEnvironment(macCatalyst)
-        .topBarTrailing
-        #else
-        .topBarLeading
-        #endif
+    private func goBack() {
+        if coordinator.path.isEmpty {
+            cancel()
+        } else {
+            coordinator.path.removeLast()
+        }
     }
 
     private func cancel() {
@@ -117,210 +138,210 @@ struct EntryFlowCoordinatorView: View {
 
 private struct EntryHeadacheStepView: View {
     let coordinator: EntryFlowCoordinator
+    let onBack: () -> Void
+    let onCancel: () -> Void
 
     @State private var selectedStartedAtPreset: EntryStartedAtPreset = .now
+
+    private let visiblePainLocations = ["Stirn", "Schläfen", "Nacken", "Einseitig"]
 
     var body: some View {
         @Bindable var coordinator = coordinator
 
-        Form {
-            EntryStepHeader(step: .headache, currentIndex: coordinator.currentStepIndex)
+        EntryFlowScreen(
+            step: .headache,
+            currentIndex: coordinator.currentStepIndex,
+            onBack: onBack,
+            onCancel: onCancel
+        ) {
+            HeadacheIntensityCard(intensity: $coordinator.draft.intensity)
 
-            Section {
-                HeadacheIntensityCard(intensity: $coordinator.draft.intensity)
-            } header: {
-                Text("Intensität")
-            } footer: {
-                Text("Du kannst nach diesem Schritt direkt speichern oder weitere Details ergänzen.")
+            EntryFieldGroup(title: "Wo spürst du den Schmerz?") {
+                EntryTileGrid(minimumColumnWidth: 68) {
+                    ForEach(visiblePainLocations, id: \.self) { location in
+                        EntryOptionTile(
+                            title: location,
+                            systemImage: painLocationSymbol(for: location),
+                            isSelected: coordinator.draft.selectedPainLocations.contains(location),
+                            colorToken: .coral,
+                            accessibilityIdentifier: "entry-location-\(location)"
+                        ) {
+                            toggle(location, in: &coordinator.draft.selectedPainLocations)
+                        }
+                    }
+                }
             }
 
-            Section("Schmerzort") {
-                MultiSelectGrid(
-                    options: coordinator.painLocationOptions,
-                    selection: $coordinator.draft.selectedPainLocations,
-                    colorToken: NewEntryStepCatalog.metadata(for: .headache).colorToken,
-                    accessibilityPrefix: "Schmerzort"
-                )
-            }
-
-            Section("Zeitpunkt") {
-                Picker("Zeitpunkt", selection: $selectedStartedAtPreset) {
+            EntryFieldGroup(title: "Wann tritt es auf?") {
+                EntryChipRow {
                     ForEach(EntryStartedAtPreset.allCases) { preset in
-                        Text(preset.title).tag(preset)
-                    }
-                }
-                .pickerStyle(.inline)
-                .onChange(of: selectedStartedAtPreset) { _, preset in
-                    if preset != .custom {
-                        coordinator.selectStartedAtPreset(preset)
+                        EntrySelectionChip(
+                            title: preset.title,
+                            isSelected: selectedStartedAtPreset == preset,
+                            colorToken: .coral,
+                            accessibilityIdentifier: "entry-started-at-\(preset.rawValue)"
+                        ) {
+                            selectedStartedAtPreset = preset
+                            if preset != .custom {
+                                coordinator.selectStartedAtPreset(preset)
+                            }
+                        }
                     }
                 }
 
-                DatePicker(
-                    "Beginn",
-                    selection: $coordinator.draft.startedAt,
-                    in: ...Date.now,
-                    displayedComponents: [.date, .hourAndMinute]
-                )
-                .disabled(selectedStartedAtPreset != .custom)
+                if selectedStartedAtPreset == .custom {
+                    DatePicker(
+                        "Beginn",
+                        selection: $coordinator.draft.startedAt,
+                        in: ...Date.now,
+                        displayedComponents: [.date, .hourAndMinute]
+                    )
+                    .datePickerStyle(.compact)
+                    .accessibilityIdentifier("entry-started-at-custom-picker")
+                }
             }
-
-            EntryStepActions(
+        } footer: {
+            EntryFlowFooter(
                 isSaving: coordinator.isSaving,
-                showsSkip: false,
                 primaryTitle: "Weiter",
+                primarySystemImage: "arrow.right",
+                primaryIdentifier: "entry-flow-next",
                 secondaryTitle: "Nur Kopfschmerz speichern",
+                secondaryIdentifier: "entry-flow-save-headache-only",
                 onPrimary: coordinator.continueToNextStep,
-                onSecondary: coordinator.saveHeadacheOnly,
-                onSkip: {}
+                onSecondary: coordinator.saveHeadacheOnly
             )
         }
-        .navigationTitle("Kopfschmerz")
-        .brandGroupedScreen()
         .onAppear {
             coordinator.draft.type = .headache
             coordinator.draft.intensity = coordinator.draft.normalizedIntensity
         }
     }
-}
 
-private struct HeadacheIntensityCard: View {
-    @Binding var intensity: Int
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Wie stark ist es gerade?")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    Text(summary)
-                        .font(.title2.weight(.bold))
-                        .monospacedDigit()
-                }
-
-                Spacer()
-
-                Text("\(normalizedIntensity)")
-                    .font(.system(size: 44, weight: .bold, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(AppTheme.symiCoral)
-            }
-
-            IntensityPicker(value: Binding(
-                get: { Double(normalizedIntensity) },
-                set: { intensity = Int($0) }
-            ))
-        }
-        .padding(.vertical, 8)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Intensität \(normalizedIntensity) von 10, \(intensityLabel)")
-    }
-
-    private var normalizedIntensity: Int {
-        min(max(intensity, 1), 10)
-    }
-
-    private var summary: String {
-        "\(normalizedIntensity)/10 · \(intensityLabel)"
-    }
-
-    private var intensityLabel: String {
-        switch normalizedIntensity {
-        case 1 ... 3:
-            "Leicht"
-        case 4 ... 6:
-            "Mittel"
-        case 7 ... 8:
-            "Stark"
+    private func painLocationSymbol(for location: String) -> String {
+        switch location {
+        case "Stirn":
+            "head.profile"
+        case "Schläfen":
+            "person.crop.circle.badge.exclamationmark"
+        case "Nacken":
+            "person.crop.circle"
+        case "Einseitig":
+            "face.dashed"
         default:
-            "Sehr stark"
+            "circle"
+        }
+    }
+
+    private func toggle(_ option: String, in selection: inout Set<String>) {
+        if selection.contains(option) {
+            selection.remove(option)
+        } else {
+            selection.insert(option)
         }
     }
 }
 
 private struct EntryMedicationStepView: View {
     let coordinator: EntryFlowCoordinator
+    let onBack: () -> Void
+    let onCancel: () -> Void
+
+    @State private var selectedDosage = "400 mg"
+    @State private var selectedTakenAt = "Jetzt"
+
+    private let medicationOptions: [EntryMedicationOption] = [
+        EntryMedicationOption(title: "Ibuprofen", symbolName: "pills", category: .nsar, defaultDosage: "400 mg"),
+        EntryMedicationOption(title: "Triptan", symbolName: "capsule", category: .triptan, defaultDosage: ""),
+        EntryMedicationOption(title: "Paracetamol", symbolName: "syringe", category: .paracetamol, defaultDosage: "500 mg"),
+        EntryMedicationOption(title: "Andere", symbolName: "ellipsis", category: .other, defaultDosage: "")
+    ]
+    private let dosageOptions = ["200 mg", "400 mg", "600 mg", "Andere"]
+    private let takenAtOptions = ["Jetzt", "Vor 1 Std.", "Vor 2 Std.", "Anderer Zeitpunkt"]
 
     var body: some View {
         @Bindable var coordinator = coordinator
         @Bindable var medicationController = coordinator.medicationController
 
-        Form {
-            EntryStepHeader(step: .medication, currentIndex: coordinator.currentStepIndex)
+        EntryFlowScreen(
+            step: .medication,
+            currentIndex: coordinator.currentStepIndex,
+            onBack: onBack,
+            onCancel: onCancel
+        ) {
+            Text("Welche Medikation?")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.primary)
 
-            Section {
-                Text("Hast du etwas genommen?")
-                    .font(.headline)
-                Text("Übersichtlich. Schnell. Kontextbewusst.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+            EntryTileGrid(minimumColumnWidth: 132) {
+                ForEach(medicationOptions) { option in
+                    EntryOptionTile(
+                        title: option.title,
+                        systemImage: option.symbolName,
+                        isSelected: medicationController.isMedicationNameSelected(option.title),
+                        colorToken: .sageTeal,
+                        accessibilityIdentifier: "entry-medication-\(option.title)"
+                    ) {
+                        selectMedication(option, controller: medicationController)
+                    }
+                }
+            }
+
+            EntryOptionTile(
+                title: coordinator.draft.continuousMedicationChecks.isEmpty ? "Keine Medikation" : "Keine weitere Medikation",
+                systemImage: "slash.circle",
+                isSelected: medicationController.selectedMedications.isEmpty,
+                colorToken: .sageTeal,
+                accessibilityIdentifier: "entry-medication-none"
+            ) {
+                medicationController.resetSelections()
+            }
+
+            EntryFieldGroup(title: "Dosierung") {
+                EntryChipRow {
+                    ForEach(dosageOptions, id: \.self) { dosage in
+                        EntrySelectionChip(
+                            title: dosage,
+                            isSelected: selectedDosage == dosage,
+                            colorToken: .sageTeal,
+                            accessibilityIdentifier: "entry-dosage-\(dosage)"
+                        ) {
+                            selectedDosage = dosage
+                        }
+                    }
+                }
+            }
+
+            EntryFieldGroup(title: "Wann hast du es eingenommen?") {
+                EntryChipRow {
+                    ForEach(takenAtOptions, id: \.self) { option in
+                        EntrySelectionChip(
+                            title: option,
+                            isSelected: selectedTakenAt == option,
+                            colorToken: .sageTeal,
+                            accessibilityIdentifier: "entry-medication-time-\(option)"
+                        ) {
+                            selectedTakenAt = option
+                        }
+                    }
+                }
             }
 
             if !coordinator.draft.continuousMedicationChecks.isEmpty {
-                Section {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Label("Dauermedikation", systemImage: "pills.fill")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(AppTheme.symiPetrol)
-
-                        Text("Bestätige deine regelmäßige Medikation für heute.")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-
-                        ForEach($coordinator.draft.continuousMedicationChecks) { $check in
-                            ContinuousMedicationCheckRow(check: $check)
-                        }
-
-                        Text("Du kannst dies jederzeit in den Einstellungen anpassen.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.vertical, 4)
-                } header: {
-                    Text("Heute genommen?")
-                }
+                EntryContinuousMedicationBlock(checks: $coordinator.draft.continuousMedicationChecks)
             }
-
-            Section {
-                MedicationQuickSelectionGrid(
-                    controller: coordinator.medicationController,
-                    hasContinuousMedication: !coordinator.draft.continuousMedicationChecks.isEmpty
-                )
-
-                DisclosureGroup("Weitere Medikamente") {
-                    TextField("Medikament nach Namen filtern", text: $medicationController.searchText)
-                        .textInputAutocapitalization(.words)
-                        .autocorrectionDisabled()
-
-                    MedicationDefinitionGroupList(controller: coordinator.medicationController)
-
-                    Button {
-                        medicationController.presentEditor(for: nil)
-                    } label: {
-                        Label("Eigenes Medikament hinzufügen", systemImage: "plus")
-                    }
-                }
-
-                SelectedMedicationsSection(controller: coordinator.medicationController)
-            } header: {
-                Text(coordinator.draft.continuousMedicationChecks.isEmpty ? "Zusätzlich etwas genommen?" : "Zusätzlich etwas genommen?")
-            } footer: {
-                Text("Dosierung ist optional und kann über Medikamentenvorlagen oder eigene Medikamente gespeichert werden.")
-            }
-
-            EntryStepActions(
+        } footer: {
+            EntryFlowFooter(
                 isSaving: coordinator.isSaving,
-                showsSkip: true,
                 primaryTitle: "Weiter",
-                secondaryTitle: nil,
+                primarySystemImage: "arrow.right",
+                primaryIdentifier: "entry-flow-next",
+                secondaryTitle: "Überspringen",
+                secondaryIdentifier: "entry-flow-skip",
                 onPrimary: coordinator.continueToNextStep,
-                onSecondary: nil,
-                onSkip: coordinator.skipCurrentStep
+                onSecondary: coordinator.skipCurrentStep
             )
         }
-        .navigationTitle("Medikation")
-        .brandGroupedScreen()
         .task {
             await coordinator.continuousMedicationController.reload(for: coordinator.draft.startedAt)
             if coordinator.draft.continuousMedicationChecks.isEmpty {
@@ -365,238 +386,210 @@ private struct EntryMedicationStepView: View {
             Text("\(definition.name) wird aus SwiftData entfernt.")
         }
     }
-}
 
-private struct ContinuousMedicationCheckRow: View {
-    @Binding var check: ContinuousMedicationCheckDraft
-
-    var body: some View {
-        Toggle(isOn: $check.wasTaken) {
-            HStack(spacing: 12) {
-                Image(systemName: "pills")
-                    .foregroundStyle(AppTheme.symiPetrol)
-                    .frame(width: 28, height: 28)
-
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(check.name)
-                        .font(.subheadline.weight(.semibold))
-                    if !check.detailText.isEmpty {
-                        Text(check.detailText)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-            .contentShape(Rectangle())
+    private func selectMedication(_ option: EntryMedicationOption, controller: EpisodeMedicationSelectionController) {
+        if option.title == "Andere" {
+            controller.presentEditor(for: nil)
+            return
         }
-        .toggleStyle(.button)
-        .buttonStyle(.bordered)
-        .controlSize(.large)
-        .accessibilityLabel("\(check.name) heute genommen")
-    }
-}
 
-private struct MedicationQuickSelectionGrid: View {
-    let controller: EpisodeMedicationSelectionController
-    let hasContinuousMedication: Bool
-
-    private let options: [(String, MedicationCategory, String)] = [
-        ("Ibuprofen", .nsar, "400 mg"),
-        ("Triptan", .triptan, ""),
-        ("Paracetamol", .paracetamol, "500 mg"),
-        ("Andere", .other, "")
-    ]
-
-    var body: some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 10)], spacing: 10) {
-            ForEach(options, id: \.0) { option in
-                Button {
-                    controller.toggleMedicationSelection(
-                        named: option.0,
-                        fallbackCategory: option.1,
-                        fallbackDosage: option.2
-                    )
-                } label: {
-                    Label(option.0, systemImage: controller.isMedicationNameSelected(option.0) ? "checkmark.circle.fill" : "circle")
-                        .frame(maxWidth: .infinity, minHeight: 44)
-                }
-                .buttonStyle(.bordered)
-                .tint(controller.isMedicationNameSelected(option.0) ? AppTheme.symiPetrol : .secondary)
-            }
-
-            Button {
-                controller.resetSelections()
-            } label: {
-                Label(hasContinuousMedication ? "Keine weitere Medikation" : "Keine Medikation", systemImage: "slash.circle")
-                    .frame(maxWidth: .infinity, minHeight: 44)
-            }
-            .buttonStyle(.bordered)
-        }
+        let dosage = selectedDosage == "Andere" ? option.defaultDosage : selectedDosage
+        controller.toggleMedicationSelection(
+            named: option.title,
+            fallbackCategory: option.category,
+            fallbackDosage: dosage
+        )
     }
 }
 
 private struct EntryTriggersStepView: View {
     let coordinator: EntryFlowCoordinator
+    let onBack: () -> Void
+    let onCancel: () -> Void
+
+    private let triggerOptions: [EntryTriggerOption] = [
+        EntryTriggerOption(title: "Stress", symbolName: "brain.head.profile"),
+        EntryTriggerOption(title: "Wetter", symbolName: "cloud.sun"),
+        EntryTriggerOption(title: "Schlaf", symbolName: "moon"),
+        EntryTriggerOption(title: "Ernährung", symbolName: "apple.logo"),
+        EntryTriggerOption(title: "Bildschirmzeit", symbolName: "iphone"),
+        EntryTriggerOption(title: "Zyklus", symbolName: "drop"),
+        EntryTriggerOption(title: "Bewegung", symbolName: "figure.run"),
+        EntryTriggerOption(title: "Flüssigkeit", symbolName: "waterbottle")
+    ]
 
     var body: some View {
         @Bindable var coordinator = coordinator
 
-        Form {
-            EntryStepHeader(step: .triggers, currentIndex: coordinator.currentStepIndex)
+        EntryFlowScreen(
+            step: .triggers,
+            currentIndex: coordinator.currentStepIndex,
+            onBack: onBack,
+            onCancel: onCancel
+        ) {
+            Text("Wähle alle passenden aus.")
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.primary)
 
-            Section {
-                MultiSelectGrid(
-                    options: coordinator.triggerOptions,
-                    selection: $coordinator.draft.selectedTriggers,
-                    colorToken: NewEntryStepCatalog.metadata(for: .triggers).colorToken,
-                    accessibilityPrefix: "Auslöser"
-                )
-            } header: {
-                Text("Was könnte eine Rolle gespielt haben?")
-            } footer: {
-                Text("Du kannst mehrere auswählen. Wetter als Auslöser bleibt getrennt vom automatisch gespeicherten Wetterkontext.")
+            EntryTileGrid(minimumColumnWidth: 132) {
+                ForEach(triggerOptions) { option in
+                    EntryOptionTile(
+                        title: option.title,
+                        systemImage: option.symbolName,
+                        isSelected: coordinator.draft.selectedTriggers.contains(option.title),
+                        colorToken: .blue,
+                        accessibilityIdentifier: "entry-trigger-\(option.title)"
+                    ) {
+                        toggle(option.title, in: &coordinator.draft.selectedTriggers)
+                    }
+                }
             }
 
-            EntryStepActions(
+            EntryInfoBanner(text: "Du kannst mehrere auswählen.")
+        } footer: {
+            EntryFlowFooter(
                 isSaving: coordinator.isSaving,
-                showsSkip: true,
                 primaryTitle: "Weiter",
-                secondaryTitle: nil,
+                primarySystemImage: "arrow.right",
+                primaryIdentifier: "entry-flow-next",
+                secondaryTitle: "Überspringen",
+                secondaryIdentifier: "entry-flow-skip",
                 onPrimary: coordinator.continueToNextStep,
-                onSecondary: nil,
-                onSkip: coordinator.skipCurrentStep
+                onSecondary: coordinator.skipCurrentStep
             )
         }
-        .navigationTitle("Auslöser")
-        .brandGroupedScreen()
+    }
+
+    private func toggle(_ option: String, in selection: inout Set<String>) {
+        if selection.contains(option) {
+            selection.remove(option)
+        } else {
+            selection.insert(option)
+        }
     }
 }
 
 private struct EntryNoteStepView: View {
     let coordinator: EntryFlowCoordinator
+    let onBack: () -> Void
+    let onCancel: () -> Void
+
+    @State private var addsToToday = true
+
+    private let feelingOptions: [EntryFeelingOption] = [
+        EntryFeelingOption(title: "Müde", symbolName: "moon.zzz"),
+        EntryFeelingOption(title: "Ruhig", symbolName: "face.smiling"),
+        EntryFeelingOption(title: "Angespannt", symbolName: "face.dashed"),
+        EntryFeelingOption(title: "Besser", symbolName: "checkmark.circle")
+    ]
 
     var body: some View {
         @Bindable var coordinator = coordinator
 
-        Form {
-            EntryStepHeader(step: .note, currentIndex: coordinator.currentStepIndex)
+        EntryFlowScreen(
+            step: .note,
+            currentIndex: coordinator.currentStepIndex,
+            onBack: onBack,
+            onCancel: onCancel
+        ) {
+            EntryNoteCard(notes: $coordinator.draft.notes)
 
-            Section("Notiz") {
-                TextField("Kurz notieren, was auffällt", text: $coordinator.draft.notes, axis: .vertical)
-                    .lineLimit(3 ... 8)
-            }
-
-            Section("Weitere Angaben") {
-                TextField("Schmerzlokalisation", text: $coordinator.draft.painLocation)
-                TextField("Schmerzcharakter", text: $coordinator.draft.painCharacter)
-                TextField("Funktionelle Einschränkung", text: $coordinator.draft.functionalImpact)
-
-                Picker("Menstruationsstatus", selection: $coordinator.draft.menstruationStatus) {
-                    ForEach(MenstruationStatus.allCases) { status in
-                        Text(status.rawValue).tag(status)
+            EntryFieldGroup(title: "Wie fühlst du dich gerade?") {
+                EntryTileGrid(minimumColumnWidth: 72) {
+                    ForEach(feelingOptions) { option in
+                        EntryMoodTile(
+                            option: option,
+                            isSelected: coordinator.draft.painCharacter == option.title,
+                            accessibilityIdentifier: "entry-feeling-\(option.title)"
+                        ) {
+                            coordinator.draft.painCharacter = coordinator.draft.painCharacter == option.title ? "" : option.title
+                        }
                     }
                 }
-
-                Toggle("Ende angeben", isOn: $coordinator.draft.endedAtEnabled.animation())
-                if coordinator.draft.endedAtEnabled {
-                    DatePicker(
-                        "Ende",
-                        selection: $coordinator.draft.endedAt,
-                        in: coordinator.draft.startedAt...,
-                        displayedComponents: [.date, .hourAndMinute]
-                    )
-                }
             }
 
-            EntryStepActions(
+            EntryTodayLinkCard(isOn: $addsToToday)
+        } footer: {
+            EntryFlowFooter(
                 isSaving: coordinator.isSaving,
-                showsSkip: true,
                 primaryTitle: "Weiter",
-                secondaryTitle: nil,
+                primarySystemImage: "arrow.right",
+                primaryIdentifier: "entry-flow-next",
+                secondaryTitle: "Ohne Notiz fortfahren",
+                secondaryIdentifier: "entry-flow-skip",
                 onPrimary: coordinator.continueToNextStep,
-                onSecondary: nil,
-                onSkip: coordinator.skipCurrentStep
+                onSecondary: coordinator.skipCurrentStep
             )
         }
-        .navigationTitle("Notiz")
-        .brandGroupedScreen()
     }
 }
 
 private struct EntryReviewStepView: View {
     let coordinator: EntryFlowCoordinator
+    let onBack: () -> Void
+    let onCancel: () -> Void
 
     var body: some View {
-        @Bindable var coordinator = coordinator
+        EntryFlowScreen(
+            step: .review,
+            currentIndex: coordinator.currentStepIndex,
+            onBack: onBack,
+            onCancel: onCancel
+        ) {
+            VStack(spacing: 0) {
+                EntryReviewSummarySection(
+                    step: .headache,
+                    lines: headacheSummary,
+                    onEdit: { coordinator.edit(.headache) }
+                )
 
-        Form {
-            EntryStepHeader(step: .review, currentIndex: coordinator.currentStepIndex)
-
-            Section {
-                VStack(alignment: .leading, spacing: 14) {
+                if shouldShowMedicationSummary {
+                    Divider()
                     EntryReviewSummarySection(
-                        step: .headache,
-                        lines: headacheSummary,
-                        onEdit: { coordinator.edit(.headache) }
+                        step: .medication,
+                        lines: medicationSummary,
+                        onEdit: { coordinator.edit(.medication) }
                     )
-
-                    if shouldShowMedicationSummary {
-                        EntryReviewSummarySection(
-                            step: .medication,
-                            lines: medicationSummary,
-                            onEdit: { coordinator.edit(.medication) }
-                        )
-                    }
-
-                    if !coordinator.draft.selectedTriggers.isEmpty {
-                        EntryReviewSummarySection(
-                            step: .triggers,
-                            lines: triggerSummary,
-                            onEdit: { coordinator.edit(.triggers) }
-                        )
-                    }
-
-                    if let weatherSummary {
-                        EntryReviewSummarySection(
-                            step: .triggers,
-                            title: "Wetterkontext",
-                            lines: weatherSummary,
-                            onEdit: { coordinator.edit(.triggers) }
-                        )
-                    }
-
-                    if shouldShowNoteSummary {
-                        EntryReviewSummarySection(
-                            step: .note,
-                            title: "Notiz und Gefühl",
-                            lines: noteSummary,
-                            onEdit: { coordinator.edit(.note) }
-                        )
-                    }
                 }
-                .padding(.vertical, 4)
-            } footer: {
-                Text("Dein Eintrag hilft dir, Muster besser zu erkennen.")
+
+                if !coordinator.draft.selectedTriggers.isEmpty {
+                    Divider()
+                    EntryReviewSummarySection(
+                        step: .triggers,
+                        lines: triggerSummary,
+                        onEdit: { coordinator.edit(.triggers) }
+                    )
+                }
+
+                if shouldShowNoteSummary {
+                    Divider()
+                    EntryReviewSummarySection(
+                        step: .note,
+                        lines: noteSummary,
+                        onEdit: { coordinator.edit(.note) }
+                    )
+                }
             }
-
-            Section {
-                PrimaryButton(action: coordinator.saveFromReview) {
-                    if coordinator.isSaving {
-                        ProgressView()
-                    } else {
-                        Text("Eintrag speichern")
-                    }
-                }
-                .disabled(coordinator.isSaving)
-
-                Button("Bearbeiten") {
-                    coordinator.edit(.headache)
-                }
-                .disabled(coordinator.isSaving)
+            .background(entryCardBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
             }
+            .accessibilityElement(children: .contain)
+
+            EntryPatternHint()
+        } footer: {
+            EntryFlowFooter(
+                isSaving: coordinator.isSaving,
+                primaryTitle: "Eintrag speichern",
+                primarySystemImage: "checkmark",
+                primaryIdentifier: "entry-flow-save",
+                secondaryTitle: "Bearbeiten",
+                secondaryIdentifier: "entry-flow-edit",
+                onPrimary: coordinator.saveFromReview,
+                onSecondary: { coordinator.edit(.headache) }
+            )
         }
-        .navigationTitle("Eintrag prüfen")
-        .brandGroupedScreen()
         .task {
             await coordinator.refreshWeatherIfNeeded()
         }
@@ -605,15 +598,15 @@ private struct EntryReviewStepView: View {
     private var headacheSummary: [String] {
         let draft = coordinator.draft
         return [
-            "Intensität \(draft.normalizedIntensity)/10 · \(intensityLabel(for: draft.normalizedIntensity))",
+            "\(draft.normalizedIntensity)/10 · \(intensityLabel(for: draft.normalizedIntensity))",
             draft.resolvedPainLocation.isEmpty ? "Ort nicht angegeben" : "Ort: \(draft.resolvedPainLocation)",
-            "Zeitpunkt: \(draft.startedAt.formatted(date: .abbreviated, time: .shortened))"
+            "Zeitpunkt: \(startedAtSummary(for: draft.startedAt))"
         ]
     }
 
     private var shouldShowMedicationSummary: Bool {
         !coordinator.medicationController.selectedMedications.isEmpty ||
-        !coordinator.draft.continuousMedicationChecks.isEmpty
+            !coordinator.draft.continuousMedicationChecks.isEmpty
     }
 
     private var medicationSummary: [String] {
@@ -632,7 +625,7 @@ private struct EntryReviewStepView: View {
             if medication.quantity > 1 {
                 parts.append("x\(medication.quantity)")
             }
-            parts.append("Zeitpunkt: \(coordinator.draft.startedAt.formatted(date: .omitted, time: .shortened))")
+            parts.append("Jetzt")
             return parts.joined(separator: " · ")
         }
 
@@ -640,31 +633,7 @@ private struct EntryReviewStepView: View {
     }
 
     private var triggerSummary: [String] {
-        coordinator.draft.selectedTriggers.sorted()
-    }
-
-    private var weatherSummary: [String]? {
-        switch coordinator.weatherLoadState {
-        case .loaded(let weather):
-            var lines = [weather.condition]
-            if let temperature = weather.temperature {
-                lines.append("Temperatur \(temperature.formatted(.number.precision(.fractionLength(1)))) °C")
-            }
-            if let pressure = weather.pressure {
-                lines.append("Luftdruck \(pressure.formatted(.number.precision(.fractionLength(0)))) hPa")
-            }
-            if let humidity = weather.humidity {
-                lines.append("Luftfeuchte \(humidity.formatted(.number.precision(.fractionLength(0)))) %")
-            }
-            if let precipitation = weather.precipitation {
-                lines.append("Niederschlag \(precipitation.formatted(.number.precision(.fractionLength(1)))) mm")
-            }
-            return lines
-        case .loading:
-            return ["Wetter wird gerade geladen."]
-        case .idle, .unavailable:
-            return nil
-        }
+        [coordinator.draft.selectedTriggers.sorted().joined(separator: ", ")]
     }
 
     private var shouldShowNoteSummary: Bool {
@@ -681,17 +650,30 @@ private struct EntryReviewStepView: View {
         if !notes.isEmpty {
             lines.append(notes)
         }
+        if !impact.isEmpty {
+            lines.append(impact)
+        }
         if !feeling.isEmpty {
             lines.append("Gefühl: \(feeling)")
-        }
-        if !impact.isEmpty {
-            lines.append("Einschränkung: \(impact)")
         }
         if draft.menstruationStatus != .unknown {
             lines.append("Regel: \(draft.menstruationStatus.rawValue)")
         }
 
         return lines
+    }
+
+    private var entryCardBackground: some ShapeStyle {
+        Color(uiColor: .secondarySystemGroupedBackground)
+    }
+
+    private func startedAtSummary(for startedAt: Date) -> String {
+        let interval = abs(startedAt.timeIntervalSinceNow)
+        if interval < 10 * 60 {
+            return "Jetzt"
+        }
+
+        return startedAt.formatted(date: .abbreviated, time: .shortened)
     }
 
     private func intensityLabel(for intensity: Int) -> String {
@@ -708,118 +690,793 @@ private struct EntryReviewStepView: View {
     }
 }
 
-private struct EntryStepHeader: View {
+private struct EntryFlowScreen<Content: View, Footer: View>: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let step: EntryFlowStep
+    let currentIndex: Int
+    let onBack: () -> Void
+    let onCancel: () -> Void
+    @ViewBuilder let content: Content
+    @ViewBuilder let footer: Footer
+
+    init(
+        step: EntryFlowStep,
+        currentIndex: Int,
+        onBack: @escaping () -> Void,
+        onCancel: @escaping () -> Void,
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder footer: () -> Footer
+    ) {
+        self.step = step
+        self.currentIndex = currentIndex
+        self.onBack = onBack
+        self.onCancel = onCancel
+        self.content = content()
+        self.footer = footer()
+    }
+
+    var body: some View {
+        ZStack {
+            EntryFlowBackground()
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                EntryFlowTopBar(onBack: onBack, onCancel: onCancel)
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 22) {
+                        Text(step.rawValue)
+                            .font(.caption2)
+                            .foregroundStyle(.clear)
+                            .frame(width: 1, height: 1)
+                            .accessibilityElement()
+                            .accessibilityLabel("Flow-Schritt \(step.rawValue)")
+                            .accessibilityIdentifier("entry-flow-step-\(step.rawValue)")
+
+                        EntryStepHero(step: step, currentIndex: currentIndex)
+                        content
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 8)
+                    .padding(.bottom, 24)
+                    .frame(maxWidth: 420, alignment: .leading)
+                    .frame(maxWidth: .infinity)
+                }
+                .scrollIndicators(.hidden)
+                .scrollDismissesKeyboard(.interactively)
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            footer
+                .padding(.horizontal, 20)
+                .padding(.top, 10)
+                .padding(.bottom, 10)
+                .frame(maxWidth: 420)
+                .frame(maxWidth: .infinity)
+                .background(.regularMaterial)
+        }
+        .navigationBarBackButtonHidden(true)
+    }
+}
+
+private struct EntryFlowTopBar: View {
+    let onBack: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .frame(width: 44, height: 44)
+                    .background(.thinMaterial, in: Circle())
+                    .overlay {
+                        Circle()
+                            .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                    }
+            }
+            .accessibilityLabel("Zurück")
+            .accessibilityIdentifier("entry-flow-back")
+
+            Spacer()
+
+            Button("Abbrechen", action: onCancel)
+                .font(.callout.weight(.medium))
+                .foregroundStyle(AppTheme.symiPetrol)
+                .frame(minHeight: 44)
+                .accessibilityIdentifier("entry-flow-cancel")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
+        .padding(.bottom, 2)
+        .frame(maxWidth: 420)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct EntryStepHero: View {
     let step: EntryFlowStep
     let currentIndex: Int
 
     var body: some View {
         let metadata = NewEntryStepCatalog.metadata(for: step.catalogID)
 
-        Section {
-            HStack(spacing: 14) {
-                StepIcon(metadata)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 18) {
+                EntryProgressTrack(
+                    currentStep: currentIndex,
+                    totalSteps: EntryFlowCoordinator.steps.count,
+                    colorToken: metadata.colorToken
+                )
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(metadata.title)
-                        .font(.headline)
-                    Text(metadata.subline)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
+                Text("von \(EntryFlowCoordinator.steps.count)")
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
-            .padding(.vertical, 4)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Schritt \(currentIndex) von \(EntryFlowCoordinator.steps.count)")
 
-            ProgressIndicator(currentStep: currentIndex, colorToken: metadata.colorToken)
+            Text(metadata.title)
+                .font(.title.weight(.bold))
+                .foregroundStyle(metadata.colorToken.color)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(metadata.subline)
+                .font(.callout)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }
 
-private struct EntryStepActions: View {
-    let isSaving: Bool
-    let showsSkip: Bool
-    let primaryTitle: String
-    let secondaryTitle: String?
-    let onPrimary: () -> Void
-    let onSecondary: (() -> Void)?
-    let onSkip: () -> Void
+private struct EntryProgressTrack: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let currentStep: Int
+    let totalSteps: Int
+    let colorToken: NewEntryStepColorToken
 
     var body: some View {
-        Section {
-            PrimaryButton(action: onPrimary) {
-                Text(primaryTitle)
+        GeometryReader { proxy in
+            let indicatorSize: CGFloat = 24
+            let progressWidth = max(proxy.size.width - indicatorSize, 1)
+            let xOffset = CGFloat(clampedCurrentStep - 1) / CGFloat(max(totalSteps - 1, 1)) * progressWidth
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.secondary.opacity(0.18))
+                    .frame(height: 4)
+                    .offset(y: 10)
+
+                Capsule()
+                    .fill(colorToken.color(for: colorScheme))
+                    .frame(width: xOffset + indicatorSize / 2, height: 4)
+                    .offset(y: 10)
+
+                Text("\(clampedCurrentStep)")
+                    .font(.caption.weight(.bold))
+                    .monospacedDigit()
+                    .foregroundStyle(.white)
+                    .frame(width: indicatorSize, height: indicatorSize)
+                    .background(colorToken.color(for: colorScheme), in: Circle())
+                    .offset(x: xOffset)
             }
+        }
+        .frame(height: 24)
+    }
+
+    private var clampedCurrentStep: Int {
+        min(max(currentStep, 1), max(totalSteps, 1))
+    }
+}
+
+private struct HeadacheIntensityCard: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @Binding var intensity: Int
+
+    var body: some View {
+        VStack(spacing: 18) {
+            ZStack(alignment: .center) {
+                EntryGaugeArc()
+                    .stroke(
+                        LinearGradient(
+                            colors: [
+                                NewEntryStepColorToken.sageTeal.color,
+                                Color(red: 0.96, green: 0.79, blue: 0.48),
+                                NewEntryStepColorToken.coral.color
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        ),
+                        style: StrokeStyle(lineWidth: 13, lineCap: .round)
+                    )
+                    .frame(width: 212, height: 142)
+                    .accessibilityHidden(true)
+
+                VStack(spacing: 4) {
+                    Text("\(normalizedIntensity)")
+                        .font(.system(size: 58, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundStyle(AppTheme.symiPetrol)
+                        .minimumScaleFactor(0.75)
+
+                    Text("/10")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+
+                    Text(intensityLabel)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(NewEntryStepColorToken.coral.color)
+                        .padding(.top, 8)
+                }
+                .padding(.top, 20)
+            }
+            .frame(maxWidth: .infinity)
+
+            VStack(spacing: 8) {
+                Slider(
+                    value: Binding(
+                        get: { Double(normalizedIntensity) },
+                        set: { intensity = Int($0) }
+                    ),
+                    in: 1 ... 10,
+                    step: 1
+                )
+                .tint(NewEntryStepColorToken.coral.color)
+                .accessibilityLabel("Kopfschmerzstärke \(normalizedIntensity) von 10, \(intensityLabel.lowercased())")
+                .accessibilityIdentifier("entry-intensity-slider")
+
+                HStack {
+                    Text("0")
+                    Spacer()
+                    Text("10")
+                }
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+            }
+        }
+        .padding(22)
+        .frame(maxWidth: .infinity)
+        .background(entryCardBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(NewEntryStepColorToken.coral.border(for: colorScheme), lineWidth: 1)
+        }
+        .accessibilityIdentifier("entry-intensity-card")
+    }
+
+    private var entryCardBackground: some ShapeStyle {
+        Color(uiColor: .secondarySystemGroupedBackground)
+    }
+
+    private var normalizedIntensity: Int {
+        min(max(intensity, 1), 10)
+    }
+
+    private var intensityLabel: String {
+        switch normalizedIntensity {
+        case 1 ... 3:
+            "Leicht"
+        case 4 ... 6:
+            "Mittel"
+        case 7 ... 8:
+            "Stark"
+        default:
+            "Sehr stark"
+        }
+    }
+}
+
+private struct EntryGaugeArc: Shape {
+    func path(in rect: CGRect) -> Path {
+        let radius = min(rect.width / 2, rect.height) - 8
+        let center = CGPoint(x: rect.midX, y: rect.maxY - 8)
+        var path = Path()
+        path.addArc(
+            center: center,
+            radius: radius,
+            startAngle: .degrees(200),
+            endAngle: .degrees(340),
+            clockwise: false
+        )
+        return path
+    }
+}
+
+private struct EntryFieldGroup<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.primary)
+
+            content
+        }
+    }
+}
+
+private struct EntryTileGrid<Content: View>: View {
+    let minimumColumnWidth: CGFloat
+    @ViewBuilder let content: Content
+
+    init(minimumColumnWidth: CGFloat, @ViewBuilder content: () -> Content) {
+        self.minimumColumnWidth = minimumColumnWidth
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.adaptive(minimum: minimumColumnWidth), spacing: 10, alignment: .top)
+            ],
+            alignment: .leading,
+            spacing: 10
+        ) {
+            content
+        }
+    }
+}
+
+private struct EntryOptionTile: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let title: String
+    let systemImage: String
+    let isSelected: Bool
+    let colorToken: NewEntryStepColorToken
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 10) {
+                Image(systemName: systemImage)
+                    .font(.title3.weight(.medium))
+                    .foregroundStyle(isSelected ? colorToken.color(for: colorScheme) : .secondary)
+                    .frame(height: 26)
+
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, minHeight: 82)
+            .background(tileBackground, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(isSelected ? colorToken.border(for: colorScheme) : Color.primary.opacity(0.09), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
+        .accessibilityHint(isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus.")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private var tileBackground: Color {
+        if isSelected {
+            return colorToken.selectedFill(for: colorScheme)
+        }
+
+        return Color(uiColor: .secondarySystemGroupedBackground)
+    }
+}
+
+private struct EntryChipRow<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.adaptive(minimum: 70), spacing: 8, alignment: .top)
+            ],
+            alignment: .leading,
+            spacing: 8
+        ) {
+            content
+        }
+    }
+}
+
+private struct EntrySelectionChip: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let title: String
+    let isSelected: Bool
+    let colorToken: NewEntryStepColorToken
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.footnote.weight(.medium))
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.82)
+                .foregroundStyle(isSelected ? colorToken.color(for: colorScheme) : .primary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 9)
+                .frame(maxWidth: .infinity, minHeight: 44)
+                .background(isSelected ? colorToken.selectedFill(for: colorScheme) : Color(uiColor: .secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(isSelected ? colorToken.border(for: colorScheme) : Color.primary.opacity(0.08), lineWidth: 1)
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
+private struct EntryContinuousMedicationBlock: View {
+    @Binding var checks: [ContinuousMedicationCheckDraft]
+
+    var body: some View {
+        EntryFieldGroup(title: "Dauermedikation") {
+            VStack(spacing: 10) {
+                ForEach($checks) { $check in
+                    Toggle(isOn: $check.wasTaken) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(check.name)
+                                .font(.subheadline.weight(.semibold))
+                            if !check.detailText.isEmpty {
+                                Text(check.detailText)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .toggleStyle(.switch)
+                    .frame(minHeight: 44)
+                    .accessibilityLabel("\(check.name) heute genommen")
+                }
+            }
+        }
+    }
+}
+
+private struct EntryInfoBanner: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let text: String
+
+    var body: some View {
+        Label(text, systemImage: "info.circle")
+            .font(.footnote.weight(.medium))
+            .foregroundStyle(NewEntryStepColorToken.blue.color)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(NewEntryStepColorToken.blue.softFill(for: colorScheme), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .accessibilityIdentifier("entry-trigger-info")
+    }
+}
+
+private struct EntryNoteCard: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @Binding var notes: String
+
+    private let limit = 500
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            TextEditor(text: $notes)
+                .font(.callout)
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .frame(minHeight: 230)
+                .onChange(of: notes) { _, newValue in
+                    if newValue.count > limit {
+                        notes = String(newValue.prefix(limit))
+                    }
+                }
+                .accessibilityLabel("Notiz")
+                .accessibilityIdentifier("entry-note-text")
+
+            if notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Was hat geholfen?")
+                    Text("Was war heute anders?")
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 20)
+                .allowsHitTesting(false)
+            }
+
+            VStack {
+                Spacer()
+                HStack {
+                    Spacer()
+                    Text("\(notes.count)/\(limit)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .padding(12)
+                }
+            }
+        }
+        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(NewEntryStepColorToken.warmAmber.border(for: colorScheme), lineWidth: 1)
+        }
+    }
+}
+
+private struct EntryMoodTile: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let option: EntryFeelingOption
+    let isSelected: Bool
+    let accessibilityIdentifier: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 6) {
+                Image(systemName: option.symbolName)
+                    .font(.title3.weight(.medium))
+                    .foregroundStyle(isSelected ? NewEntryStepColorToken.warmAmber.color(for: colorScheme) : .secondary)
+                    .frame(height: 26)
+
+                Text(option.title)
+                    .font(.caption.weight(.medium))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, minHeight: 76)
+            .background(
+                isSelected ?
+                    NewEntryStepColorToken.warmAmber.selectedFill(for: colorScheme) :
+                    Color(uiColor: .secondarySystemGroupedBackground),
+                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(isSelected ? NewEntryStepColorToken.warmAmber.border(for: colorScheme) : Color.primary.opacity(0.08), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option.title)
+        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
+private struct EntryTodayLinkCard: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack(spacing: 14) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Zu heutigem Eintrag hinzufügen")
+                    .font(.subheadline.weight(.semibold))
+                Text("Diese Notiz wird mit deinem Eintrag von heute verknüpft.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 8)
+
+            Toggle("Zu heutigem Eintrag hinzufügen", isOn: $isOn)
+                .labelsHidden()
+                .tint(NewEntryStepColorToken.warmAmber.color)
+                .accessibilityIdentifier("entry-note-link-toggle")
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+        .background(NewEntryStepColorToken.warmAmber.softFill(for: colorScheme), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+private struct EntryFlowFooter: View {
+    let isSaving: Bool
+    let primaryTitle: String
+    let primarySystemImage: String
+    let primaryIdentifier: String
+    let secondaryTitle: String?
+    let secondaryIdentifier: String?
+    let onPrimary: () -> Void
+    let onSecondary: (() -> Void)?
+
+    init(
+        isSaving: Bool,
+        primaryTitle: String,
+        primarySystemImage: String,
+        primaryIdentifier: String,
+        secondaryTitle: String? = nil,
+        secondaryIdentifier: String? = nil,
+        onPrimary: @escaping () -> Void,
+        onSecondary: (() -> Void)? = nil
+    ) {
+        self.isSaving = isSaving
+        self.primaryTitle = primaryTitle
+        self.primarySystemImage = primarySystemImage
+        self.primaryIdentifier = primaryIdentifier
+        self.secondaryTitle = secondaryTitle
+        self.secondaryIdentifier = secondaryIdentifier
+        self.onPrimary = onPrimary
+        self.onSecondary = onSecondary
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Button(action: onPrimary) {
+                HStack(spacing: 12) {
+                    Spacer(minLength: 0)
+
+                    if isSaving {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text(primaryTitle)
+                            .font(.headline.weight(.semibold))
+                        Image(systemName: primarySystemImage)
+                            .font(.headline.weight(.semibold))
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .foregroundStyle(.white)
+                .padding(.horizontal, 18)
+                .frame(maxWidth: .infinity, minHeight: 54)
+                .background(AppTheme.symiPetrol, in: Capsule())
+            }
+            .buttonStyle(.plain)
             .disabled(isSaving)
+            .accessibilityIdentifier(primaryIdentifier)
 
             if let secondaryTitle, let onSecondary {
                 Button(secondaryTitle, action: onSecondary)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(AppTheme.symiPetrol)
+                    .frame(minHeight: 44)
                     .disabled(isSaving)
-            }
-
-            if showsSkip {
-                Button("Überspringen", action: onSkip)
-                    .disabled(isSaving)
+                    .accessibilityIdentifier(secondaryIdentifier ?? "entry-flow-secondary")
             }
         }
     }
 }
 
 private struct EntryReviewSummarySection: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     let step: EntryFlowStep
-    let title: String?
     let lines: [String]
     let onEdit: () -> Void
-
-    init(
-        step: EntryFlowStep,
-        title: String? = nil,
-        lines: [String],
-        onEdit: @escaping () -> Void
-    ) {
-        self.step = step
-        self.title = title
-        self.lines = lines
-        self.onEdit = onEdit
-    }
 
     var body: some View {
         let metadata = NewEntryStepCatalog.metadata(for: step.catalogID)
 
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center, spacing: 10) {
-                StepIcon(metadata)
-                    .frame(width: 36, height: 36)
+        HStack(alignment: .top, spacing: 12) {
+            StepIcon(metadata)
+                .frame(width: 42, height: 42)
 
-                Text(title ?? metadata.title)
-                    .font(.subheadline.weight(.semibold))
+            VStack(alignment: .leading, spacing: 7) {
+                Text(metadata.title)
+                    .font(.headline.weight(.semibold))
 
-                Spacer(minLength: 8)
-
-                Button("Bearbeiten", action: onEdit)
-                    .font(.caption.weight(.semibold))
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
                 ForEach(lines, id: \.self) { line in
                     Text(line)
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(.primary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .padding(.leading, 46)
+
+            Spacer(minLength: 8)
         }
-        .padding(12)
+        .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(metadata.colorToken.softFill(for: colorScheme))
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(metadata.colorToken.border(for: colorScheme), lineWidth: 1)
-        }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onEdit)
         .accessibilityElement(children: .combine)
+        .accessibilityHint("Tippe doppelt, um diesen Schritt zu bearbeiten.")
+        .accessibilityIdentifier("entry-review-\(step.rawValue)")
     }
+}
+
+private struct EntryPatternHint: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Label {
+            Text("Dein Eintrag hilft dir, Muster besser zu erkennen.")
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: "sparkles")
+                .foregroundStyle(NewEntryStepColorToken.purple.color)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(NewEntryStepColorToken.purple.softFill(for: colorScheme), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityIdentifier("entry-review-pattern-hint")
+    }
+}
+
+private struct EntryFlowBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        LinearGradient(
+            colors: colors,
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var colors: [Color] {
+        if colorScheme == .dark {
+            return [
+                Color(red: 0.08, green: 0.09, blue: 0.10),
+                Color(red: 0.06, green: 0.10, blue: 0.10),
+                Color(red: 0.10, green: 0.09, blue: 0.08)
+            ]
+        }
+
+        return [
+            Color(red: 0.99, green: 0.98, blue: 0.96),
+            Color.white,
+            Color(red: 0.95, green: 0.98, blue: 0.97)
+        ]
+    }
+}
+
+private struct EntryMedicationOption: Identifiable {
+    let title: String
+    let symbolName: String
+    let category: MedicationCategory
+    let defaultDosage: String
+
+    var id: String { title }
+}
+
+private struct EntryTriggerOption: Identifiable {
+    let title: String
+    let symbolName: String
+
+    var id: String { title }
+}
+
+private struct EntryFeelingOption: Identifiable {
+    let title: String
+    let symbolName: String
+
+    var id: String { title }
 }
 
 private extension EntryFlowStep {

--- a/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
+++ b/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
@@ -38,7 +38,7 @@ enum NewEntryStepCatalog {
         NewEntryStepMetadata(
             id: .medication,
             title: "Medikation",
-            subline: "Was hast du genommen?",
+            subline: "Hast du etwas genommen?",
             symbolName: "pills.fill",
             colorToken: .sageTeal,
             status: nil
@@ -54,7 +54,7 @@ enum NewEntryStepCatalog {
         NewEntryStepMetadata(
             id: .note,
             title: "Notiz",
-            subline: "Was fällt dir auf?",
+            subline: "Was möchtest du festhalten?",
             symbolName: "note.text",
             colorToken: .warmAmber,
             status: nil

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -169,7 +169,26 @@ struct EntryFlowCoordinatorTests {
 
         #expect(coordinator.isCancelled)
         #expect(coordinator.path.isEmpty)
-        #expect(coordinator.draft.intensity == 5)
+        #expect(coordinator.draft.intensity == 4)
+    }
+
+    @Test
+    func reviewSaveAllowsMissingTriggersAndWeatherData() async throws {
+        let repository = EntryFlowEpisodeRepositoryMock()
+        let coordinator = makeCoordinator(repository: repository)
+        coordinator.draft.intensity = 4
+
+        coordinator.continueToNextStep()
+        coordinator.skipCurrentStep()
+        coordinator.skipCurrentStep()
+        coordinator.skipCurrentStep()
+        coordinator.saveFromReview()
+        try await waitForSaveResult(on: coordinator)
+
+        #expect(repository.saveCount == 1)
+        #expect(repository.lastSavedDraft?.selectedTriggers.isEmpty == true)
+        #expect(repository.lastWeatherSnapshot == nil)
+        #expect(coordinator.saveResult == .saved(repository.savedID))
     }
 
     private func makeCoordinator(

--- a/SymiTests/NewEntryDesignSystemTests.swift
+++ b/SymiTests/NewEntryDesignSystemTests.swift
@@ -18,9 +18,9 @@ struct NewEntryDesignSystemTests {
     func stepCatalogDefinesGermanCopySymbolsAndColorTokens() {
         let expected: [NewEntryStepID: (String, String, String, NewEntryStepColorToken)] = [
             .headache: ("Kopfschmerz", "Wie stark ist es gerade?", "waveform.path.ecg", .coral),
-            .medication: ("Medikation", "Was hast du genommen?", "pills.fill", .sageTeal),
+            .medication: ("Medikation", "Hast du etwas genommen?", "pills.fill", .sageTeal),
             .triggers: ("Auslöser", "Was könnte eine Rolle gespielt haben?", "brain.head.profile", .blue),
-            .note: ("Notiz", "Was fällt dir auf?", "note.text", .warmAmber),
+            .note: ("Notiz", "Was möchtest du festhalten?", "note.text", .warmAmber),
             .review: ("Eintrag prüfen", "Alles bereit zum Speichern.", "checkmark.seal.fill", .purple)
         ]
 

--- a/SymiUITests/EntryFlowUITests.swift
+++ b/SymiUITests/EntryFlowUITests.swift
@@ -1,0 +1,233 @@
+import XCTest
+
+@MainActor
+final class EntryFlowUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testCompleteFiveStepFlowSavesEntry() {
+        let app = launchEntryFlow()
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
+        assertHeadacheStepMatchesReference(in: app)
+        attachScreenshot(named: "entry-flow-01-headache", app: app)
+        app.buttons["entry-location-Schläfen"].tap()
+        app.buttons["entry-flow-next"].tap()
+
+        XCTAssertTrue(step("medication", in: app).waitForExistence(timeout: 3))
+        assertMedicationStepMatchesReference(in: app)
+        attachScreenshot(named: "entry-flow-02-medication", app: app)
+        app.buttons["entry-medication-Ibuprofen"].tap()
+        app.buttons["entry-flow-next"].tap()
+
+        XCTAssertTrue(step("triggers", in: app).waitForExistence(timeout: 3))
+        assertTriggersStepMatchesReference(in: app)
+        attachScreenshot(named: "entry-flow-03-triggers", app: app)
+        app.buttons["entry-trigger-Stress"].tap()
+        app.buttons["entry-trigger-Wetter"].tap()
+        app.buttons["entry-flow-next"].tap()
+
+        XCTAssertTrue(step("note", in: app).waitForExistence(timeout: 3))
+        assertNoteStepMatchesReference(in: app)
+        attachScreenshot(named: "entry-flow-04-note", app: app)
+        app.buttons["entry-feeling-Müde"].tap()
+        app.buttons["entry-flow-next"].tap()
+
+        XCTAssertTrue(step("review", in: app).waitForExistence(timeout: 3))
+        assertReviewStepMatchesReference(in: app)
+        attachScreenshot(named: "entry-flow-05-review", app: app)
+        XCTAssertTrue(app.staticTexts["4/10 · Mittel"].exists)
+        XCTAssertTrue(app.staticTexts["Ort: Schläfen"].exists)
+        XCTAssertTrue(staticText(containing: "Ibuprofen", in: app).exists)
+        XCTAssertTrue(staticText(containing: "Stress, Wetter", in: app).exists)
+        XCTAssertTrue(app.staticTexts["Gefühl: Müde"].exists)
+
+        app.buttons["entry-flow-save"].tap()
+        XCTAssertTrue(app.alerts["Eintrag gespeichert"].waitForExistence(timeout: 6))
+    }
+
+    func testHeadacheOnlyDirectSaveFromFirstStep() {
+        let app = launchEntryFlow()
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
+        app.buttons["entry-flow-save-headache-only"].tap()
+
+        XCTAssertTrue(app.alerts["Eintrag gespeichert"].waitForExistence(timeout: 6))
+    }
+
+    func testOptionalStepsCanBeSkippedAndStillSavedWithoutWeather() {
+        let app = launchEntryFlow(extraArguments: ["-mt_disable_weather"])
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
+        app.buttons["entry-flow-next"].tap()
+
+        XCTAssertTrue(step("medication", in: app).waitForExistence(timeout: 3))
+        app.buttons["entry-flow-skip"].tap()
+
+        XCTAssertTrue(step("triggers", in: app).waitForExistence(timeout: 3))
+        app.buttons["entry-flow-skip"].tap()
+
+        XCTAssertTrue(step("note", in: app).waitForExistence(timeout: 3))
+        app.buttons["entry-flow-skip"].tap()
+
+        XCTAssertTrue(step("review", in: app).waitForExistence(timeout: 3))
+        app.buttons["entry-flow-save"].tap()
+
+        XCTAssertTrue(app.alerts["Eintrag gespeichert"].waitForExistence(timeout: 6))
+    }
+
+    func testBackNavigationKeepsDraftSelection() {
+        let app = launchEntryFlow()
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
+        let templeButton = app.buttons["entry-location-Schläfen"]
+        templeButton.tap()
+        app.buttons["entry-flow-next"].tap()
+
+        XCTAssertTrue(step("medication", in: app).waitForExistence(timeout: 3))
+        app.buttons["entry-flow-back"].tap()
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 3))
+        XCTAssertEqual(templeButton.value as? String, "Ausgewählt")
+    }
+
+    func testCancelInTheMiddleReturnsToFreshHeadacheStep() {
+        let app = launchEntryFlow()
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
+        app.buttons["entry-location-Schläfen"].tap()
+        app.buttons["entry-flow-next"].tap()
+
+        XCTAssertTrue(step("medication", in: app).waitForExistence(timeout: 3))
+        app.buttons["entry-flow-cancel"].tap()
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 3))
+        XCTAssertEqual(app.buttons["entry-location-Schläfen"].value as? String, "Nicht ausgewählt")
+    }
+
+    func testAccessibilitySizeDarkModeAndTouchTargets() {
+        let app = launchEntryFlow(
+            extraArguments: [
+                "-AppleInterfaceStyle", "Dark",
+                "-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityL"
+            ]
+        )
+
+        XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
+        XCTAssertMinimumTouchTarget(app.buttons["entry-flow-next"])
+        XCTAssertMinimumTouchTarget(app.buttons["entry-flow-save-headache-only"])
+        XCTAssertMinimumTouchTarget(app.buttons["entry-location-Schläfen"])
+    }
+
+    private func launchEntryFlow(extraArguments: [String] = []) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-ui_testing",
+            "-mt_screenshot_screen",
+            "new-entry",
+            "-mt_screenshot_seed",
+            "default"
+        ]
+        app.launchArguments += extraArguments
+        app.launch()
+        return app
+    }
+
+    private func step(_ id: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)["entry-flow-step-\(id)"]
+    }
+
+    private func staticText(containing text: String, in app: XCUIApplication) -> XCUIElement {
+        app.staticTexts.containing(NSPredicate(format: "label CONTAINS %@", text)).firstMatch
+    }
+
+    private func assertHeadacheStepMatchesReference(in app: XCUIApplication) {
+        XCTAssertVisibleText("Kopfschmerz", in: app)
+        XCTAssertVisibleText("Wie stark ist es gerade?", in: app)
+        XCTAssertVisibleText("Mittel", in: app)
+        XCTAssertVisibleText("Wo spürst du den Schmerz?", in: app)
+        XCTAssertVisibleText("Wann tritt es auf?", in: app)
+        XCTAssertTrue(app.buttons["entry-location-Schläfen"].exists)
+        XCTAssertTrue(app.buttons["entry-started-at-now"].exists)
+        XCTAssertTrue(app.buttons["entry-flow-next"].exists)
+        XCTAssertTrue(app.buttons["entry-flow-save-headache-only"].exists)
+        XCTAssertVisibleText("von 5", in: app)
+    }
+
+    private func assertMedicationStepMatchesReference(in app: XCUIApplication) {
+        XCTAssertVisibleText("Medikation", in: app)
+        XCTAssertVisibleText("Hast du etwas genommen?", in: app)
+        XCTAssertVisibleText("Welche Medikation?", in: app)
+        XCTAssertVisibleText("Dosierung", in: app)
+        XCTAssertVisibleText("Wann hast du es eingenommen?", in: app)
+        XCTAssertTrue(app.buttons["entry-medication-Ibuprofen"].exists)
+        XCTAssertTrue(app.buttons["entry-medication-Triptan"].exists)
+        XCTAssertTrue(app.buttons["entry-dosage-400 mg"].exists)
+        XCTAssertTrue(app.buttons["entry-flow-skip"].exists)
+        XCTAssertVisibleText("von 5", in: app)
+    }
+
+    private func assertTriggersStepMatchesReference(in app: XCUIApplication) {
+        XCTAssertVisibleText("Auslöser", in: app)
+        XCTAssertVisibleText("Was könnte eine Rolle gespielt haben?", in: app)
+        XCTAssertVisibleText("Wähle alle passenden aus.", in: app)
+        XCTAssertTrue(app.buttons["entry-trigger-Stress"].exists)
+        XCTAssertTrue(app.buttons["entry-trigger-Wetter"].exists)
+        XCTAssertTrue(app.buttons["entry-trigger-Schlaf"].exists)
+        XCTAssertTrue(app.buttons["entry-trigger-Ernährung"].exists)
+        XCTAssertVisibleText("Du kannst mehrere auswählen.", in: app)
+        XCTAssertVisibleText("von 5", in: app)
+    }
+
+    private func assertNoteStepMatchesReference(in app: XCUIApplication) {
+        XCTAssertVisibleText("Notiz", in: app)
+        XCTAssertVisibleText("Was möchtest du festhalten?", in: app)
+        XCTAssertVisibleText("Was hat geholfen?", in: app)
+        XCTAssertVisibleText("Was war heute anders?", in: app)
+        XCTAssertVisibleText("Wie fühlst du dich gerade?", in: app)
+        XCTAssertTrue(app.buttons["entry-feeling-Müde"].exists)
+        XCTAssertTrue(app.switches["entry-note-link-toggle"].exists)
+        XCTAssertTrue(app.buttons["entry-flow-skip"].exists)
+        XCTAssertVisibleText("von 5", in: app)
+    }
+
+    private func assertReviewStepMatchesReference(in app: XCUIApplication) {
+        XCTAssertVisibleText("Eintrag prüfen", in: app)
+        XCTAssertVisibleText("Alles bereit zum Speichern.", in: app)
+        XCTAssertVisibleText("Kopfschmerz", in: app)
+        XCTAssertVisibleText("Medikation", in: app)
+        XCTAssertVisibleText("Auslöser", in: app)
+        XCTAssertVisibleText("Notiz", in: app)
+        XCTAssertVisibleText("Dein Eintrag hilft dir, Muster besser zu erkennen.", in: app)
+        XCTAssertTrue(app.buttons["entry-flow-save"].exists)
+        XCTAssertTrue(app.buttons["entry-flow-edit"].exists)
+        XCTAssertVisibleText("von 5", in: app)
+    }
+
+    private func XCTAssertVisibleText(
+        _ text: String,
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(staticText(containing: text, in: app).exists, "Missing visible text: \(text)", file: file, line: line)
+    }
+
+    private func attachScreenshot(named name: String, app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private func XCTAssertMinimumTouchTarget(
+        _ element: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(element.exists, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(element.frame.width, 44, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(element.frame.height, 44, file: file, line: line)
+    }
+}


### PR DESCRIPTION
Closes #170

## Änderungen
- Neuer Eintrag als fünfteiliger, referenznaher SwiftUI-Flow mit eigener Topbar, Progress-Anzeige, Step-Karten und Review-Screen umgesetzt.
- Accessibility-/Dynamic-Type-/Dark-Mode-Details ergänzt: stabile VoiceOver-Labels, 44pt-Touch-Target-Checks, adaptive Farbtoken und UI-Test-Identifier.
- UI-Tests für vollständigen 5-Step-Flow, Direkt-Speichern, optionale Steps überspringen, Zurück mit Draft, Abbruch und Speichern ohne Trigger/Wetter ergänzt.
- Pflichtbild-Validierung im kompletten UI-Test über sichtbare Copy-/Step-Assertions und fünf Screenshot-Attachments im xcresult.

## Validierung
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 16 Pro' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:SymiUITests/EntryFlowUITests CODE_SIGNING_ALLOWED=NO`
- `git diff --check`