### PR TITLE
[codex] Extract input flow design system

### DIFF
--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -1,3209 +1,3485 @@
 {
-  "sourceLanguage": "de",
-  "strings": {
-    "": {},
-    ", Anzahl: %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ", quantity: %1$lld"
+  "sourceLanguage" : "de",
+  "strings" : {
+    "" : {
+
+    },
+    ", Anzahl: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", quantity: %1$lld"
           }
         }
       }
     },
-    ", Wirkung: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": ", effect: %1$@"
+    ", Wirkung: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ", effect: %1$@"
           }
         }
       }
     },
-    "%@ · %@ · Intensität %lld/10": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ · %2$@ · Intensity %3$lld/10"
+    "/10" : {
+
+    },
+    "%@ · %@ · Intensität %lld/10" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$@ · Intensity %3$lld/10"
           }
         }
       }
     },
-    "%@ · Intensität %lld/10": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@ · Intensität %2$lld/10"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ · Intensity %2$lld/10"
-          }
-        }
-      }
-    },
-    "%@ %% Luftfeuchte": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ %% humidity"
-          }
-        }
-      }
-    },
-    "%@ abwählen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Deselect %1$@"
-          }
-        }
-      }
-    },
-    "%@ Bericht": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ report"
-          }
-        }
-      }
-    },
-    "%@ ist dein ruhiges Migräne Tagebuch. Du hältst fest, was passiert ist, und entscheidest selbst, welche zusätzlichen Daten du einbeziehst.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ is your calm migraine diary. You record what happened and decide which additional data you want to include."
-          }
-        }
-      }
-    },
-    "%@ mm Niederschlag": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ mm precipitation"
-          }
-        }
-      }
-    },
-    "%@ wird aus SwiftData entfernt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ will be removed from SwiftData."
-          }
-        }
-      }
-    },
-    "%@ wird in den Papierkorb verschoben.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ will be moved to the trash."
-          }
-        }
-      }
-    },
-    "%@: %@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$@: %2$@"
+    "%@ · Intensität %lld/10" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ · Intensität %2$lld/10"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@: %2$@"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · Intensity %2$lld/10"
           }
         }
       }
     },
-    "%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld"
+    "%@ %% Luftfeuchte" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ %% humidity"
           }
         }
       }
     },
-    "%lld Eintrag%@": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$lld Eintrag%2$@"
+    "%@ abwählen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deselect %1$@"
+          }
+        }
+      }
+    },
+    "%@ Bericht" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ report"
+          }
+        }
+      }
+    },
+    "%@ heute genommen" : {
+
+    },
+    "%@ ist dein ruhiges Migräne Tagebuch. Du hältst fest, was passiert ist, und entscheidest selbst, welche zusätzlichen Daten du einbeziehst." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ is your calm migraine diary. You record what happened and decide which additional data you want to include."
+          }
+        }
+      }
+    },
+    "%@ mm Niederschlag" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ mm precipitation"
+          }
+        }
+      }
+    },
+    "%@ wird aus SwiftData entfernt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ will be removed from SwiftData."
+          }
+        }
+      }
+    },
+    "%@ wird in den Papierkorb verschoben." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ will be moved to the trash."
+          }
+        }
+      }
+    },
+    "%@: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@: %2$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld entr%2$@"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: %2$@"
           }
         }
       }
     },
-    "%lld Eintrag%@ · Höchste Intensität %lld/10": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "new",
-            "value": "%1$lld Eintrag%2$@ · Höchste Intensität %3$lld/10"
+    "%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        }
+      }
+    },
+    "%lld Eintrag%@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld Eintrag%2$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld entr%2$@ · Highest intensity %3$lld/10"
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld entr%2$@"
           }
         }
       }
     },
-    "%lld von 10": {},
-    "%lld/10": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld/10"
+    "%lld Eintrag%@ · Höchste Intensität %lld/10" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld Eintrag%2$@ · Höchste Intensität %3$lld/10"
           }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld entr%2$@ · Highest intensity %3$lld/10"
+          }
+        }
+      }
+    },
+    "%lld von 10" : {
+
+    },
+    "%lld von 10, %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld von 10, %2$@"
+          }
+        }
+      }
+    },
+    "%lld/%lld" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld/%2$lld"
+          }
+        }
+      }
+    },
+    "%lld/10" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/10"
+          }
+        }
+      }
+    },
+    "%lldx" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lldx"
+          }
         }
       }
     },
-    "%lldx": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lldx"
+    "2 Stunden" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 hours"
           }
         }
       }
     },
-    "2 Stunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2 hours"
+    "24 Stunden" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24 hours"
           }
         }
       }
     },
-    "24 Stunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "24 hours"
+    "30 Minuten" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 minutes"
           }
         }
       }
     },
-    "30 Minuten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "30 minutes"
+    "Abbrechen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
           }
         }
       }
     },
-    "Abbrechen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
+    "Abweichende Felder: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conflicting fields: %1$@"
           }
         }
       }
     },
-    "Abweichende Felder: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conflicting fields: %1$@"
+    "Adresse" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Address"
           }
         }
       }
     },
-    "Adresse": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Address"
+    "Aktionen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actions"
           }
         }
       }
     },
-    "Aktionen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Actions"
+    "Aktiv" : {
+
+    },
+    "Aktive Episoden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active Episodes"
           }
         }
       }
     },
-    "Aktive Episoden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Active Episodes"
+    "Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable sync to use iCloud synchronization and conflict handling."
           }
         }
       }
     },
-    "Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable sync to use iCloud synchronization and conflict handling."
+    "Aktualisieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh"
           }
         }
       }
     },
-    "Aktualisieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refresh"
+    "Aktuell" : {
+
+    },
+    "Aktuell ausgewählt." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Currently selected."
           }
         }
       }
+    },
+    "Aktueller Zustand" : {
+
     },
-    "Aktuell ausgewählt.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Currently selected."
+    "Alle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
           }
         }
       }
     },
-    "Aktueller Zustand": {},
-    "Alle": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All"
+    "Alle Details" : {
+
+    },
+    "Alles im Blick" : {
+
+    },
+    "Allgemein" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
           }
         }
       }
     },
-    "Alle Details": {},
-    "Alles im Blick": {},
-    "Allgemein": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "General"
+    "Als Wiederholungseinnahme dokumentiert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Documented as a repeat dose"
           }
         }
       }
     },
-    "Als Wiederholungseinnahme dokumentiert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Documented as a repeat dose"
+    "Änderungen speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save Changes"
           }
         }
       }
     },
-    "Änderungen speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save Changes"
+    "Ansicht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View"
           }
         }
       }
     },
-    "Ansicht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View"
+    "Antiemetikum" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antiemetic"
           }
         }
       }
     },
-    "Antiemetikum": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Antiemetic"
+    "Anzahl" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quantity"
           }
         }
       }
     },
-    "Anzahl": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quantity"
+    "Anzahl: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quantity: %lld"
           }
         }
       }
     },
-    "Anzahl: %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quantity: %lld"
+    "App herunterladen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download the app"
           }
         }
       }
     },
-    "App herunterladen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Download the app"
+    "Apple Health" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Health"
           }
         }
       }
     },
-    "Apple Health": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple Health"
+    "Apple Health optional" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Health Optional"
           }
         }
       }
     },
-    "Apple Health optional": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple Health Optional"
+    "Apple Health wird nur genutzt, wenn du einzelne Datentypen freigibst. Wenn ein Health-Datentyp auf deinem Gerät nicht verfügbar ist, wird er ausgelassen." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Health is used only if you allow individual data types. If a Health data type is not available on your device, it is skipped."
           }
         }
       }
     },
-    "Apple Health wird nur genutzt, wenn du einzelne Datentypen freigibst. Wenn ein Health-Datentyp auf deinem Gerät nicht verfügbar ist, wird er ausgelassen.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple Health is used only if you allow individual data types. If a Health data type is not available on your device, it is skipped."
+    "Apple Health wird nur genutzt, wenn du einzelne Informationen freigibst." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Health is used only if you share individual information."
           }
         }
       }
     },
-    "Apple Health wird nur genutzt, wenn du einzelne Informationen freigibst.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple Health is used only if you share individual information."
+    "Apple Health wird nur nach deiner Freigabe pro Datentyp genutzt. Nicht auf deiner iOS-Version verfügbare HealthKit-Daten werden nicht erzwungen." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Health is used only after you grant access per data type. HealthKit data that is not available on your iOS version is not forced."
           }
         }
       }
     },
-    "Apple Health wird nur nach deiner Freigabe pro Datentyp genutzt. Nicht auf deiner iOS-Version verfügbare HealthKit-Daten werden nicht erzwungen.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple Health is used only after you grant access per data type. HealthKit data that is not available on your iOS version is not forced."
+    "Apple-Health-Daten bleiben optional. Gelesene Werte werden als Apple-Health-Kontext gekennzeichnet; geschriebene Symptome enthalten keine Notizen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Health data remains optional. Read values are labeled as Apple Health context; written symptoms do not include notes."
           }
         }
       }
     },
-    "Apple-Health-Daten bleiben optional. Gelesene Werte werden als Apple-Health-Kontext gekennzeichnet; geschriebene Symptome enthalten keine Notizen.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apple Health data remains optional. Read values are labeled as Apple Health context; written symptoms do not include notes."
+    "Attribution" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attribution"
           }
         }
       }
     },
-    "Attribution": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attribution"
+    "Ausgewählt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selected"
           }
         }
       }
     },
-    "Ausgewählt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selected"
+    "Auswertung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analysis"
           }
         }
       }
+    },
+    "Backup" : {
+
+    },
+    "Backup einlesen" : {
+
     },
-    "Auswertung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Analysis"
+    "Backup erstellen" : {
+
+    },
+    "Backup teilen" : {
+
+    },
+    "Bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
           }
         }
       }
+    },
+    "Beenden" : {
+
     },
-    "Backup": {},
-    "Backup einlesen": {},
-    "Backup erstellen": {},
-    "Backup teilen": {},
-    "Bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit"
+    "Beendet" : {
+
+    },
+    "Beginn" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
           }
         }
       }
     },
-    "Beginn": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start"
+    "Bei neuen, starken oder ungewohnten Symptomen, bei Unsicherheit oder im Notfall solltest du medizinische Hilfe holen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For new, severe or unusual symptoms, uncertainty or emergencies, you should seek medical help."
           }
         }
       }
     },
-    "Bei neuen, starken oder ungewohnten Symptomen, bei Unsicherheit oder im Notfall solltest du medizinische Hilfe holen.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For new, severe or unusual symptoms, uncertainty or emergencies, you should seek medical help."
+    "Bei Warnzeichen Hilfe holen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Get Help for Warning Signs"
           }
         }
       }
     },
-    "Bei Warnzeichen Hilfe holen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Get Help for Warning Signs"
+    "Beim Laden wird dein ungefährer Standort verwendet, um Wetterdaten für den Episodenzeitpunkt abzurufen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When loading, your approximate location is used to retrieve weather data for the episode time."
           }
         }
       }
     },
-    "Beim Laden wird dein ungefährer Standort verwendet, um Wetterdaten für den Episodenzeitpunkt abzurufen.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When loading, your approximate location is used to retrieve weather data for the episode time."
+    "Beiträge" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contributions"
           }
         }
       }
     },
-    "Beiträge": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contributions"
+    "Berechtigungen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permissions"
           }
         }
       }
     },
-    "Berechtigungen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Permissions"
+    "Bericht" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Report"
           }
         }
       }
+    },
+    "Berichte erstellen" : {
+
+    },
+    "Berichtsdaten werden vorbereitet." : {
+
     },
-    "Bericht": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Report"
+    "Bevor du startest" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Before You Start"
           }
         }
       }
     },
-    "Berichtsdaten werden vorbereitet.": {},
-    "Bevor du startest": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Before You Start"
+    "Bis" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To"
           }
         }
       }
     },
-    "Bis": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To"
+    "Bisher dokumentiert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logged So Far"
           }
         }
       }
     },
-    "Bisher dokumentiert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Logged So Far"
+    "Bundesland" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "State"
           }
         }
       }
     },
-    "Bundesland": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "State"
+    "Cloud hat recht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Cloud Version"
           }
         }
       }
     },
-    "Cloud hat recht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Cloud Version"
+    "Cloud-Daten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cloud Data"
           }
         }
       }
     },
-    "Cloud-Daten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud Data"
+    "Cloud-Daten verwalten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manage Cloud Data"
           }
         }
       }
     },
-    "Cloud-Daten verwalten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Manage Cloud Data"
+    "Das Backup enthält alle Einträge, eigene Medikamentenvorlagen, Wetter-Snapshots und gespeicherten Apple-Health-Kontext, inklusive Papierkorb-Einträgen." : {
+
+    },
+    "Das Projekt steht unter der GNU GPL v3." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The project is licensed under the GNU GPL v3."
           }
         }
       }
     },
-    "Das Backup enthält alle Einträge, eigene Medikamentenvorlagen, Wetter-Snapshots und gespeicherten Apple-Health-Kontext, inklusive Papierkorb-Einträgen.": {},
-    "Das Projekt steht unter der GNU GPL v3.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The project is licensed under the GNU GPL v3."
+    "Das Protokoll bleibt lokal auf diesem Gerät. Es enthält technische Metadaten zu Synchronisation, Konflikten und Fehlern, aber keine sensiblen Freitextinhalte im Klartext." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The log stays local on this device. It contains technical metadata about synchronization, conflicts and errors, but no sensitive free-text content in plain text."
           }
         }
       }
     },
-    "Das Protokoll bleibt lokal auf diesem Gerät. Es enthält technische Metadaten zu Synchronisation, Konflikten und Fehlern, aber keine sensiblen Freitextinhalte im Klartext.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The log stays local on this device. It contains technical metadata about synchronization, conflicts and errors, but no sensitive free-text content in plain text."
+    "Das Wetter wird als Kontext mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt." : {
+
+    },
+    "Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather is loaded with your approximate location via Apple Weather. The entry is still saved without weather if permission is not granted."
           }
         }
       }
     },
-    "Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather is loaded with your approximate location via Apple Weather. The entry is still saved without weather if permission is not granted."
+    "Daten exportieren" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Data"
           }
         }
       }
     },
-    "Daten exportieren": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export Data"
+    "Daten sichern" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back Up Data"
           }
         }
       }
+    },
+    "Daten und Backup" : {
+
     },
-    "Daten sichern": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back Up Data"
+    "Daten wiederherstellen" : {
+
+    },
+    "Datenexport" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Export"
           }
         }
       }
     },
-    "Daten und Backup": {},
-    "Datenexport": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Data Export"
+    "Datenschutz" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
           }
         }
       }
     },
-    "Datenschutz": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy"
+    "Datenschutz und Hinweise" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy and Notes"
           }
         }
       }
     },
-    "Datenschutz und Hinweise": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Privacy and Notes"
+    "Datenschutzerklärung öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Privacy Policy"
           }
         }
       }
+    },
+    "Dauermedikation" : {
+
+    },
+    "Dauermedikation hinzufügen" : {
+
     },
-    "Datenschutzerklärung öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Privacy Policy"
+    "Dauermedikationen sind ein eigener Verlaufskontext und bleiben von Akutmedikation in Einträgen getrennt." : {
+
+    },
+    "Dein Eintrag hilft dir, Muster besser zu erkennen." : {
+
+    },
+    "Dein Eintrag wurde lokal gespeichert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your entry was saved locally."
           }
         }
       }
     },
-    "Dein Eintrag wurde lokal gespeichert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your entry was saved locally."
+    "Deine Daten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Data"
           }
         }
       }
     },
-    "Deine Daten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Data"
+    "Deine Daten gehören dir" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Data Belongs to You"
           }
         }
       }
+    },
+    "Deine Daten gehören dir." : {
+
     },
-    "Deine Daten gehören dir": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Data Belongs to You"
+    "Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your entries stay local on this device and help you keep track of patterns, triggers and routines that work."
           }
         }
       }
     },
-    "Deine Daten gehören dir.": {},
-    "Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your entries stay local on this device and help you keep track of patterns, triggers and routines that work."
+    "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync works defensively: conflicts are not overwritten silently, but made visible here."
           }
         }
       }
     },
-    "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync works defensively: conflicts are not overwritten silently, but made visible here."
+    "Der PDF-Bericht von %@ wird lokal erzeugt und kann systemweit geteilt werden." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The PDF report from %1$@ is created locally and can be shared system-wide."
           }
         }
       }
     },
-    "Der PDF-Bericht von %@ wird lokal erzeugt und kann systemweit geteilt werden.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The PDF report from %1$@ is created locally and can be shared system-wide."
+    "Detaillierte Einträge" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detailed entries"
           }
         }
       }
     },
-    "Detaillierte Einträge": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detailed entries"
+    "Detaillierter Bericht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detailed report"
           }
         }
       }
     },
-    "Detaillierter Bericht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detailed report"
+    "Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The app remains fully usable locally. iCloud sync is optional, works separately from SwiftData and can be disabled again at any time."
           }
         }
       }
     },
-    "Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The app remains fully usable locally. iCloud sync is optional, works separately from SwiftData and can be disabled again at any time."
+    "Die App funktioniert auch ohne iCloud. Wenn du Sync aktivierst, werden deine App-Daten über deinen eigenen iCloud-Account abgeglichen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The app also works without iCloud. If you enable sync, your app data is synced through your own iCloud account."
           }
         }
       }
     },
-    "Die App funktioniert auch ohne iCloud. Wenn du Sync aktivierst, werden deine App-Daten über deinen eigenen iCloud-Account abgeglichen.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The app also works without iCloud. If you enable sync, your app data is synced through your own iCloud account."
+    "Die App hilft dir, eigene Beobachtungen festzuhalten und später wiederzufinden." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The app helps you record your own observations and find them again later."
           }
         }
       }
     },
-    "Die App hilft dir, eigene Beobachtungen festzuhalten und später wiederzufinden.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The app helps you record your own observations and find them again later."
+    "Die App ist aktuell für iPhone, deutsche Sprache und iOS 17.6 oder neuer ausgelegt." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The app is currently designed for iPhone, German language and iOS 17.6 or later."
           }
         }
       }
     },
-    "Die App ist aktuell für iPhone, deutsche Sprache und iOS 17.6 oder neuer ausgelegt.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The app is currently designed for iPhone, German language and iOS 17.6 or later."
+    "Die App stellt keine Diagnose, bewertet deine Beschwerden nicht medizinisch und empfiehlt keine Behandlung." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The app does not provide a diagnosis, does not medically assess your symptoms and does not recommend treatment."
           }
         }
       }
     },
-    "Die App stellt keine Diagnose, bewertet deine Beschwerden nicht medizinisch und empfiehlt keine Behandlung.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The app does not provide a diagnosis, does not medically assess your symptoms and does not recommend treatment."
+    "Die App unterstützt deine Dokumentation. Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The app supports your documentation. It does not replace a medical diagnosis, treatment decisions or emergency contacts."
           }
         }
       }
     },
-    "Die App unterstützt deine Dokumentation. Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The app supports your documentation. It does not replace a medical diagnosis, treatment decisions or emergency contacts."
+    "Die Liste zeigt Beispieldaten für den Screenshot-Modus." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The list shows sample data for screenshot mode."
           }
         }
       }
     },
-    "Die Liste zeigt Beispieldaten für den Screenshot-Modus.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The list shows sample data for screenshot mode."
+    "Die Treffer sind nach relevanten Fachgebieten gruppiert und innerhalb der Gruppen nach PLZ und Name sortiert." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Results are grouped by relevant specialties and sorted within groups by postal code and name."
           }
         }
       }
     },
-    "Die Treffer sind nach relevanten Fachgebieten gruppiert und innerhalb der Gruppen nach PLZ und Name sortiert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Results are grouped by relevant specialties and sorted within groups by postal code and name."
+    "Diese Aktion löscht den lokalen SwiftData-Store auf diesem Gerät. Eine spätere Migration ist nur möglich, wenn du die Store-Dateien vorher gesichert hast." : {
+
+    },
+    "Diese Episode wird in den Papierkorb verschoben." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This episode will be moved to the trash."
           }
         }
       }
+    },
+    "Diese Notiz wird mit deinem Eintrag von heute verknüpft." : {
+
+    },
+    "Diese Option entfernt die lokalen Store-Dateien erst nach deiner Bestätigung und erstellt danach einen neuen leeren Store." : {
+
     },
-    "Diese Episode wird in den Papierkorb verschoben.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This episode will be moved to the trash."
+    "Dokumentationshilfe" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Documentation Aid"
           }
         }
       }
     },
-    "Dokumentationshilfe": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Documentation Aid"
+    "Dokumentierte Medikamente: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Documented medications: %1$@"
           }
         }
       }
     },
-    "Dokumentierte Medikamente: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Documented medications: %1$@"
+    "Dosierung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosage"
           }
         }
       }
     },
-    "Dosierung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dosage"
+    "Dosierung, optional" : {
+
+    },
+    "Du behältst die Kontrolle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You Stay in Control"
           }
         }
       }
     },
-    "Du behältst die Kontrolle": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You Stay in Control"
+    "Du dokumentierst Zeitpunkt, Dauer, Intensität, Symptome, mögliche Auslöser, Medikamente und persönliche Notizen." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You document timing, duration, intensity, symptoms, possible triggers, medication and personal notes."
           }
         }
       }
     },
-    "Du dokumentierst Zeitpunkt, Dauer, Intensität, Symptome, mögliche Auslöser, Medikamente und persönliche Notizen.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You document timing, duration, intensity, symptoms, possible triggers, medication and personal notes."
+    "Du dokumentierst Zeitpunkt, Intensität, hilfreiche Hinweise und persönliche Notizen ohne Formulargefühl." : {
+
+    },
+    "Du kannst die Standortfreigabe in den Einstellungen dieser App unter \"Standort\" auf \"Beim Verwenden der App\" ändern." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can change location permission in this app's settings under \"Location\" to \"While Using the App\"."
           }
         }
       }
     },
-    "Du dokumentierst Zeitpunkt, Intensität, hilfreiche Hinweise und persönliche Notizen ohne Formulargefühl.": {},
-    "Du kannst die Standortfreigabe in den Einstellungen dieser App unter \"Standort\" auf \"Beim Verwenden der App\" ändern.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can change location permission in this app's settings under \"Location\" to \"While Using the App\"."
+    "Du kannst entscheiden ob und in welchem Ausmaß du deine Gesundheitsdaten an diese App freigibst. Sie werden niemals an Dritte weitergegeben." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can decide whether and to what extent you share your health data with this app. It is never shared with third parties."
           }
         }
       }
     },
-    "Du kannst entscheiden ob und in welchem Ausmaß du deine Gesundheitsdaten an diese App freigibst. Sie werden niemals an Dritte weitergegeben.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can decide whether and to what extent you share your health data with this app. It is never shared with third parties."
+    "Durchschnittliche Intensität: %@/10" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Average intensity: %1$@/10"
           }
         }
       }
     },
-    "Durchschnittliche Intensität: %@/10": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Average intensity: %1$@/10"
+    "E-Mail" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email"
           }
         }
       }
     },
-    "E-Mail": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Email"
+    "Eigenes Medikament" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Medication"
           }
         }
       }
     },
-    "Eigenes Medikament": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom Medication"
+    "Eigenes Medikament hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Custom Medication"
           }
         }
       }
     },
-    "Eigenes Medikament hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add Custom Medication"
+    "Eigenes Medikament löschen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Custom Medication?"
           }
         }
       }
+    },
+    "Eine schnelle Einschätzung reicht. Details kannst du im Eintrag ergänzen." : {
+
     },
-    "Eigenes Medikament löschen?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Custom Medication?"
+    "Einschränkung: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Functional impact: %1$@"
           }
         }
       }
     },
-    "Eine schnelle Einschätzung reicht. Details kannst du im Eintrag ergänzen.": {},
-    "Einschränkung: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Functional impact: %1$@"
+    "Einstellungen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
           }
         }
       }
     },
-    "Einstellungen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Settings"
+    "Einstellungen öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Settings"
           }
         }
       }
     },
-    "Einstellungen öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Settings"
+    "Eintrag bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Entry"
           }
         }
       }
     },
-    "Eintrag bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Entry"
+    "Eintrag erstellen" : {
+
+    },
+    "Eintrag gespeichert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entry Saved"
           }
         }
       }
+    },
+    "Eintrag konnte nicht gespeichert werden" : {
+
     },
-    "Eintrag erstellen": {},
-    "Eintrag gespeichert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entry Saved"
+    "Eintrag löschen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Entry?"
           }
         }
       }
     },
-    "Eintrag löschen?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Entry?"
+    "Eintrag speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save Entry"
           }
         }
       }
     },
-    "Eintrag speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save Entry"
+    "Einträge" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries"
           }
         }
       }
     },
-    "Einträge": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entries"
+    "Einträge im Zeitraum: %lld" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries in period: %lld"
           }
         }
       }
     },
-    "Einträge im Zeitraum: %lld": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entries in period: %lld"
+    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden auf diesem Gerät gespeichert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device."
           }
         }
       }
     },
-    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden auf diesem Gerät gespeichert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device."
+    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden zuerst auf diesem Gerät gespeichert." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device first."
           }
         }
       }
     },
-    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden zuerst auf diesem Gerät gespeichert.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device first."
+    "Einträge: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entries: %1$lld"
           }
         }
       }
+    },
+    "Eintragen" : {
+
+    },
+    "Enddatum" : {
+
     },
-    "Einträge: %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entries: %1$lld"
+    "Enddatum setzen" : {
+
+    },
+    "Ende" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "End"
           }
         }
       }
     },
-    "Eintragen": {},
-    "Ende": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "End"
+    "Ende angeben" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specify End"
           }
         }
       }
     },
-    "Ende angeben": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Specify End"
+    "Ende: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "End: %1$@"
           }
         }
       }
     },
-    "Ende: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "End: %1$@"
+    "Endzeit angeben" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specify End Time"
           }
         }
       }
     },
-    "Endzeit angeben": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Specify End Time"
+    "Entfernen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove"
           }
         }
       }
     },
-    "Entfernen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove"
+    "Entfernt die Auswahl." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Removes the selection."
           }
         }
       }
     },
-    "Entfernt die Auswahl.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Removes the selection."
+    "Episode" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode"
           }
         }
       }
     },
-    "Episode": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Episode"
+    "Episode löschen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Episode?"
           }
         }
       }
     },
-    "Episode löschen?": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Episode?"
+    "Episode nicht gefunden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode Not Found"
           }
         }
       }
     },
-    "Episode nicht gefunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Episode Not Found"
+    "Episodendetail" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode Details"
           }
         }
       }
     },
-    "Episodendetail": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Episode Details"
+    "Episodentypen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Episode types"
           }
         }
       }
     },
-    "Episodentypen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Episode types"
+    "Erinnerung" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder"
           }
         }
       }
     },
-    "Erinnerung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reminder"
+    "Erinnerung aktivieren" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Reminder"
           }
         }
       }
     },
-    "Erinnerung aktivieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Reminder"
+    "Erinnerung: %@" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminder: %1$@"
           }
         }
       }
     },
-    "Erinnerung: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reminder: %1$@"
+    "Erinnerungen bleiben lokal" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminders Stay Local"
           }
         }
       }
     },
-    "Erinnerungen bleiben lokal": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reminders Stay Local"
+    "Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create a PDF report or JSON5 backup for a freely selectable period."
           }
         }
       }
     },
-    "Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create a PDF report or JSON5 backup for a freely selectable period."
+    "Erstellt mit %@." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Created with %1$@."
           }
         }
       }
     },
-    "Erstellt mit %@.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Created with %1$@."
+    "Export" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export"
           }
         }
       }
     },
-    "Export": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export"
+    "Export nur mit deiner Aktion" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Export Only When You Choose"
           }
         }
       }
     },
-    "Export nur mit deiner Aktion": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Export Only When You Choose"
+    "Fachgebiet" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specialty"
           }
         }
       }
     },
-    "Fachgebiet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Specialty"
+    "Feedback und Hilfe findest du über symiapp.com." : {
+
+    },
+    "Feedback und Ideen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback and Ideas"
           }
         }
       }
     },
-    "Feedback und Hilfe findest du über symiapp.com.": {},
-    "Feedback und Ideen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback and Ideas"
+    "Fehler erneut versuchen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry Error"
           }
         }
       }
     },
-    "Fehler erneut versuchen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Retry Error"
+    "Fehler, Ideen und Verbesserungsvorschläge kannst du als GitHub-Issue einreichen." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can submit bugs, ideas and suggestions as GitHub issues."
           }
         }
       }
     },
-    "Fehler, Ideen und Verbesserungsvorschläge kannst du als GitHub-Issue einreichen.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can submit bugs, ideas and suggestions as GitHub issues."
+    "Fehler: %@" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error: %1$@"
           }
         }
       }
     },
-    "Fehler: %@": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error: %1$@"
+    "Filter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter"
           }
         }
       }
+    },
+    "Flow-Schritt %@" : {
+
     },
-    "Filter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filter"
+    "Frequenz, optional" : {
+
+    },
+    "Funktionelle Einschränkung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Functional Limitation"
           }
         }
       }
     },
-    "Funktionelle Einschränkung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Functional Limitation"
+    "Für %@ ist noch nichts dokumentiert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing has been documented for %1$@ yet."
           }
         }
       }
     },
-    "Für %@ ist noch nichts dokumentiert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nothing has been documented for %1$@ yet."
+    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nicht als eigener Tagebucheintrag gespeichert." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For weather data, the app asks for your approximate location. Coordinates are not stored as their own diary entry."
           }
         }
       }
     },
-    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nicht als eigener Tagebucheintrag gespeichert.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For weather data, the app asks for your approximate location. Coordinates are not stored as their own diary entry."
+    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nur für den Wetteraufruf benötigt und nie gespeichert." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For weather data, the app asks for your approximate location. Coordinates are only needed for the weather request and are never stored."
           }
         }
       }
     },
-    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nur für den Wetteraufruf benötigt und nie gespeichert.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For weather data, the app asks for your approximate location. Coordinates are only needed for the weather request and are never stored."
+    "Gesundheit" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Health"
           }
         }
       }
     },
-    "Gesundheit": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Health"
+    "GitHub-Issues öffnen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open GitHub Issues"
           }
         }
       }
     },
-    "GitHub-Issues öffnen": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open GitHub Issues"
+    "Gut" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Good"
           }
         }
       }
     },
-    "Gut": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Good"
+    "Häufige Symptome: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Common symptoms: %1$@"
           }
         }
       }
     },
-    "Häufige Symptome: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Common symptoms: %1$@"
+    "Häufige Trigger: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Common triggers: %1$@"
           }
         }
       }
     },
-    "Häufige Trigger: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Common triggers: %1$@"
+    "Herzfrequenz %@ bpm" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heart rate %1$@ bpm"
           }
         }
       }
     },
-    "Herzfrequenz %@ bpm": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Heart rate %1$@ bpm"
+    "Heute" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today"
           }
         }
       }
     },
-    "Heute": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Today"
+    "Hinweis: %@" : {
+
+    },
+    "Hinzufügen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add"
           }
         }
       }
     },
-    "Hinweis: %@": {},
-    "Hinzufügen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add"
+    "iCloud ist freiwillig" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud Is Optional"
           }
         }
       }
+    },
+    "In Sekunden eintragen" : {
+
     },
-    "iCloud ist freiwillig": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iCloud Is Optional"
+    "Intensität" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intensity"
           }
         }
       }
     },
-    "In Sekunden eintragen": {},
-    "Intensität": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensity"
+    "Intensität %lld" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intensity %lld"
           }
         }
       }
     },
-    "Intensität %lld": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensity %lld"
+    "Intensität im Verlauf" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intensity over time"
           }
         }
       }
     },
-    "Intensität im Verlauf": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensity over time"
+    "iOS verwaltet Health-Berechtigungen pro Datentyp. Verweigerte Leserechte erscheinen in der App wie fehlende Daten." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS manages Health permissions per data type. Denied read permissions appear in the app as missing data."
           }
         }
       }
     },
-    "iOS verwaltet Health-Berechtigungen pro Datentyp. Verweigerte Leserechte erscheinen in der App wie fehlende Daten.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iOS manages Health permissions per data type. Denied read permissions appear in the app as missing data."
+    "iPhone und Deutsch" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iPhone and German"
           }
         }
       }
     },
-    "iPhone und Deutsch": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "iPhone and German"
+    "Jetzt synchronisieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Now"
           }
         }
       }
     },
-    "Jetzt synchronisieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Now"
+    "JSON5 erstellen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create JSON5"
           }
         }
       }
     },
-    "JSON5 erstellen": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create JSON5"
+    "JSON5 importieren" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Import JSON5"
           }
         }
       }
     },
-    "JSON5 importieren": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import JSON5"
+    "JSON5 teilen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share JSON5"
           }
         }
       }
     },
-    "JSON5 teilen": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share JSON5"
+    "JSON5-Export enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON5 export contains all entries and custom medication templates, including trashed entries."
           }
         }
       }
     },
-    "JSON5-Export enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "JSON5 export contains all entries and custom medication templates, including trashed entries."
+    "Kategorie" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Category"
           }
         }
       }
     },
-    "Kategorie": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Category"
+    "Kein Medikament gefunden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Medication Found"
           }
         }
       }
     },
-    "Kein Medikament gefunden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Medication Found"
+    "Kein Protokoll vorhanden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Log Available"
           }
         }
       }
     },
-    "Kein Protokoll vorhanden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Log Available"
+    "Keine" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "None"
           }
         }
       }
     },
-    "Keine": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "None"
+    "Keine aktive Dauermedikation." : {
+
+    },
+    "Keine beendete Dauermedikation." : {
+
+    },
+    "Keine Diagnose, keine Therapieempfehlung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Diagnosis, No Treatment Recommendation"
           }
         }
       }
     },
-    "Keine Diagnose, keine Therapieempfehlung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Diagnosis, No Treatment Recommendation"
+    "Keine Einträge im Zeitraum" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Entries in Period"
           }
         }
       }
     },
-    "Keine Einträge im Zeitraum": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Entries in Period"
+    "Keine gelöschten Einträge." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No deleted entries."
           }
         }
       }
     },
-    "Keine gelöschten Einträge.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No deleted entries."
+    "Keine offenen Konflikte." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No open conflicts."
           }
         }
       }
     },
-    "Keine offenen Konflikte.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No open conflicts."
+    "Konflikt lösen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resolve Conflict"
           }
         }
       }
     },
-    "Konflikt lösen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resolve Conflict"
+    "Konflikt wird verarbeitet …" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Processing conflict ..."
           }
         }
       }
     },
-    "Konflikt wird verarbeitet …": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Processing conflict ..."
+    "Konflikte" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conflicts"
           }
         }
       }
     },
-    "Konflikte": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Conflicts"
+    "Kontakt" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact"
           }
         }
       }
     },
-    "Kontakt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact"
+    "Kopfschmerz" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Headache"
           }
         }
       }
+    },
+    "Kopfschmerzstärke" : {
+
     },
-    "Kopfschmerz": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Headache"
+    "Kurz notieren, was auffällt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Briefly note what stands out"
           }
         }
       }
     },
-    "Kurz notieren, was auffällt": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Briefly note what stands out"
+    "Kurzüberblick" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Executive summary"
           }
         }
       }
     },
-    "Kurzüberblick": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Executive summary"
+    "Leerer Neustart" : {
+
+    },
+    "Leerer Store wird erstellt" : {
+
+    },
+    "Lesen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read"
           }
         }
       }
     },
-    "Lesen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Read"
+    "Lesen und Schreiben sind getrennt. Du kannst jeden Health-Datentyp einzeln erlauben und später wieder deaktivieren." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading and writing are separate. You can allow each Health data type individually and turn it off again later."
           }
         }
       }
     },
-    "Lesen und Schreiben sind getrennt. Du kannst jeden Health-Datentyp einzeln erlauben und später wieder deaktivieren.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reading and writing are separate. You can allow each Health data type individually and turn it off again later."
+    "Lesen und Schreiben werden getrennt verwaltet. Die App nutzt nur Daten, die für Schmerzepisoden als Kontext sinnvoll sind." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading and writing are managed separately. The app uses only data that is useful as context for pain episodes."
           }
         }
       }
     },
-    "Lesen und Schreiben werden getrennt verwaltet. Die App nutzt nur Daten, die für Schmerzepisoden als Kontext sinnvoll sind.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reading and writing are managed separately. The app uses only data that is useful as context for pain episodes."
+    "Leserechte anfragen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request Read Access"
           }
         }
       }
     },
-    "Leserechte anfragen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request Read Access"
+    "Letzter Fehler" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latest Error"
           }
         }
       }
     },
-    "Letzter Fehler": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Latest Error"
+    "Lizenz" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "License"
           }
         }
       }
     },
-    "Lizenz": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "License"
+    "Lokal hat recht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use Local Version"
           }
         }
       }
+    },
+    "Lokale Daten wurden nicht gelöscht" : {
+
     },
-    "Lokal hat recht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use Local Version"
+    "Lokale Store-Dateien löschen?" : {
+
+    },
+    "Lokaler Stand und Cloud-Stand unterscheiden sich." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local and cloud versions differ."
           }
         }
       }
     },
-    "Lokaler Stand und Cloud-Stand unterscheiden sich.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Local and cloud versions differ."
+    "Lokales JSON5-Backup erstellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create Local JSON5 Backup"
           }
         }
       }
     },
-    "Lokales JSON5-Backup erstellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create Local JSON5 Backup"
+    "Löschen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
           }
         }
       }
     },
-    "Löschen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete"
+    "Manche Health-Datentypen gibt es erst auf neueren iOS-Versionen. Die App bleibt nutzbar und zeigt einfach nur die verfügbaren Werte." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some Health data types exist only on newer iOS versions. The app remains usable and simply shows the available values."
           }
         }
       }
     },
-    "Manche Health-Datentypen gibt es erst auf neueren iOS-Versionen. Die App bleibt nutzbar und zeigt einfach nur die verfügbaren Werte.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Some Health data types exist only on newer iOS versions. The app remains usable and simply shows the available values."
+    "Medikament" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medication"
           }
         }
       }
     },
-    "Medikament": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medication"
+    "Medikament ausgewählt. Passe die Anzahl an." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medication selected. Adjust the quantity."
           }
         }
       }
     },
-    "Medikament ausgewählt. Passe die Anzahl an.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medication selected. Adjust the quantity."
+    "Medikament bearbeiten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Medication"
           }
         }
       }
     },
-    "Medikament bearbeiten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Edit Medication"
+    "Medikament nach Namen filtern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter medication by name"
           }
         }
       }
     },
-    "Medikament nach Namen filtern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Filter medication by name"
+    "Medikamente" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medications"
           }
         }
       }
     },
-    "Medikamente": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medications"
+    "Medikamente: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medications: %1$@"
           }
         }
       }
     },
-    "Medikamente: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medications: %1$@"
+    "Medizinische Einordnung" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medical Context"
           }
         }
       }
     },
-    "Medizinische Einordnung": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medical Context"
+    "Medizinischer Hinweis" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medical Note"
           }
         }
       }
     },
-    "Medizinischer Hinweis": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Medical Note"
+    "Mehr" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
           }
         }
       }
     },
-    "Mehr": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More"
+    "Mehr gute Tage" : {
+
+    },
+    "Menstruation %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menstruation %1$@"
           }
         }
       }
     },
-    "Mehr gute Tage": {},
-    "Menstruation %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Menstruation %1$@"
+    "Menstruationsstatus" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menstruation Status"
           }
         }
       }
     },
-    "Menstruationsstatus": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Menstruation Status"
+    "Migräne" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migraine"
           }
         }
       }
+    },
+    "Mit leerem Store starten" : {
+
     },
-    "Migräne": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Migraine"
+    "Monat" : {
+
+    },
+    "Muster verstehen" : {
+
+    },
+    "Nach Name, Fachgebiet oder Ort suchen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search by name, specialty or place"
           }
         }
       }
     },
-    "Monat": {},
-    "Muster verstehen": {},
-    "Nach Name, Fachgebiet oder Ort suchen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search by name, specialty or place"
+    "Nächster Monat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next Month"
           }
         }
       }
     },
-    "Nächster Monat": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Next Month"
+    "Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
           }
         }
       }
     },
-    "Name": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Name"
+    "Neuer Eintrag" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Entry"
           }
         }
       }
     },
-    "Neuer Eintrag": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Entry"
+    "Nicht alles ist überall verfügbar" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Everything Is Available Everywhere"
           }
         }
       }
+    },
+    "Nicht ausgewählt" : {
+
     },
-    "Nicht alles ist überall verfügbar": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Not Everything Is Available Everywhere"
+    "Noch kein Eintrag für diesen Tag." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No entry for this day yet."
           }
         }
       }
     },
-    "Noch kein Eintrag für diesen Tag.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No entry for this day yet."
+    "Noch keine Einträge an diesem Tag" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Entries on This Day Yet"
           }
         }
       }
     },
-    "Noch keine Einträge an diesem Tag": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No Entries on This Day Yet"
+    "Notiz" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note"
           }
         }
       }
     },
-    "Notiz": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note"
+    "Notiz: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note: %1$@"
           }
         }
       }
     },
-    "Notiz: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Note: %1$@"
+    "NSAR" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NSAID"
           }
         }
       }
     },
-    "NSAR": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "NSAID"
+    "Nur ergänzen, wenn du heute etwas genommen hast." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only add this if you took something today."
           }
         }
       }
     },
-    "Nur ergänzen, wenn du heute etwas genommen hast.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Only add this if you took something today."
+    "Nur Fehler" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errors Only"
           }
         }
       }
     },
-    "Nur Fehler": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Errors Only"
+    "Nur Sync" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Only"
           }
         }
       }
     },
-    "Nur Sync": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Only"
+    "Öffnet die Detailansicht des Eintrags." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opens the entry detail view."
           }
         }
       }
     },
-    "Öffnet die Detailansicht des Eintrags.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opens the entry detail view."
+    "Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opens a new diary entry for the currently selected calendar day."
           }
         }
       }
     },
-    "Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opens a new diary entry for the currently selected calendar day."
+    "OK" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         }
       }
     },
-    "OK": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "OK"
+    "Open Source" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Source"
           }
         }
       }
     },
-    "Open Source": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Source"
+    "Optionale Details" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optional Details"
           }
         }
       }
     },
-    "Optionale Details": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Optional Details"
+    "Optionaler Hinweis" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optional Note"
           }
         }
       }
     },
-    "Optionaler Hinweis": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Optional Note"
+    "Ort" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Place"
           }
         }
       }
     },
-    "Ort": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Place"
+    "Papierkorb" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trash"
           }
         }
       }
     },
-    "Papierkorb": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trash"
+    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trashed entries remain local and in the cloud until you intentionally restore them or permanently remove them later."
           }
         }
       }
     },
-    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Trashed entries remain local and in the cloud until you intentionally restore them or permanently remove them later."
+    "Passe den Suchbegriff an oder füge ein eigenes Medikament hinzu." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adjust the search term or add a custom medication."
           }
         }
       }
     },
-    "Passe den Suchbegriff an oder füge ein eigenes Medikament hinzu.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust the search term or add a custom medication."
+    "Passe den Suchbegriff an oder nutze die manuelle Anlage." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adjust the search term or use manual creation."
           }
         }
       }
     },
-    "Passe den Suchbegriff an oder nutze die manuelle Anlage.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust the search term or use manual creation."
+    "Passe den Zeitraum an, damit ein Bericht aus deinem Tagebuch erstellt werden kann." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adjust the period so a report can be created from your diary."
           }
         }
       }
     },
-    "Passe den Zeitraum an, damit ein Bericht aus deinem Tagebuch erstellt werden kann.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust the period so a report can be created from your diary."
+    "PDF" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
           }
         }
       }
     },
-    "PDF": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "PDF"
+    "PDF erstellen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create PDF"
           }
         }
       }
     },
-    "PDF erstellen": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create PDF"
+    "PDF teilen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share PDF"
           }
         }
       }
     },
-    "PDF teilen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share PDF"
+    "PDF vorbereiten" : {
+
+    },
+    "PDF wird vorbereitet." : {
+
+    },
+    "PDF-Berichte helfen dir, deine Einträge übersichtlich mitzunehmen. Sie werden nur erstellt und geteilt, wenn du das aktiv auslöst." : {
+
+    },
+    "PDF-Berichte und Backups entstehen lokal. Sie verlassen die App erst, wenn du sie über iOS teilst oder speicherst." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF reports and backups are created locally. They leave the app only when you share or save them through iOS."
           }
         }
       }
     },
-    "PDF vorbereiten": {},
-    "PDF wird vorbereitet.": {},
-    "PDF-Berichte und Backups entstehen lokal. Sie verlassen die App erst, wenn du sie über iOS teilst oder speicherst.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "PDF reports and backups are created locally. They leave the app only when you share or save them through iOS."
+    "PDF-Modus" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF mode"
           }
         }
       }
     },
-    "PDF-Modus": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "PDF mode"
+    "PLZ" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Postal Code"
           }
         }
       }
     },
-    "PLZ": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Postal Code"
+    "Praxis / Ort" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Practice / Place"
           }
         }
       }
     },
-    "Praxis / Ort": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Practice / Place"
+    "Projekt auf GitHub öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Project on GitHub"
           }
         }
       }
     },
-    "Projekt auf GitHub öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Project on GitHub"
+    "Protokoll löschen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete Log"
           }
         }
       }
     },
-    "Protokoll löschen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Delete Log"
+    "Protokoll teilen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share Log"
           }
         }
       }
     },
-    "Protokoll teilen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share Log"
+    "Pull Requests sind willkommen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pull requests are welcome."
           }
         }
       }
     },
-    "Pull Requests sind willkommen.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pull requests are welcome."
+    "Quelle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source"
           }
         }
       }
     },
-    "Quelle": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source"
+    "Quelle: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source: %1$@"
           }
         }
       }
     },
-    "Quelle: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source: %1$@"
+    "Rechtliche Hinweise öffnen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Legal Notices"
           }
         }
       }
     },
-    "Rechtliche Hinweise öffnen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Legal Notices"
+    "Ruhepuls %@ bpm" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resting heart rate %1$@ bpm"
           }
         }
       }
     },
-    "Ruhepuls %@ bpm": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resting heart rate %1$@ bpm"
+    "ruhig" : {
+
+    },
+    "Sanfte Verlaufsgrafik deiner letzten Einträge" : {
+
+    },
+    "Schlaf %@ min" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sleep %1$@ min"
           }
         }
       }
     },
-    "ruhig": {},
-    "Sanfte Verlaufsgrafik deiner letzten Einträge": {},
-    "Schlaf %@ min": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sleep %1$@ min"
+    "Schließen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         }
       }
     },
-    "Schließen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+    "Schmerzcharakter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pain Character"
           }
         }
       }
     },
-    "Schmerzcharakter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pain Character"
+    "Schmerzereignisse festhalten" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Record Pain Events"
           }
         }
       }
     },
-    "Schmerzereignisse festhalten": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Record Pain Events"
+    "Schmerzlokalisation" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pain Location"
           }
         }
       }
     },
-    "Schmerzlokalisation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pain Location"
+    "Schmerztage im Zeitraum: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pain days in period: %1$lld"
           }
         }
       }
     },
-    "Schmerztage im Zeitraum: %lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pain days in period: %1$lld"
+    "Schneller Eintrag" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Entry"
           }
         }
       }
     },
-    "Schneller Eintrag": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Quick Entry"
+    "Schreiben" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Write"
           }
         }
       }
     },
-    "Schreiben": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Write"
+    "Schreibrechte anfragen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request Write Access"
           }
         }
       }
     },
-    "Schreibrechte anfragen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Request Write Access"
+    "Schritt %lld von %lld" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Schritt %1$lld von %2$lld"
           }
         }
       }
     },
-    "Schritte %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Steps %1$@"
+    "Schritte %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steps %1$@"
           }
         }
       }
     },
-    "Setzt die Intensität auf %lld von 10.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sets intensity to %lld out of 10."
+    "Setzt die Intensität auf %lld von 10." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sets intensity to %lld out of 10."
           }
         }
       }
+    },
+    "Sichere die vorhandenen Store-Dateien, bevor du Symi mit einem leeren Store startest. Ohne Löschbestätigung bleiben die Dateien an ihrem aktuellen Ort." : {
+
+    },
+    "Sichern" : {
+
     },
-    "Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "It does not replace medical diagnosis, treatment decisions or emergency contacts."
+    "Sicherung teilen" : {
+
+    },
+    "Sicherung und Migration" : {
+
+    },
+    "Sicherung wird vorbereitet" : {
+
+    },
+    "Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "It does not replace medical diagnosis, treatment decisions or emergency contacts."
           }
         }
       }
     },
-    "So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This quickly creates a useful diary entry. Everything else is optional."
+    "Skala" : {
+
+    },
+    "So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This quickly creates a useful diary entry. Everything else is optional."
           }
         }
       }
     },
-    "Sobald Sync-Vorgänge oder Fehler auftreten, erscheinen sie hier.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Once sync operations or errors occur, they will appear here."
+    "Sobald Sync-Vorgänge oder Fehler auftreten, erscheinen sie hier." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once sync operations or errors occur, they will appear here."
           }
         }
       }
     },
-    "Sonstiges": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Other"
+    "Sonstiges" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Other"
           }
         }
       }
     },
-    "Speichern": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Save"
+    "Später migrieren" : {
+
+    },
+    "Speichern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
           }
         }
       }
     },
-    "Stammdaten": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Master Data"
+    "Stammdaten" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Master Data"
           }
         }
       }
+    },
+    "Standardmäßig startet der Zeitraum am ersten Tag des vorvorherigen Monats und endet inklusive heute." : {
+
     },
-    "Standardmäßig startet der Zeitraum am ersten Tag des vorvorherigen Monats und endet inklusive heute.": {},
-    "Standort für Wetter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Location for Weather"
+    "Standort für Wetter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location for Weather"
           }
         }
       }
     },
-    "stark": {},
-    "Stärkste Episode: %@ · %lld/10": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Strongest episode: %1$@ · %2$lld/10"
+    "stark" : {
+
+    },
+    "Stärkste Episode: %@ · %lld/10" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Strongest episode: %1$@ · %2$lld/10"
           }
         }
       }
     },
-    "Status": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Status"
+    "Startdatum" : {
+
+    },
+    "Status" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
           }
         }
       }
+    },
+    "Store-Dateien löschen und leer starten" : {
+
     },
-    "Straße": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Street"
+    "Store-Dateien sichern" : {
+
+    },
+    "Straße" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Street"
           }
         }
       }
     },
-    "Suche starten": {},
-    "Support öffnen": {},
-    "Symi": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symi"
+    "Support öffnen" : {
+
+    },
+    "Symi" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symi"
           }
         }
       }
+    },
+    "Symi bleibt lokal nutzbar. Sync und Export passieren nur, wenn du sie aktiv nutzt." : {
+
     },
-    "Symi bleibt lokal nutzbar. Sync und Export passieren nur, wenn du sie aktiv nutzt.": {},
-    "Symi-Bericht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symi-Report"
+    "Symi-Bericht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symi-Report"
           }
         }
       }
     },
-    "symiapp.com": {},
-    "symiapp.com öffnen": {},
-    "Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome können an Apple Health übertragen werden. Notizen und Medikamente bleiben in der App.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symptom data such as headache and selected accompanying symptoms can be transferred to Apple Health. Notes and medication stay in the app."
+    "symiapp.com" : {
+
+    },
+    "symiapp.com öffnen" : {
+
+    },
+    "Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome können an Apple Health übertragen werden. Notizen und Medikamente bleiben in der App." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symptom data such as headache and selected accompanying symptoms can be transferred to Apple Health. Notes and medication stay in the app."
           }
         }
       }
     },
-    "Symptome": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symptoms"
+    "Symptome" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symptoms"
           }
         }
       }
     },
-    "Symptome %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symptoms %1$@"
+    "Symptome %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symptoms %1$@"
           }
         }
       }
     },
-    "Symptome: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Symptoms: %1$@"
+    "Symptome: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Symptoms: %1$@"
           }
         }
       }
     },
-    "Sync aktivieren": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Sync"
+    "Sync aktivieren" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Sync"
           }
         }
       }
     },
-    "Sync-Protokoll": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sync Log"
+    "Sync-Protokoll" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Log"
           }
         }
       }
     },
-    "Synchronisation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Synchronization"
+    "Synchronisation" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronization"
           }
         }
       }
     },
-    "Tagebuch": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diary"
+    "Tagebuch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diary"
           }
         }
       }
     },
-    "Tagebuch öffnen": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Diary"
+    "Tagebuch öffnen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Diary"
           }
         }
       }
     },
-    "Tagebuchübersicht": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Diary overview"
+    "Tagebuchübersicht" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diary overview"
           }
         }
       }
+    },
+    "Tagesbereich" : {
+
     },
-    "Teilweise": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Partial"
+    "Teilweise" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partial"
           }
         }
       }
     },
-    "Telefon": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phone"
+    "Telefon" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phone"
           }
         }
       }
     },
-    "Trigger": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Triggers"
+    "Tippe doppelt, um diesen Schritt zu bearbeiten." : {
+
+    },
+    "Trigger" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triggers"
           }
         }
       }
     },
-    "Trigger: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Triggers: %1$@"
+    "Trigger: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triggers: %1$@"
           }
         }
       }
     },
-    "Typ": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Type"
+    "Typ" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type"
           }
         }
       }
     },
-    "Übersicht": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Overview"
+    "Übersicht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overview"
           }
         }
       }
     },
-    "Unklar": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unclear"
+    "Unklar" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unclear"
           }
         }
       }
     },
-    "V1 schreibt nur Kopfschmerz und ausgewählte Begleitsymptome. Medikamente, Zyklusdaten und Konfliktlogik sind eigene Folge-Issues.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "V1 writes only headache and selected accompanying symptoms. Medication, cycle data and conflict logic are separate follow-up issues."
+    "V1 schreibt nur Kopfschmerz und ausgewählte Begleitsymptome. Medikamente, Zyklusdaten und Konfliktlogik sind eigene Folge-Issues." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "V1 writes only headache and selected accompanying symptoms. Medication, cycle data and conflict logic are separate follow-up issues."
           }
         }
       }
     },
-    "Verbindung": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connection"
+    "Verbindung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connection"
           }
         }
       }
     },
-    "Version 1": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version 1"
+    "Version 1" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version 1"
           }
         }
       }
     },
-    "Version 2 schreibt nur einfache Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome. Notizen und Medikamente bleiben in der App.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version 2 writes only simple symptom data such as headache and selected accompanying symptoms. Notes and medication stay in the app."
+    "Version 2 schreibt nur einfache Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome. Notizen und Medikamente bleiben in der App." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version 2 writes only simple symptom data such as headache and selected accompanying symptoms. Notes and medication stay in the app."
           }
         }
       }
     },
-    "Version und Plattform": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version and Platform"
+    "Version und Plattform" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version and Platform"
           }
         }
       }
     },
-    "Verstanden": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Understood"
+    "Verstanden" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Understood"
           }
         }
       }
     },
-    "Von": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "From"
+    "Von" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "From"
           }
         }
       }
     },
-    "Vorheriger Monat": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Previous Month"
+    "von %lld" : {
+
+    },
+    "Vorheriger Monat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous Month"
           }
         }
       }
     },
-    "Vorlauf": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lead Time"
+    "Vorlauf" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lead Time"
           }
         }
       }
     },
-    "Vorschau": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview"
+    "Vorschau" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preview"
           }
         }
       }
     },
-    "Wählt diese Option aus.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selects this option."
+    "Wählt diese Option aus." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selects this option."
           }
         }
       }
     },
-    "Wählt dieses Medikament aus.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Selects this medication."
+    "Wählt dieses Medikament aus." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selects this medication."
           }
         }
       }
     },
-    "Was die App macht": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "What the App Does"
+    "Was die App macht" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What the App Does"
           }
         }
       }
     },
-    "Was geschrieben wird": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "What Gets Written"
+    "Was geschrieben wird" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What Gets Written"
           }
         }
       }
+    },
+    "Was hat geholfen?" : {
+
     },
-    "Website und Support: symiapp.com": {},
-    "Weitere Angaben": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Additional Details"
+    "Was war heute anders?" : {
+
+    },
+    "Website und Support: symiapp.com" : {
+
+    },
+    "Weitere Angaben" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Additional Details"
           }
         }
       }
     },
-    "Weitere Funktionen können folgen. Medizinische Auswertungen, zusätzliche Plattformen und komplexere Health-Abgleiche werden separat konzipiert.": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More features may follow. Medical analysis, additional platforms and more complex Health syncing will be designed separately."
+    "Weitere Funktionen können folgen. Medizinische Auswertungen, zusätzliche Plattformen und komplexere Health-Abgleiche werden separat konzipiert." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More features may follow. Medical analysis, additional platforms and more complex Health syncing will be designed separately."
           }
         }
       }
+    },
+    "Wenige Angaben reichen. Alles Weitere bleibt optional." : {
+
     },
-    "Wenige Angaben reichen. Alles Weitere bleibt optional.": {},
-    "Wenn aktiviert, enthält das PDF zusätzlich die detaillierten Einträge mit Medikamenten, Triggern, Wetterdaten, Apple-Health-Kontext und Notizen.": {},
-    "Wetter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather"
+    "Wenn aktiviert, enthält das PDF zusätzlich die detaillierten Einträge mit Medikamenten, Triggern, Wetterdaten, Apple-Health-Kontext und Notizen." : {
+
+    },
+    "Wetter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather"
           }
         }
       }
     },
-    "Wetter wird ermittelt …": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading weather ..."
+    "Wetter wird ermittelt …" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading weather ..."
           }
         }
       }
     },
-    "Wetter wird vorbereitet": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preparing Weather"
+    "Wetter wird vorbereitet" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing Weather"
           }
         }
       }
     },
-    "Wetter: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather: %1$@"
+    "Wetter: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather: %1$@"
           }
         }
       }
     },
-    "Wetterdaten": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather Data"
+    "Wetterdaten" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather Data"
           }
         }
       }
     },
-    "Wetterdaten kommen von Apple Weather. Beim Speichern eines Eintrags merkt sich die App einen passenden Wetter-Snapshot.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather data comes from Apple Weather. When saving an entry, the app stores a matching weather snapshot."
+    "Wetterdaten kommen von Apple Weather. Beim Speichern eines Eintrags merkt sich die App einen passenden Wetter-Snapshot." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather data comes from Apple Weather. When saving an entry, the app stores a matching weather snapshot."
           }
         }
       }
     },
-    "Wetterdaten und freiwillig freigegebene Apple-Health-Daten ergänzen deine Einträge, damit du später mehr Kontext hast.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather data and voluntarily shared Apple Health data add context to your entries for later review."
+    "Wetterdaten und freiwillig freigegebene Apple-Health-Daten ergänzen deine Einträge, damit du später mehr Kontext hast." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather data and voluntarily shared Apple Health data add context to your entries for later review."
           }
         }
       }
     },
-    "Wetterquellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weather Sources"
+    "Wetterquellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather Sources"
           }
         }
       }
     },
-    "Wetterquellen anzeigen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Weather Sources"
+    "Wetterquellen anzeigen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Weather Sources"
           }
         }
       }
     },
-    "Wiederherstellen": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore"
+    "Wiederherstellen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore"
           }
         }
       }
     },
-    "Wirkung: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Effect: %1$@"
+    "Wirkung: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effect: %1$@"
           }
         }
       }
     },
-    "Wirkungseintritt: %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Onset of relief: %1$@"
+    "Wirkungseintritt: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onset of relief: %1$@"
           }
         }
       }
+    },
+    "Woche" : {
+
     },
-    "Woche": {},
-    "Zeigt die Episoden dieses Tages darunter an.": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shows this day's episodes below."
+    "Zeigt die Episoden dieses Tages darunter an." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shows this day's episodes below."
           }
         }
       }
     },
-    "Zeitraum": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Period"
+    "Zeitraum" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Period"
           }
         }
       }
     },
-    "Zeitraum: %@ bis %@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Period: %1$@ to %2$@"
+    "Zeitraum: %@ bis %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Period: %1$@ to %2$@"
           }
         }
       }
+    },
+    "Zu heutigem Eintrag hinzufügen" : {
+
+    },
+    "Zurück" : {
+
     },
-    "Zusammenhänge besser erkennen": {
-      "extractionState": "stale",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "See Patterns More Clearly"
+    "Zusammenhänge besser erkennen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "See Patterns More Clearly"
           }
         }
       }
     }
   },
-  "version": "1.2"
+  "version" : "1.2"
 }

--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -1,3485 +1,3209 @@
 {
-  "sourceLanguage" : "de",
-  "strings" : {
-    "" : {
-
-    },
-    ", Anzahl: %lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", quantity: %1$lld"
+  "sourceLanguage": "de",
+  "strings": {
+    "": {},
+    ", Anzahl: %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", quantity: %1$lld"
           }
         }
       }
     },
-    ", Wirkung: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ", effect: %1$@"
+    ", Wirkung: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", effect: %1$@"
           }
         }
       }
     },
-    "/10" : {
-
-    },
-    "%@ · %@ · Intensität %lld/10" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ · %2$@ · Intensity %3$lld/10"
+    "%@ · %@ · Intensität %lld/10": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ · %2$@ · Intensity %3$lld/10"
           }
         }
       }
     },
-    "%@ · Intensität %lld/10" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ · Intensität %2$lld/10"
+    "%@ · Intensität %lld/10": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@ · Intensität %2$lld/10"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ · Intensity %2$lld/10"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ · Intensity %2$lld/10"
           }
         }
       }
     },
-    "%@ %% Luftfeuchte" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %% humidity"
+    "%@ %% Luftfeuchte": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ %% humidity"
           }
         }
       }
     },
-    "%@ abwählen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deselect %1$@"
+    "%@ abwählen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deselect %1$@"
           }
         }
       }
     },
-    "%@ Bericht" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ report"
+    "%@ Bericht": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ report"
           }
         }
       }
     },
-    "%@ heute genommen" : {
-
-    },
-    "%@ ist dein ruhiges Migräne Tagebuch. Du hältst fest, was passiert ist, und entscheidest selbst, welche zusätzlichen Daten du einbeziehst." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ is your calm migraine diary. You record what happened and decide which additional data you want to include."
+    "%@ ist dein ruhiges Migräne Tagebuch. Du hältst fest, was passiert ist, und entscheidest selbst, welche zusätzlichen Daten du einbeziehst.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ is your calm migraine diary. You record what happened and decide which additional data you want to include."
           }
         }
       }
     },
-    "%@ mm Niederschlag" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ mm precipitation"
+    "%@ mm Niederschlag": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ mm precipitation"
           }
         }
       }
     },
-    "%@ wird aus SwiftData entfernt." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ will be removed from SwiftData."
+    "%@ wird aus SwiftData entfernt.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ will be removed from SwiftData."
           }
         }
       }
     },
-    "%@ wird in den Papierkorb verschoben." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ will be moved to the trash."
+    "%@ wird in den Papierkorb verschoben.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ will be moved to the trash."
           }
         }
       }
     },
-    "%@: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@: %2$@"
+    "%@: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$@: %2$@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@: %2$@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
           }
         }
       }
     },
-    "%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld"
+    "%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
           }
         }
       }
     },
-    "%lld Eintrag%@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld Eintrag%2$@"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld entr%2$@"
-          }
-        }
-      }
-    },
-    "%lld Eintrag%@ · Höchste Intensität %lld/10" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld Eintrag%2$@ · Höchste Intensität %3$lld/10"
+    "%lld Eintrag%@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$lld Eintrag%2$@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld entr%2$@ · Highest intensity %3$lld/10"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld entr%2$@"
           }
         }
       }
     },
-    "%lld von 10" : {
-
-    },
-    "%lld von 10, %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld von 10, %2$@"
-          }
-        }
-      }
-    },
-    "%lld/%lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld/%2$lld"
+    "%lld Eintrag%@ · Höchste Intensität %lld/10": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "%1$lld Eintrag%2$@ · Höchste Intensität %3$lld/10"
           }
-        }
-      }
-    },
-    "%lld/10" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld/10"
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld entr%2$@ · Highest intensity %3$lld/10"
           }
         }
       }
     },
-    "%lldx" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lldx"
+    "%lld von 10": {},
+    "%lld/10": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/10"
           }
         }
       }
     },
-    "2 Stunden" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2 hours"
+    "%lldx": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldx"
           }
         }
       }
     },
-    "24 Stunden" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "24 hours"
+    "2 Stunden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 hours"
           }
         }
       }
     },
-    "30 Minuten" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 minutes"
+    "24 Stunden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 hours"
           }
         }
       }
     },
-    "Abbrechen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "30 Minuten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 minutes"
           }
         }
       }
     },
-    "Abweichende Felder: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conflicting fields: %1$@"
+    "Abbrechen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         }
       }
     },
-    "Adresse" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Address"
+    "Abweichende Felder: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conflicting fields: %1$@"
           }
         }
       }
     },
-    "Aktionen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actions"
+    "Adresse": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Address"
           }
         }
       }
     },
-    "Aktiv" : {
-
-    },
-    "Aktive Episoden" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Active Episodes"
+    "Aktionen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actions"
           }
         }
       }
     },
-    "Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable sync to use iCloud synchronization and conflict handling."
+    "Aktive Episoden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active Episodes"
           }
         }
       }
     },
-    "Aktualisieren" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Refresh"
+    "Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable sync to use iCloud synchronization and conflict handling."
           }
         }
       }
     },
-    "Aktuell" : {
-
-    },
-    "Aktuell ausgewählt." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currently selected."
+    "Aktualisieren": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
           }
         }
       }
-    },
-    "Aktueller Zustand" : {
-
     },
-    "Alle" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All"
+    "Aktuell ausgewählt.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currently selected."
           }
         }
       }
     },
-    "Alle Details" : {
-
-    },
-    "Alles im Blick" : {
-
-    },
-    "Allgemein" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "General"
+    "Aktueller Zustand": {},
+    "Alle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All"
           }
         }
       }
     },
-    "Als Wiederholungseinnahme dokumentiert" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Documented as a repeat dose"
+    "Alle Details": {},
+    "Alles im Blick": {},
+    "Allgemein": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
           }
         }
       }
     },
-    "Änderungen speichern" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save Changes"
+    "Als Wiederholungseinnahme dokumentiert": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documented as a repeat dose"
           }
         }
       }
     },
-    "Ansicht" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "View"
+    "Änderungen speichern": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Changes"
           }
         }
       }
     },
-    "Antiemetikum" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Antiemetic"
+    "Ansicht": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View"
           }
         }
       }
     },
-    "Anzahl" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quantity"
+    "Antiemetikum": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Antiemetic"
           }
         }
       }
     },
-    "Anzahl: %lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quantity: %lld"
+    "Anzahl": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quantity"
           }
         }
       }
     },
-    "App herunterladen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download the app"
+    "Anzahl: %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quantity: %lld"
           }
         }
       }
     },
-    "Apple Health" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Health"
+    "App herunterladen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download the app"
           }
         }
       }
     },
-    "Apple Health optional" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Health Optional"
+    "Apple Health": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Health"
           }
         }
       }
     },
-    "Apple Health wird nur genutzt, wenn du einzelne Datentypen freigibst. Wenn ein Health-Datentyp auf deinem Gerät nicht verfügbar ist, wird er ausgelassen." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Health is used only if you allow individual data types. If a Health data type is not available on your device, it is skipped."
+    "Apple Health optional": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Health Optional"
           }
         }
       }
     },
-    "Apple Health wird nur genutzt, wenn du einzelne Informationen freigibst." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Health is used only if you share individual information."
+    "Apple Health wird nur genutzt, wenn du einzelne Datentypen freigibst. Wenn ein Health-Datentyp auf deinem Gerät nicht verfügbar ist, wird er ausgelassen.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Health is used only if you allow individual data types. If a Health data type is not available on your device, it is skipped."
           }
         }
       }
     },
-    "Apple Health wird nur nach deiner Freigabe pro Datentyp genutzt. Nicht auf deiner iOS-Version verfügbare HealthKit-Daten werden nicht erzwungen." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Health is used only after you grant access per data type. HealthKit data that is not available on your iOS version is not forced."
+    "Apple Health wird nur genutzt, wenn du einzelne Informationen freigibst.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Health is used only if you share individual information."
           }
         }
       }
     },
-    "Apple-Health-Daten bleiben optional. Gelesene Werte werden als Apple-Health-Kontext gekennzeichnet; geschriebene Symptome enthalten keine Notizen." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apple Health data remains optional. Read values are labeled as Apple Health context; written symptoms do not include notes."
+    "Apple Health wird nur nach deiner Freigabe pro Datentyp genutzt. Nicht auf deiner iOS-Version verfügbare HealthKit-Daten werden nicht erzwungen.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Health is used only after you grant access per data type. HealthKit data that is not available on your iOS version is not forced."
           }
         }
       }
     },
-    "Attribution" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attribution"
+    "Apple-Health-Daten bleiben optional. Gelesene Werte werden als Apple-Health-Kontext gekennzeichnet; geschriebene Symptome enthalten keine Notizen.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apple Health data remains optional. Read values are labeled as Apple Health context; written symptoms do not include notes."
           }
         }
       }
     },
-    "Ausgewählt" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selected"
+    "Attribution": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attribution"
           }
         }
       }
     },
-    "Auswertung" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysis"
+    "Ausgewählt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected"
           }
         }
       }
-    },
-    "Backup" : {
-
-    },
-    "Backup einlesen" : {
-
-    },
-    "Backup erstellen" : {
-
     },
-    "Backup teilen" : {
-
-    },
-    "Bearbeiten" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit"
+    "Auswertung": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysis"
           }
         }
       }
-    },
-    "Beenden" : {
-
-    },
-    "Beendet" : {
-
     },
-    "Beginn" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+    "Backup": {},
+    "Backup einlesen": {},
+    "Backup erstellen": {},
+    "Backup teilen": {},
+    "Bearbeiten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit"
           }
         }
       }
     },
-    "Bei neuen, starken oder ungewohnten Symptomen, bei Unsicherheit oder im Notfall solltest du medizinische Hilfe holen." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For new, severe or unusual symptoms, uncertainty or emergencies, you should seek medical help."
+    "Beginn": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
           }
         }
       }
     },
-    "Bei Warnzeichen Hilfe holen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Get Help for Warning Signs"
+    "Bei neuen, starken oder ungewohnten Symptomen, bei Unsicherheit oder im Notfall solltest du medizinische Hilfe holen.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For new, severe or unusual symptoms, uncertainty or emergencies, you should seek medical help."
           }
         }
       }
     },
-    "Beim Laden wird dein ungefährer Standort verwendet, um Wetterdaten für den Episodenzeitpunkt abzurufen." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "When loading, your approximate location is used to retrieve weather data for the episode time."
+    "Bei Warnzeichen Hilfe holen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get Help for Warning Signs"
           }
         }
       }
     },
-    "Beiträge" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contributions"
+    "Beim Laden wird dein ungefährer Standort verwendet, um Wetterdaten für den Episodenzeitpunkt abzurufen.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When loading, your approximate location is used to retrieve weather data for the episode time."
           }
         }
       }
     },
-    "Berechtigungen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permissions"
+    "Beiträge": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contributions"
           }
         }
       }
     },
-    "Bericht" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report"
+    "Berechtigungen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
           }
         }
       }
     },
-    "Berichte erstellen" : {
-
-    },
-    "Berichtsdaten werden vorbereitet." : {
-
-    },
-    "Bevor du startest" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Before You Start"
+    "Bericht": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report"
           }
         }
       }
     },
-    "Bis" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To"
+    "Berichtsdaten werden vorbereitet.": {},
+    "Bevor du startest": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Before You Start"
           }
         }
       }
     },
-    "Bisher dokumentiert" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logged So Far"
+    "Bis": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To"
           }
         }
       }
     },
-    "Bundesland" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "State"
+    "Bisher dokumentiert": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logged So Far"
           }
         }
       }
     },
-    "Cloud hat recht" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Cloud Version"
+    "Bundesland": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "State"
           }
         }
       }
     },
-    "Cloud-Daten" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cloud Data"
+    "Cloud hat recht": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Cloud Version"
           }
         }
       }
     },
-    "Cloud-Daten verwalten" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Manage Cloud Data"
+    "Cloud-Daten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud Data"
           }
         }
       }
-    },
-    "Das Backup enthält alle Einträge, eigene Medikamentenvorlagen, Wetter-Snapshots und gespeicherten Apple-Health-Kontext, inklusive Papierkorb-Einträgen." : {
-
     },
-    "Das Projekt steht unter der GNU GPL v3." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The project is licensed under the GNU GPL v3."
+    "Cloud-Daten verwalten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manage Cloud Data"
           }
         }
       }
     },
-    "Das Protokoll bleibt lokal auf diesem Gerät. Es enthält technische Metadaten zu Synchronisation, Konflikten und Fehlern, aber keine sensiblen Freitextinhalte im Klartext." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The log stays local on this device. It contains technical metadata about synchronization, conflicts and errors, but no sensitive free-text content in plain text."
+    "Das Backup enthält alle Einträge, eigene Medikamentenvorlagen, Wetter-Snapshots und gespeicherten Apple-Health-Kontext, inklusive Papierkorb-Einträgen.": {},
+    "Das Projekt steht unter der GNU GPL v3.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The project is licensed under the GNU GPL v3."
           }
         }
       }
     },
-    "Das Wetter wird als Kontext mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt." : {
-
-    },
-    "Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weather is loaded with your approximate location via Apple Weather. The entry is still saved without weather if permission is not granted."
+    "Das Protokoll bleibt lokal auf diesem Gerät. Es enthält technische Metadaten zu Synchronisation, Konflikten und Fehlern, aber keine sensiblen Freitextinhalte im Klartext.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The log stays local on this device. It contains technical metadata about synchronization, conflicts and errors, but no sensitive free-text content in plain text."
           }
         }
       }
     },
-    "Daten exportieren" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export Data"
+    "Das Wetter wird mit deinem ungefähren Standort über Apple Weather geladen. Der Eintrag wird auch ohne Wetter gespeichert, wenn keine Freigabe vorliegt.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather is loaded with your approximate location via Apple Weather. The entry is still saved without weather if permission is not granted."
           }
         }
       }
     },
-    "Daten sichern" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back Up Data"
+    "Daten exportieren": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Data"
           }
         }
       }
-    },
-    "Daten und Backup" : {
-
     },
-    "Daten wiederherstellen" : {
-
-    },
-    "Datenexport" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data Export"
+    "Daten sichern": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back Up Data"
           }
         }
       }
     },
-    "Datenschutz" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy"
+    "Daten und Backup": {},
+    "Datenexport": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data Export"
           }
         }
       }
     },
-    "Datenschutz und Hinweise" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Privacy and Notes"
+    "Datenschutz": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy"
           }
         }
       }
     },
-    "Datenschutzerklärung öffnen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Privacy Policy"
+    "Datenschutz und Hinweise": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy and Notes"
           }
         }
       }
-    },
-    "Dauermedikation" : {
-
-    },
-    "Dauermedikation hinzufügen" : {
-
     },
-    "Dauermedikationen sind ein eigener Verlaufskontext und bleiben von Akutmedikation in Einträgen getrennt." : {
-
-    },
-    "Dein Eintrag hilft dir, Muster besser zu erkennen." : {
-
-    },
-    "Dein Eintrag wurde lokal gespeichert." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your entry was saved locally."
+    "Datenschutzerklärung öffnen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Privacy Policy"
           }
         }
       }
     },
-    "Deine Daten" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Data"
+    "Dein Eintrag wurde lokal gespeichert.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your entry was saved locally."
           }
         }
       }
     },
-    "Deine Daten gehören dir" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your Data Belongs to You"
+    "Deine Daten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Data"
           }
         }
       }
-    },
-    "Deine Daten gehören dir." : {
-
     },
-    "Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your entries stay local on this device and help you keep track of patterns, triggers and routines that work."
+    "Deine Daten gehören dir": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Data Belongs to You"
           }
         }
       }
     },
-    "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync works defensively: conflicts are not overwritten silently, but made visible here."
+    "Deine Daten gehören dir.": {},
+    "Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your entries stay local on this device and help you keep track of patterns, triggers and routines that work."
           }
         }
       }
     },
-    "Der PDF-Bericht von %@ wird lokal erzeugt und kann systemweit geteilt werden." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The PDF report from %1$@ is created locally and can be shared system-wide."
+    "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync works defensively: conflicts are not overwritten silently, but made visible here."
           }
         }
       }
     },
-    "Detaillierte Einträge" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detailed entries"
+    "Der PDF-Bericht von %@ wird lokal erzeugt und kann systemweit geteilt werden.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The PDF report from %1$@ is created locally and can be shared system-wide."
           }
         }
       }
     },
-    "Detaillierter Bericht" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detailed report"
+    "Detaillierte Einträge": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detailed entries"
           }
         }
       }
     },
-    "Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The app remains fully usable locally. iCloud sync is optional, works separately from SwiftData and can be disabled again at any time."
+    "Detaillierter Bericht": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detailed report"
           }
         }
       }
     },
-    "Die App funktioniert auch ohne iCloud. Wenn du Sync aktivierst, werden deine App-Daten über deinen eigenen iCloud-Account abgeglichen." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The app also works without iCloud. If you enable sync, your app data is synced through your own iCloud account."
+    "Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app remains fully usable locally. iCloud sync is optional, works separately from SwiftData and can be disabled again at any time."
           }
         }
       }
     },
-    "Die App hilft dir, eigene Beobachtungen festzuhalten und später wiederzufinden." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The app helps you record your own observations and find them again later."
+    "Die App funktioniert auch ohne iCloud. Wenn du Sync aktivierst, werden deine App-Daten über deinen eigenen iCloud-Account abgeglichen.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app also works without iCloud. If you enable sync, your app data is synced through your own iCloud account."
           }
         }
       }
     },
-    "Die App ist aktuell für iPhone, deutsche Sprache und iOS 17.6 oder neuer ausgelegt." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The app is currently designed for iPhone, German language and iOS 17.6 or later."
+    "Die App hilft dir, eigene Beobachtungen festzuhalten und später wiederzufinden.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app helps you record your own observations and find them again later."
           }
         }
       }
     },
-    "Die App stellt keine Diagnose, bewertet deine Beschwerden nicht medizinisch und empfiehlt keine Behandlung." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The app does not provide a diagnosis, does not medically assess your symptoms and does not recommend treatment."
+    "Die App ist aktuell für iPhone, deutsche Sprache und iOS 17.6 oder neuer ausgelegt.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app is currently designed for iPhone, German language and iOS 17.6 or later."
           }
         }
       }
     },
-    "Die App unterstützt deine Dokumentation. Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The app supports your documentation. It does not replace a medical diagnosis, treatment decisions or emergency contacts."
+    "Die App stellt keine Diagnose, bewertet deine Beschwerden nicht medizinisch und empfiehlt keine Behandlung.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app does not provide a diagnosis, does not medically assess your symptoms and does not recommend treatment."
           }
         }
       }
     },
-    "Die Liste zeigt Beispieldaten für den Screenshot-Modus." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The list shows sample data for screenshot mode."
+    "Die App unterstützt deine Dokumentation. Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The app supports your documentation. It does not replace a medical diagnosis, treatment decisions or emergency contacts."
           }
         }
       }
     },
-    "Die Treffer sind nach relevanten Fachgebieten gruppiert und innerhalb der Gruppen nach PLZ und Name sortiert." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Results are grouped by relevant specialties and sorted within groups by postal code and name."
+    "Die Liste zeigt Beispieldaten für den Screenshot-Modus.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The list shows sample data for screenshot mode."
           }
         }
       }
     },
-    "Diese Aktion löscht den lokalen SwiftData-Store auf diesem Gerät. Eine spätere Migration ist nur möglich, wenn du die Store-Dateien vorher gesichert hast." : {
-
-    },
-    "Diese Episode wird in den Papierkorb verschoben." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This episode will be moved to the trash."
+    "Die Treffer sind nach relevanten Fachgebieten gruppiert und innerhalb der Gruppen nach PLZ und Name sortiert.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Results are grouped by relevant specialties and sorted within groups by postal code and name."
           }
         }
       }
-    },
-    "Diese Notiz wird mit deinem Eintrag von heute verknüpft." : {
-
-    },
-    "Diese Option entfernt die lokalen Store-Dateien erst nach deiner Bestätigung und erstellt danach einen neuen leeren Store." : {
-
     },
-    "Dokumentationshilfe" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Documentation Aid"
+    "Diese Episode wird in den Papierkorb verschoben.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This episode will be moved to the trash."
           }
         }
       }
     },
-    "Dokumentierte Medikamente: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Documented medications: %1$@"
+    "Dokumentationshilfe": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documentation Aid"
           }
         }
       }
     },
-    "Dosierung" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dosage"
+    "Dokumentierte Medikamente: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Documented medications: %1$@"
           }
         }
       }
     },
-    "Dosierung, optional" : {
-
-    },
-    "Du behältst die Kontrolle" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You Stay in Control"
+    "Dosierung": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosage"
           }
         }
       }
     },
-    "Du dokumentierst Zeitpunkt, Dauer, Intensität, Symptome, mögliche Auslöser, Medikamente und persönliche Notizen." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You document timing, duration, intensity, symptoms, possible triggers, medication and personal notes."
+    "Du behältst die Kontrolle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You Stay in Control"
           }
         }
       }
     },
-    "Du dokumentierst Zeitpunkt, Intensität, hilfreiche Hinweise und persönliche Notizen ohne Formulargefühl." : {
-
-    },
-    "Du kannst die Standortfreigabe in den Einstellungen dieser App unter \"Standort\" auf \"Beim Verwenden der App\" ändern." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can change location permission in this app's settings under \"Location\" to \"While Using the App\"."
+    "Du dokumentierst Zeitpunkt, Dauer, Intensität, Symptome, mögliche Auslöser, Medikamente und persönliche Notizen.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You document timing, duration, intensity, symptoms, possible triggers, medication and personal notes."
           }
         }
       }
     },
-    "Du kannst entscheiden ob und in welchem Ausmaß du deine Gesundheitsdaten an diese App freigibst. Sie werden niemals an Dritte weitergegeben." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can decide whether and to what extent you share your health data with this app. It is never shared with third parties."
+    "Du dokumentierst Zeitpunkt, Intensität, hilfreiche Hinweise und persönliche Notizen ohne Formulargefühl.": {},
+    "Du kannst die Standortfreigabe in den Einstellungen dieser App unter \"Standort\" auf \"Beim Verwenden der App\" ändern.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can change location permission in this app's settings under \"Location\" to \"While Using the App\"."
           }
         }
       }
     },
-    "Durchschnittliche Intensität: %@/10" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Average intensity: %1$@/10"
+    "Du kannst entscheiden ob und in welchem Ausmaß du deine Gesundheitsdaten an diese App freigibst. Sie werden niemals an Dritte weitergegeben.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can decide whether and to what extent you share your health data with this app. It is never shared with third parties."
           }
         }
       }
     },
-    "E-Mail" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Email"
+    "Durchschnittliche Intensität: %@/10": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Average intensity: %1$@/10"
           }
         }
       }
     },
-    "Eigenes Medikament" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Custom Medication"
+    "E-Mail": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Email"
           }
         }
       }
     },
-    "Eigenes Medikament hinzufügen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add Custom Medication"
+    "Eigenes Medikament": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom Medication"
           }
         }
       }
     },
-    "Eigenes Medikament löschen?" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Custom Medication?"
+    "Eigenes Medikament hinzufügen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Custom Medication"
           }
         }
       }
-    },
-    "Eine schnelle Einschätzung reicht. Details kannst du im Eintrag ergänzen." : {
-
     },
-    "Einschränkung: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Functional impact: %1$@"
+    "Eigenes Medikament löschen?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Custom Medication?"
           }
         }
       }
     },
-    "Einstellungen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings"
+    "Eine schnelle Einschätzung reicht. Details kannst du im Eintrag ergänzen.": {},
+    "Einschränkung: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Functional impact: %1$@"
           }
         }
       }
     },
-    "Einstellungen öffnen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Settings"
+    "Einstellungen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
           }
         }
       }
     },
-    "Eintrag bearbeiten" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Entry"
+    "Einstellungen öffnen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
           }
         }
       }
     },
-    "Eintrag erstellen" : {
-
-    },
-    "Eintrag gespeichert" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entry Saved"
+    "Eintrag bearbeiten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Entry"
           }
         }
       }
     },
-    "Eintrag konnte nicht gespeichert werden" : {
-
-    },
-    "Eintrag löschen?" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Entry?"
+    "Eintrag erstellen": {},
+    "Eintrag gespeichert": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entry Saved"
           }
         }
       }
     },
-    "Eintrag speichern" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save Entry"
+    "Eintrag löschen?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Entry?"
           }
         }
       }
     },
-    "Einträge" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entries"
+    "Eintrag speichern": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Entry"
           }
         }
       }
     },
-    "Einträge im Zeitraum: %lld" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entries in period: %lld"
+    "Einträge": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entries"
           }
         }
       }
     },
-    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden auf diesem Gerät gespeichert." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device."
+    "Einträge im Zeitraum: %lld": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entries in period: %lld"
           }
         }
       }
     },
-    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden zuerst auf diesem Gerät gespeichert." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device first."
+    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden auf diesem Gerät gespeichert.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device."
           }
         }
       }
     },
-    "Einträge: %lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entries: %1$lld"
+    "Einträge, Medikamente, Notizen, Trigger, Symptome, Wetter-Snapshots und gelesener Apple-Health-Kontext werden zuerst auf diesem Gerät gespeichert.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entries, medication, notes, triggers, symptoms, weather snapshots and read Apple Health context are stored on this device first."
           }
         }
       }
-    },
-    "Eintragen" : {
-
     },
-    "Enddatum" : {
-
-    },
-    "Enddatum setzen" : {
-
-    },
-    "Ende" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "End"
+    "Einträge: %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entries: %1$lld"
           }
         }
       }
     },
-    "Ende angeben" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Specify End"
+    "Eintragen": {},
+    "Ende": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End"
           }
         }
       }
     },
-    "Ende: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "End: %1$@"
+    "Ende angeben": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Specify End"
           }
         }
       }
     },
-    "Endzeit angeben" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Specify End Time"
+    "Ende: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End: %1$@"
           }
         }
       }
     },
-    "Entfernen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remove"
+    "Endzeit angeben": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Specify End Time"
           }
         }
       }
     },
-    "Entfernt die Auswahl." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Removes the selection."
+    "Entfernen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
           }
         }
       }
     },
-    "Episode" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Episode"
+    "Entfernt die Auswahl.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removes the selection."
           }
         }
       }
     },
-    "Episode löschen?" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Episode?"
+    "Episode": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episode"
           }
         }
       }
     },
-    "Episode nicht gefunden" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Episode Not Found"
+    "Episode löschen?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Episode?"
           }
         }
       }
     },
-    "Episodendetail" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Episode Details"
+    "Episode nicht gefunden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episode Not Found"
           }
         }
       }
     },
-    "Episodentypen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Episode types"
+    "Episodendetail": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episode Details"
           }
         }
       }
     },
-    "Erinnerung" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reminder"
+    "Episodentypen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episode types"
           }
         }
       }
     },
-    "Erinnerung aktivieren" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Reminder"
+    "Erinnerung": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reminder"
           }
         }
       }
     },
-    "Erinnerung: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reminder: %1$@"
+    "Erinnerung aktivieren": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Reminder"
           }
         }
       }
     },
-    "Erinnerungen bleiben lokal" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reminders Stay Local"
+    "Erinnerung: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reminder: %1$@"
           }
         }
       }
     },
-    "Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create a PDF report or JSON5 backup for a freely selectable period."
+    "Erinnerungen bleiben lokal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reminders Stay Local"
           }
         }
       }
     },
-    "Erstellt mit %@." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Created with %1$@."
+    "Erstelle einen PDF-Bericht oder ein JSON5-Backup für einen frei wählbaren Zeitraum.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a PDF report or JSON5 backup for a freely selectable period."
           }
         }
       }
     },
-    "Export" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export"
+    "Erstellt mit %@.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Created with %1$@."
           }
         }
       }
     },
-    "Export nur mit deiner Aktion" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export Only When You Choose"
+    "Export": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export"
           }
         }
       }
     },
-    "Fachgebiet" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Specialty"
+    "Export nur mit deiner Aktion": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Only When You Choose"
           }
         }
       }
-    },
-    "Feedback und Hilfe findest du über symiapp.com." : {
-
     },
-    "Feedback und Ideen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feedback and Ideas"
+    "Fachgebiet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Specialty"
           }
         }
       }
     },
-    "Fehler erneut versuchen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retry Error"
+    "Feedback und Hilfe findest du über symiapp.com.": {},
+    "Feedback und Ideen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback and Ideas"
           }
         }
       }
     },
-    "Fehler, Ideen und Verbesserungsvorschläge kannst du als GitHub-Issue einreichen." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can submit bugs, ideas and suggestions as GitHub issues."
+    "Fehler erneut versuchen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry Error"
           }
         }
       }
     },
-    "Fehler: %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: %1$@"
+    "Fehler, Ideen und Verbesserungsvorschläge kannst du als GitHub-Issue einreichen.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can submit bugs, ideas and suggestions as GitHub issues."
           }
         }
       }
     },
-    "Filter" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filter"
+    "Fehler: %@": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: %1$@"
           }
         }
       }
     },
-    "Flow-Schritt %@" : {
-
-    },
-    "Frequenz, optional" : {
-
-    },
-    "Funktionelle Einschränkung" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Functional Limitation"
+    "Filter": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter"
           }
         }
       }
     },
-    "Für %@ ist noch nichts dokumentiert." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nothing has been documented for %1$@ yet."
+    "Funktionelle Einschränkung": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Functional Limitation"
           }
         }
       }
     },
-    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nicht als eigener Tagebucheintrag gespeichert." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For weather data, the app asks for your approximate location. Coordinates are not stored as their own diary entry."
+    "Für %@ ist noch nichts dokumentiert.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing has been documented for %1$@ yet."
           }
         }
       }
     },
-    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nur für den Wetteraufruf benötigt und nie gespeichert." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For weather data, the app asks for your approximate location. Coordinates are only needed for the weather request and are never stored."
+    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nicht als eigener Tagebucheintrag gespeichert.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For weather data, the app asks for your approximate location. Coordinates are not stored as their own diary entry."
           }
         }
       }
     },
-    "Gesundheit" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Health"
+    "Für Wetterdaten fragt die App nach deinem ungefähren Standort. Die Koordinaten werden nur für den Wetteraufruf benötigt und nie gespeichert.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For weather data, the app asks for your approximate location. Coordinates are only needed for the weather request and are never stored."
           }
         }
       }
     },
-    "GitHub-Issues öffnen" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open GitHub Issues"
+    "Gesundheit": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Health"
           }
         }
       }
     },
-    "Gut" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Good"
+    "GitHub-Issues öffnen": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open GitHub Issues"
           }
         }
       }
     },
-    "Häufige Symptome: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Common symptoms: %1$@"
+    "Gut": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Good"
           }
         }
       }
     },
-    "Häufige Trigger: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Common triggers: %1$@"
+    "Häufige Symptome: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common symptoms: %1$@"
           }
         }
       }
     },
-    "Herzfrequenz %@ bpm" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heart rate %1$@ bpm"
+    "Häufige Trigger: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Common triggers: %1$@"
           }
         }
       }
     },
-    "Heute" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Today"
+    "Herzfrequenz %@ bpm": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heart rate %1$@ bpm"
           }
         }
       }
-    },
-    "Hinweis: %@" : {
-
     },
-    "Hinzufügen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add"
+    "Heute": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Today"
           }
         }
       }
     },
-    "iCloud ist freiwillig" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "iCloud Is Optional"
+    "Hinweis: %@": {},
+    "Hinzufügen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add"
           }
         }
       }
     },
-    "In Sekunden eintragen" : {
-
-    },
-    "Intensität" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intensity"
+    "iCloud ist freiwillig": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iCloud Is Optional"
           }
         }
       }
     },
-    "Intensität %lld" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intensity %lld"
+    "In Sekunden eintragen": {},
+    "Intensität": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intensity"
           }
         }
       }
     },
-    "Intensität im Verlauf" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Intensity over time"
+    "Intensität %lld": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intensity %lld"
           }
         }
       }
     },
-    "iOS verwaltet Health-Berechtigungen pro Datentyp. Verweigerte Leserechte erscheinen in der App wie fehlende Daten." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "iOS manages Health permissions per data type. Denied read permissions appear in the app as missing data."
+    "Intensität im Verlauf": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intensity over time"
           }
         }
       }
     },
-    "iPhone und Deutsch" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "iPhone and German"
+    "iOS verwaltet Health-Berechtigungen pro Datentyp. Verweigerte Leserechte erscheinen in der App wie fehlende Daten.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iOS manages Health permissions per data type. Denied read permissions appear in the app as missing data."
           }
         }
       }
     },
-    "Jetzt synchronisieren" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Now"
+    "iPhone und Deutsch": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone and German"
           }
         }
       }
     },
-    "JSON5 erstellen" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create JSON5"
+    "Jetzt synchronisieren": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Now"
           }
         }
       }
     },
-    "JSON5 importieren" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Import JSON5"
+    "JSON5 erstellen": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create JSON5"
           }
         }
       }
     },
-    "JSON5 teilen" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share JSON5"
+    "JSON5 importieren": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import JSON5"
           }
         }
       }
     },
-    "JSON5-Export enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "JSON5 export contains all entries and custom medication templates, including trashed entries."
+    "JSON5 teilen": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share JSON5"
           }
         }
       }
     },
-    "Kategorie" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Category"
+    "JSON5-Export enthält alle Einträge sowie eigene Medikamentenvorlagen, inklusive Papierkorb-Einträgen.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON5 export contains all entries and custom medication templates, including trashed entries."
           }
         }
       }
     },
-    "Kein Medikament gefunden" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Medication Found"
+    "Kategorie": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Category"
           }
         }
       }
     },
-    "Kein Protokoll vorhanden" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Log Available"
+    "Kein Medikament gefunden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Medication Found"
           }
         }
       }
     },
-    "Keine" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "None"
+    "Kein Protokoll vorhanden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Log Available"
           }
         }
       }
-    },
-    "Keine aktive Dauermedikation." : {
-
     },
-    "Keine beendete Dauermedikation." : {
-
-    },
-    "Keine Diagnose, keine Therapieempfehlung" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Diagnosis, No Treatment Recommendation"
+    "Keine": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
           }
         }
       }
     },
-    "Keine Einträge im Zeitraum" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Entries in Period"
+    "Keine Diagnose, keine Therapieempfehlung": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Diagnosis, No Treatment Recommendation"
           }
         }
       }
     },
-    "Keine gelöschten Einträge." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No deleted entries."
+    "Keine Einträge im Zeitraum": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Entries in Period"
           }
         }
       }
     },
-    "Keine offenen Konflikte." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No open conflicts."
+    "Keine gelöschten Einträge.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No deleted entries."
           }
         }
       }
     },
-    "Konflikt lösen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resolve Conflict"
+    "Keine offenen Konflikte.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No open conflicts."
           }
         }
       }
     },
-    "Konflikt wird verarbeitet …" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processing conflict ..."
+    "Konflikt lösen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolve Conflict"
           }
         }
       }
     },
-    "Konflikte" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conflicts"
+    "Konflikt wird verarbeitet …": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processing conflict ..."
           }
         }
       }
     },
-    "Kontakt" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact"
+    "Konflikte": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conflicts"
           }
         }
       }
     },
-    "Kopfschmerz" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Headache"
+    "Kontakt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact"
           }
         }
       }
     },
-    "Kopfschmerzstärke" : {
-
-    },
-    "Kurz notieren, was auffällt" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Briefly note what stands out"
+    "Kopfschmerz": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Headache"
           }
         }
       }
     },
-    "Kurzüberblick" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Executive summary"
+    "Kurz notieren, was auffällt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Briefly note what stands out"
           }
         }
       }
-    },
-    "Leerer Neustart" : {
-
     },
-    "Leerer Store wird erstellt" : {
-
-    },
-    "Lesen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Read"
+    "Kurzüberblick": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executive summary"
           }
         }
       }
     },
-    "Lesen und Schreiben sind getrennt. Du kannst jeden Health-Datentyp einzeln erlauben und später wieder deaktivieren." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reading and writing are separate. You can allow each Health data type individually and turn it off again later."
+    "Lesen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Read"
           }
         }
       }
     },
-    "Lesen und Schreiben werden getrennt verwaltet. Die App nutzt nur Daten, die für Schmerzepisoden als Kontext sinnvoll sind." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reading and writing are managed separately. The app uses only data that is useful as context for pain episodes."
+    "Lesen und Schreiben sind getrennt. Du kannst jeden Health-Datentyp einzeln erlauben und später wieder deaktivieren.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading and writing are separate. You can allow each Health data type individually and turn it off again later."
           }
         }
       }
     },
-    "Leserechte anfragen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Request Read Access"
+    "Lesen und Schreiben werden getrennt verwaltet. Die App nutzt nur Daten, die für Schmerzepisoden als Kontext sinnvoll sind.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading and writing are managed separately. The app uses only data that is useful as context for pain episodes."
           }
         }
       }
     },
-    "Letzter Fehler" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Latest Error"
+    "Leserechte anfragen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request Read Access"
           }
         }
       }
     },
-    "Lizenz" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "License"
+    "Letzter Fehler": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Latest Error"
           }
         }
       }
     },
-    "Lokal hat recht" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Use Local Version"
+    "Lizenz": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "License"
           }
         }
       }
-    },
-    "Lokale Daten wurden nicht gelöscht" : {
-
-    },
-    "Lokale Store-Dateien löschen?" : {
-
     },
-    "Lokaler Stand und Cloud-Stand unterscheiden sich." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local and cloud versions differ."
+    "Lokal hat recht": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use Local Version"
           }
         }
       }
     },
-    "Lokales JSON5-Backup erstellen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create Local JSON5 Backup"
+    "Lokaler Stand und Cloud-Stand unterscheiden sich.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local and cloud versions differ."
           }
         }
       }
     },
-    "Löschen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete"
+    "Lokales JSON5-Backup erstellen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create Local JSON5 Backup"
           }
         }
       }
     },
-    "Manche Health-Datentypen gibt es erst auf neueren iOS-Versionen. Die App bleibt nutzbar und zeigt einfach nur die verfügbaren Werte." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Some Health data types exist only on newer iOS versions. The app remains usable and simply shows the available values."
+    "Löschen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
           }
         }
       }
     },
-    "Medikament" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medication"
+    "Manche Health-Datentypen gibt es erst auf neueren iOS-Versionen. Die App bleibt nutzbar und zeigt einfach nur die verfügbaren Werte.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Some Health data types exist only on newer iOS versions. The app remains usable and simply shows the available values."
           }
         }
       }
     },
-    "Medikament ausgewählt. Passe die Anzahl an." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medication selected. Adjust the quantity."
+    "Medikament": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medication"
           }
         }
       }
     },
-    "Medikament bearbeiten" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edit Medication"
+    "Medikament ausgewählt. Passe die Anzahl an.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medication selected. Adjust the quantity."
           }
         }
       }
     },
-    "Medikament nach Namen filtern" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Filter medication by name"
+    "Medikament bearbeiten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Medication"
           }
         }
       }
     },
-    "Medikamente" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medications"
+    "Medikament nach Namen filtern": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter medication by name"
           }
         }
       }
     },
-    "Medikamente: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medications: %1$@"
+    "Medikamente": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medications"
           }
         }
       }
     },
-    "Medizinische Einordnung" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medical Context"
+    "Medikamente: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medications: %1$@"
           }
         }
       }
     },
-    "Medizinischer Hinweis" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medical Note"
+    "Medizinische Einordnung": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medical Context"
           }
         }
       }
     },
-    "Mehr" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More"
+    "Medizinischer Hinweis": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medical Note"
           }
         }
       }
     },
-    "Mehr gute Tage" : {
-
-    },
-    "Menstruation %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menstruation %1$@"
+    "Mehr": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More"
           }
         }
       }
     },
-    "Menstruationsstatus" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menstruation Status"
+    "Mehr gute Tage": {},
+    "Menstruation %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menstruation %1$@"
           }
         }
       }
     },
-    "Migräne" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Migraine"
+    "Menstruationsstatus": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menstruation Status"
           }
         }
       }
-    },
-    "Mit leerem Store starten" : {
-
-    },
-    "Monat" : {
-
     },
-    "Muster verstehen" : {
-
-    },
-    "Nach Name, Fachgebiet oder Ort suchen" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search by name, specialty or place"
+    "Migräne": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Migraine"
           }
         }
       }
     },
-    "Nächster Monat" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next Month"
+    "Monat": {},
+    "Muster verstehen": {},
+    "Nach Name, Fachgebiet oder Ort suchen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search by name, specialty or place"
           }
         }
       }
     },
-    "Name" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name"
+    "Nächster Monat": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Month"
           }
         }
       }
     },
-    "Neuer Eintrag" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Entry"
+    "Name": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
           }
         }
       }
     },
-    "Nicht alles ist überall verfügbar" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not Everything Is Available Everywhere"
+    "Neuer Eintrag": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Entry"
           }
         }
       }
-    },
-    "Nicht ausgewählt" : {
-
     },
-    "Noch kein Eintrag für diesen Tag." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No entry for this day yet."
+    "Nicht alles ist überall verfügbar": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not Everything Is Available Everywhere"
           }
         }
       }
     },
-    "Noch keine Einträge an diesem Tag" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Entries on This Day Yet"
+    "Noch kein Eintrag für diesen Tag.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No entry for this day yet."
           }
         }
       }
     },
-    "Notiz" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note"
+    "Noch keine Einträge an diesem Tag": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Entries on This Day Yet"
           }
         }
       }
     },
-    "Notiz: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Note: %1$@"
+    "Notiz": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note"
           }
         }
       }
     },
-    "NSAR" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "NSAID"
+    "Notiz: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Note: %1$@"
           }
         }
       }
     },
-    "Nur ergänzen, wenn du heute etwas genommen hast." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Only add this if you took something today."
+    "NSAR": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NSAID"
           }
         }
       }
     },
-    "Nur Fehler" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Errors Only"
+    "Nur ergänzen, wenn du heute etwas genommen hast.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Only add this if you took something today."
           }
         }
       }
     },
-    "Nur Sync" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Only"
+    "Nur Fehler": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errors Only"
           }
         }
       }
     },
-    "Öffnet die Detailansicht des Eintrags." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opens the entry detail view."
+    "Nur Sync": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Only"
           }
         }
       }
     },
-    "Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opens a new diary entry for the currently selected calendar day."
+    "Öffnet die Detailansicht des Eintrags.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens the entry detail view."
           }
         }
       }
     },
-    "OK" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+    "Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens a new diary entry for the currently selected calendar day."
           }
         }
       }
     },
-    "Open Source" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Source"
+    "OK": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
           }
         }
       }
     },
-    "Optionale Details" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Optional Details"
+    "Open Source": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Source"
           }
         }
       }
     },
-    "Optionaler Hinweis" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Optional Note"
+    "Optionale Details": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional Details"
           }
         }
       }
     },
-    "Ort" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Place"
+    "Optionaler Hinweis": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional Note"
           }
         }
       }
     },
-    "Papierkorb" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trash"
+    "Ort": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Place"
           }
         }
       }
     },
-    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trashed entries remain local and in the cloud until you intentionally restore them or permanently remove them later."
+    "Papierkorb": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trash"
           }
         }
       }
     },
-    "Passe den Suchbegriff an oder füge ein eigenes Medikament hinzu." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adjust the search term or add a custom medication."
+    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trashed entries remain local and in the cloud until you intentionally restore them or permanently remove them later."
           }
         }
       }
     },
-    "Passe den Suchbegriff an oder nutze die manuelle Anlage." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adjust the search term or use manual creation."
+    "Passe den Suchbegriff an oder füge ein eigenes Medikament hinzu.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adjust the search term or add a custom medication."
           }
         }
       }
     },
-    "Passe den Zeitraum an, damit ein Bericht aus deinem Tagebuch erstellt werden kann." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adjust the period so a report can be created from your diary."
+    "Passe den Suchbegriff an oder nutze die manuelle Anlage.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adjust the search term or use manual creation."
           }
         }
       }
     },
-    "PDF" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PDF"
+    "Passe den Zeitraum an, damit ein Bericht aus deinem Tagebuch erstellt werden kann.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adjust the period so a report can be created from your diary."
           }
         }
       }
     },
-    "PDF erstellen" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Create PDF"
+    "PDF": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PDF"
           }
         }
       }
     },
-    "PDF teilen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share PDF"
+    "PDF erstellen": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create PDF"
           }
         }
       }
-    },
-    "PDF vorbereiten" : {
-
-    },
-    "PDF wird vorbereitet." : {
-
-    },
-    "PDF-Berichte helfen dir, deine Einträge übersichtlich mitzunehmen. Sie werden nur erstellt und geteilt, wenn du das aktiv auslöst." : {
-
     },
-    "PDF-Berichte und Backups entstehen lokal. Sie verlassen die App erst, wenn du sie über iOS teilst oder speicherst." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PDF reports and backups are created locally. They leave the app only when you share or save them through iOS."
+    "PDF teilen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share PDF"
           }
         }
       }
     },
-    "PDF-Modus" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PDF mode"
+    "PDF vorbereiten": {},
+    "PDF wird vorbereitet.": {},
+    "PDF-Berichte und Backups entstehen lokal. Sie verlassen die App erst, wenn du sie über iOS teilst oder speicherst.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PDF reports and backups are created locally. They leave the app only when you share or save them through iOS."
           }
         }
       }
     },
-    "PLZ" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Postal Code"
+    "PDF-Modus": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PDF mode"
           }
         }
       }
     },
-    "Praxis / Ort" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Practice / Place"
+    "PLZ": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postal Code"
           }
         }
       }
     },
-    "Projekt auf GitHub öffnen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Project on GitHub"
+    "Praxis / Ort": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Practice / Place"
           }
         }
       }
     },
-    "Protokoll löschen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Log"
+    "Projekt auf GitHub öffnen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Project on GitHub"
           }
         }
       }
     },
-    "Protokoll teilen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share Log"
+    "Protokoll löschen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Log"
           }
         }
       }
     },
-    "Pull Requests sind willkommen." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pull requests are welcome."
+    "Protokoll teilen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share Log"
           }
         }
       }
     },
-    "Quelle" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source"
+    "Pull Requests sind willkommen.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pull requests are welcome."
           }
         }
       }
     },
-    "Quelle: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source: %1$@"
+    "Quelle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
           }
         }
       }
     },
-    "Rechtliche Hinweise öffnen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Legal Notices"
+    "Quelle: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source: %1$@"
           }
         }
       }
     },
-    "Ruhepuls %@ bpm" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resting heart rate %1$@ bpm"
+    "Rechtliche Hinweise öffnen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Legal Notices"
           }
         }
       }
     },
-    "ruhig" : {
-
-    },
-    "Sanfte Verlaufsgrafik deiner letzten Einträge" : {
-
-    },
-    "Schlaf %@ min" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sleep %1$@ min"
+    "Ruhepuls %@ bpm": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resting heart rate %1$@ bpm"
           }
         }
       }
     },
-    "Schließen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+    "ruhig": {},
+    "Sanfte Verlaufsgrafik deiner letzten Einträge": {},
+    "Schlaf %@ min": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sleep %1$@ min"
           }
         }
       }
     },
-    "Schmerzcharakter" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pain Character"
+    "Schließen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         }
       }
     },
-    "Schmerzereignisse festhalten" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Record Pain Events"
+    "Schmerzcharakter": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pain Character"
           }
         }
       }
     },
-    "Schmerzlokalisation" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pain Location"
+    "Schmerzereignisse festhalten": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record Pain Events"
           }
         }
       }
     },
-    "Schmerztage im Zeitraum: %lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pain days in period: %1$lld"
+    "Schmerzlokalisation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pain Location"
           }
         }
       }
     },
-    "Schneller Eintrag" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quick Entry"
+    "Schmerztage im Zeitraum: %lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pain days in period: %1$lld"
           }
         }
       }
     },
-    "Schreiben" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Write"
+    "Schneller Eintrag": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quick Entry"
           }
         }
       }
     },
-    "Schreibrechte anfragen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Request Write Access"
+    "Schreiben": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write"
           }
         }
       }
     },
-    "Schritt %lld von %lld" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Schritt %1$lld von %2$lld"
+    "Schreibrechte anfragen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Request Write Access"
           }
         }
       }
     },
-    "Schritte %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Steps %1$@"
+    "Schritte %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Steps %1$@"
           }
         }
       }
     },
-    "Setzt die Intensität auf %lld von 10." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sets intensity to %lld out of 10."
+    "Setzt die Intensität auf %lld von 10.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sets intensity to %lld out of 10."
           }
         }
       }
-    },
-    "Sichere die vorhandenen Store-Dateien, bevor du Symi mit einem leeren Store startest. Ohne Löschbestätigung bleiben die Dateien an ihrem aktuellen Ort." : {
-
-    },
-    "Sichern" : {
-
-    },
-    "Sicherung teilen" : {
-
-    },
-    "Sicherung und Migration" : {
-
     },
-    "Sicherung wird vorbereitet" : {
-
-    },
-    "Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "It does not replace medical diagnosis, treatment decisions or emergency contacts."
+    "Sie ersetzt keine medizinische Diagnose, keine Therapieentscheidung und keinen Notfallkontakt.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It does not replace medical diagnosis, treatment decisions or emergency contacts."
           }
         }
       }
-    },
-    "Skala" : {
-
     },
-    "So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This quickly creates a useful diary entry. Everything else is optional."
+    "So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This quickly creates a useful diary entry. Everything else is optional."
           }
         }
       }
     },
-    "Sobald Sync-Vorgänge oder Fehler auftreten, erscheinen sie hier." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Once sync operations or errors occur, they will appear here."
+    "Sobald Sync-Vorgänge oder Fehler auftreten, erscheinen sie hier.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Once sync operations or errors occur, they will appear here."
           }
         }
       }
     },
-    "Sonstiges" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Other"
+    "Sonstiges": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Other"
           }
         }
       }
     },
-    "Später migrieren" : {
-
-    },
-    "Speichern" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save"
+    "Speichern": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
           }
         }
       }
     },
-    "Stammdaten" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Master Data"
+    "Stammdaten": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Master Data"
           }
         }
       }
     },
-    "Standardmäßig startet der Zeitraum am ersten Tag des vorvorherigen Monats und endet inklusive heute." : {
-
-    },
-    "Standort für Wetter" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Location for Weather"
+    "Standardmäßig startet der Zeitraum am ersten Tag des vorvorherigen Monats und endet inklusive heute.": {},
+    "Standort für Wetter": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Location for Weather"
           }
         }
       }
-    },
-    "stark" : {
-
     },
-    "Stärkste Episode: %@ · %lld/10" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Strongest episode: %1$@ · %2$lld/10"
+    "stark": {},
+    "Stärkste Episode: %@ · %lld/10": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strongest episode: %1$@ · %2$lld/10"
           }
         }
       }
     },
-    "Startdatum" : {
-
-    },
-    "Status" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status"
+    "Status": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status"
           }
         }
       }
-    },
-    "Store-Dateien löschen und leer starten" : {
-
-    },
-    "Store-Dateien sichern" : {
-
     },
-    "Straße" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Street"
+    "Straße": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Street"
           }
         }
       }
     },
-    "Support öffnen" : {
-
-    },
-    "Symi" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symi"
+    "Suche starten": {},
+    "Support öffnen": {},
+    "Symi": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symi"
           }
         }
       }
     },
-    "Symi bleibt lokal nutzbar. Sync und Export passieren nur, wenn du sie aktiv nutzt." : {
-
-    },
-    "Symi-Bericht" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symi-Report"
+    "Symi bleibt lokal nutzbar. Sync und Export passieren nur, wenn du sie aktiv nutzt.": {},
+    "Symi-Bericht": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symi-Report"
           }
         }
       }
-    },
-    "symiapp.com" : {
-
     },
-    "symiapp.com öffnen" : {
-
-    },
-    "Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome können an Apple Health übertragen werden. Notizen und Medikamente bleiben in der App." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symptom data such as headache and selected accompanying symptoms can be transferred to Apple Health. Notes and medication stay in the app."
+    "symiapp.com": {},
+    "symiapp.com öffnen": {},
+    "Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome können an Apple Health übertragen werden. Notizen und Medikamente bleiben in der App.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symptom data such as headache and selected accompanying symptoms can be transferred to Apple Health. Notes and medication stay in the app."
           }
         }
       }
     },
-    "Symptome" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symptoms"
+    "Symptome": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symptoms"
           }
         }
       }
     },
-    "Symptome %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symptoms %1$@"
+    "Symptome %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symptoms %1$@"
           }
         }
       }
     },
-    "Symptome: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symptoms: %1$@"
+    "Symptome: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Symptoms: %1$@"
           }
         }
       }
     },
-    "Sync aktivieren" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable Sync"
+    "Sync aktivieren": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Sync"
           }
         }
       }
     },
-    "Sync-Protokoll" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Log"
+    "Sync-Protokoll": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sync Log"
           }
         }
       }
     },
-    "Synchronisation" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronization"
+    "Synchronisation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Synchronization"
           }
         }
       }
     },
-    "Tagebuch" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diary"
+    "Tagebuch": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diary"
           }
         }
       }
     },
-    "Tagebuch öffnen" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Diary"
+    "Tagebuch öffnen": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Diary"
           }
         }
       }
     },
-    "Tagebuchübersicht" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diary overview"
+    "Tagebuchübersicht": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diary overview"
           }
         }
       }
     },
-    "Tagesbereich" : {
-
-    },
-    "Teilweise" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partial"
+    "Teilweise": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partial"
           }
         }
       }
     },
-    "Telefon" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phone"
+    "Telefon": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phone"
           }
         }
       }
-    },
-    "Tippe doppelt, um diesen Schritt zu bearbeiten." : {
-
     },
-    "Trigger" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Triggers"
+    "Trigger": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Triggers"
           }
         }
       }
     },
-    "Trigger: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Triggers: %1$@"
+    "Trigger: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Triggers: %1$@"
           }
         }
       }
     },
-    "Typ" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Type"
+    "Typ": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type"
           }
         }
       }
     },
-    "Übersicht" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Overview"
+    "Übersicht": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overview"
           }
         }
       }
     },
-    "Unklar" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unclear"
+    "Unklar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unclear"
           }
         }
       }
     },
-    "V1 schreibt nur Kopfschmerz und ausgewählte Begleitsymptome. Medikamente, Zyklusdaten und Konfliktlogik sind eigene Folge-Issues." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "V1 writes only headache and selected accompanying symptoms. Medication, cycle data and conflict logic are separate follow-up issues."
+    "V1 schreibt nur Kopfschmerz und ausgewählte Begleitsymptome. Medikamente, Zyklusdaten und Konfliktlogik sind eigene Folge-Issues.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "V1 writes only headache and selected accompanying symptoms. Medication, cycle data and conflict logic are separate follow-up issues."
           }
         }
       }
     },
-    "Verbindung" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connection"
+    "Verbindung": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection"
           }
         }
       }
     },
-    "Version 1" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version 1"
+    "Version 1": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version 1"
           }
         }
       }
     },
-    "Version 2 schreibt nur einfache Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome. Notizen und Medikamente bleiben in der App." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version 2 writes only simple symptom data such as headache and selected accompanying symptoms. Notes and medication stay in the app."
+    "Version 2 schreibt nur einfache Symptomdaten wie Kopfschmerz und ausgewählte Begleitsymptome. Notizen und Medikamente bleiben in der App.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version 2 writes only simple symptom data such as headache and selected accompanying symptoms. Notes and medication stay in the app."
           }
         }
       }
     },
-    "Version und Plattform" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version and Platform"
+    "Version und Plattform": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version and Platform"
           }
         }
       }
     },
-    "Verstanden" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Understood"
+    "Verstanden": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Understood"
           }
         }
       }
     },
-    "Von" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "From"
+    "Von": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "From"
           }
         }
       }
     },
-    "von %lld" : {
-
-    },
-    "Vorheriger Monat" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Previous Month"
+    "Vorheriger Monat": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous Month"
           }
         }
       }
     },
-    "Vorlauf" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lead Time"
+    "Vorlauf": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lead Time"
           }
         }
       }
     },
-    "Vorschau" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preview"
+    "Vorschau": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview"
           }
         }
       }
     },
-    "Wählt diese Option aus." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selects this option."
+    "Wählt diese Option aus.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selects this option."
           }
         }
       }
     },
-    "Wählt dieses Medikament aus." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selects this medication."
+    "Wählt dieses Medikament aus.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selects this medication."
           }
         }
       }
     },
-    "Was die App macht" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "What the App Does"
+    "Was die App macht": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What the App Does"
           }
         }
       }
     },
-    "Was geschrieben wird" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "What Gets Written"
+    "Was geschrieben wird": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What Gets Written"
           }
         }
       }
-    },
-    "Was hat geholfen?" : {
-
-    },
-    "Was war heute anders?" : {
-
     },
-    "Website und Support: symiapp.com" : {
-
-    },
-    "Weitere Angaben" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Additional Details"
+    "Website und Support: symiapp.com": {},
+    "Weitere Angaben": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Additional Details"
           }
         }
       }
     },
-    "Weitere Funktionen können folgen. Medizinische Auswertungen, zusätzliche Plattformen und komplexere Health-Abgleiche werden separat konzipiert." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More features may follow. Medical analysis, additional platforms and more complex Health syncing will be designed separately."
+    "Weitere Funktionen können folgen. Medizinische Auswertungen, zusätzliche Plattformen und komplexere Health-Abgleiche werden separat konzipiert.": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More features may follow. Medical analysis, additional platforms and more complex Health syncing will be designed separately."
           }
         }
       }
-    },
-    "Wenige Angaben reichen. Alles Weitere bleibt optional." : {
-
-    },
-    "Wenn aktiviert, enthält das PDF zusätzlich die detaillierten Einträge mit Medikamenten, Triggern, Wetterdaten, Apple-Health-Kontext und Notizen." : {
-
     },
-    "Wetter" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weather"
+    "Wenige Angaben reichen. Alles Weitere bleibt optional.": {},
+    "Wenn aktiviert, enthält das PDF zusätzlich die detaillierten Einträge mit Medikamenten, Triggern, Wetterdaten, Apple-Health-Kontext und Notizen.": {},
+    "Wetter": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather"
           }
         }
       }
     },
-    "Wetter wird ermittelt …" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading weather ..."
+    "Wetter wird ermittelt …": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading weather ..."
           }
         }
       }
     },
-    "Wetter wird vorbereitet" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing Weather"
+    "Wetter wird vorbereitet": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing Weather"
           }
         }
       }
     },
-    "Wetter: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weather: %1$@"
+    "Wetter: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather: %1$@"
           }
         }
       }
     },
-    "Wetterdaten" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weather Data"
+    "Wetterdaten": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather Data"
           }
         }
       }
     },
-    "Wetterdaten kommen von Apple Weather. Beim Speichern eines Eintrags merkt sich die App einen passenden Wetter-Snapshot." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weather data comes from Apple Weather. When saving an entry, the app stores a matching weather snapshot."
+    "Wetterdaten kommen von Apple Weather. Beim Speichern eines Eintrags merkt sich die App einen passenden Wetter-Snapshot.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather data comes from Apple Weather. When saving an entry, the app stores a matching weather snapshot."
           }
         }
       }
     },
-    "Wetterdaten und freiwillig freigegebene Apple-Health-Daten ergänzen deine Einträge, damit du später mehr Kontext hast." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weather data and voluntarily shared Apple Health data add context to your entries for later review."
+    "Wetterdaten und freiwillig freigegebene Apple-Health-Daten ergänzen deine Einträge, damit du später mehr Kontext hast.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather data and voluntarily shared Apple Health data add context to your entries for later review."
           }
         }
       }
     },
-    "Wetterquellen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weather Sources"
+    "Wetterquellen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weather Sources"
           }
         }
       }
     },
-    "Wetterquellen anzeigen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Weather Sources"
+    "Wetterquellen anzeigen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Weather Sources"
           }
         }
       }
     },
-    "Wiederherstellen" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restore"
+    "Wiederherstellen": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore"
           }
         }
       }
     },
-    "Wirkung: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Effect: %1$@"
+    "Wirkung: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Effect: %1$@"
           }
         }
       }
     },
-    "Wirkungseintritt: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Onset of relief: %1$@"
+    "Wirkungseintritt: %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onset of relief: %1$@"
           }
         }
       }
     },
-    "Woche" : {
-
-    },
-    "Zeigt die Episoden dieses Tages darunter an." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shows this day's episodes below."
+    "Woche": {},
+    "Zeigt die Episoden dieses Tages darunter an.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows this day's episodes below."
           }
         }
       }
     },
-    "Zeitraum" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Period"
+    "Zeitraum": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Period"
           }
         }
       }
     },
-    "Zeitraum: %@ bis %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Period: %1$@ to %2$@"
+    "Zeitraum: %@ bis %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Period: %1$@ to %2$@"
           }
         }
       }
-    },
-    "Zu heutigem Eintrag hinzufügen" : {
-
-    },
-    "Zurück" : {
-
     },
-    "Zusammenhänge besser erkennen" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "See Patterns More Clearly"
+    "Zusammenhänge besser erkennen": {
+      "extractionState": "stale",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "See Patterns More Clearly"
           }
         }
       }
     }
   },
-  "version" : "1.2"
+  "version": "1.2"
 }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -154,16 +154,16 @@ private struct EntryHeadacheStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            HeadacheIntensityCard(intensity: $coordinator.draft.intensity)
+            PainGaugeView(value: $coordinator.draft.intensity)
 
-            EntryFieldGroup(title: "Wo spürst du den Schmerz?") {
-                EntryTileGrid(minimumColumnWidth: 68) {
+            InputFlowFieldGroup(title: "Wo spürst du den Schmerz?") {
+                InputFlowTileGrid(minimumColumnWidth: 68) {
                     ForEach(visiblePainLocations, id: \.self) { location in
-                        EntryOptionTile(
+                        InputFlowSelectionTile(
                             title: location,
                             systemImage: painLocationSymbol(for: location),
                             isSelected: coordinator.draft.selectedPainLocations.contains(location),
-                            colorToken: .coral,
+                            theme: .pain,
                             accessibilityIdentifier: "entry-location-\(location)"
                         ) {
                             toggle(location, in: &coordinator.draft.selectedPainLocations)
@@ -172,13 +172,13 @@ private struct EntryHeadacheStepView: View {
                 }
             }
 
-            EntryFieldGroup(title: "Wann tritt es auf?") {
-                EntryChipRow {
+            InputFlowFieldGroup(title: "Wann tritt es auf?") {
+                InputFlowPillGrid {
                     ForEach(EntryStartedAtPreset.allCases) { preset in
-                        EntrySelectionChip(
+                        InputFlowPillOption(
                             title: preset.title,
                             isSelected: selectedStartedAtPreset == preset,
-                            colorToken: .coral,
+                            theme: .pain,
                             accessibilityIdentifier: "entry-started-at-\(preset.rawValue)"
                         ) {
                             selectedStartedAtPreset = preset
@@ -269,41 +269,41 @@ private struct EntryMedicationStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            Text("Welche Medikation?")
-                .font(.callout.weight(.medium))
-                .foregroundStyle(.primary)
+            InputFlowFieldGroup(title: "Welche Medikation?") {
+                VStack(spacing: SymiSpacing.tileSpacing) {
+                    InputFlowTileGrid(minimumColumnWidth: 132) {
+                        ForEach(medicationOptions) { option in
+                            InputFlowSelectionTile(
+                                title: option.title,
+                                systemImage: option.symbolName,
+                                isSelected: medicationController.isMedicationNameSelected(option.title),
+                                theme: .medication,
+                                accessibilityIdentifier: "entry-medication-\(option.title)"
+                            ) {
+                                selectMedication(option, controller: medicationController)
+                            }
+                        }
+                    }
 
-            EntryTileGrid(minimumColumnWidth: 132) {
-                ForEach(medicationOptions) { option in
-                    EntryOptionTile(
-                        title: option.title,
-                        systemImage: option.symbolName,
-                        isSelected: medicationController.isMedicationNameSelected(option.title),
-                        colorToken: .sageTeal,
-                        accessibilityIdentifier: "entry-medication-\(option.title)"
+                    InputFlowSelectionTile(
+                        title: coordinator.draft.continuousMedicationChecks.isEmpty ? "Keine Medikation" : "Keine weitere Medikation",
+                        systemImage: "slash.circle",
+                        isSelected: medicationController.selectedMedications.isEmpty,
+                        theme: .medication,
+                        accessibilityIdentifier: "entry-medication-none"
                     ) {
-                        selectMedication(option, controller: medicationController)
+                        medicationController.resetSelections()
                     }
                 }
             }
 
-            EntryOptionTile(
-                title: coordinator.draft.continuousMedicationChecks.isEmpty ? "Keine Medikation" : "Keine weitere Medikation",
-                systemImage: "slash.circle",
-                isSelected: medicationController.selectedMedications.isEmpty,
-                colorToken: .sageTeal,
-                accessibilityIdentifier: "entry-medication-none"
-            ) {
-                medicationController.resetSelections()
-            }
-
-            EntryFieldGroup(title: "Dosierung") {
-                EntryChipRow {
+            InputFlowFieldGroup(title: "Dosierung") {
+                InputFlowPillGrid {
                     ForEach(dosageOptions, id: \.self) { dosage in
-                        EntrySelectionChip(
+                        InputFlowPillOption(
                             title: dosage,
                             isSelected: selectedDosage == dosage,
-                            colorToken: .sageTeal,
+                            theme: .medication,
                             accessibilityIdentifier: "entry-dosage-\(dosage)"
                         ) {
                             selectedDosage = dosage
@@ -312,13 +312,13 @@ private struct EntryMedicationStepView: View {
                 }
             }
 
-            EntryFieldGroup(title: "Wann hast du es eingenommen?") {
-                EntryChipRow {
+            InputFlowFieldGroup(title: "Wann hast du es eingenommen?") {
+                InputFlowPillGrid {
                     ForEach(takenAtOptions, id: \.self) { option in
-                        EntrySelectionChip(
+                        InputFlowPillOption(
                             title: option,
                             isSelected: selectedTakenAt == option,
-                            colorToken: .sageTeal,
+                            theme: .medication,
                             accessibilityIdentifier: "entry-medication-time-\(option)"
                         ) {
                             selectedTakenAt = option
@@ -427,20 +427,18 @@ private struct EntryTriggersStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            Text("Wähle alle passenden aus.")
-                .font(.callout.weight(.medium))
-                .foregroundStyle(.primary)
-
-            EntryTileGrid(minimumColumnWidth: 132) {
-                ForEach(triggerOptions) { option in
-                    EntryOptionTile(
-                        title: option.title,
-                        systemImage: option.symbolName,
-                        isSelected: coordinator.draft.selectedTriggers.contains(option.title),
-                        colorToken: .blue,
-                        accessibilityIdentifier: "entry-trigger-\(option.title)"
-                    ) {
-                        toggle(option.title, in: &coordinator.draft.selectedTriggers)
+            InputFlowFieldGroup(title: "Wähle alle passenden aus.") {
+                InputFlowTileGrid(minimumColumnWidth: 132) {
+                    ForEach(triggerOptions) { option in
+                        InputFlowSelectionTile(
+                            title: option.title,
+                            systemImage: option.symbolName,
+                            isSelected: coordinator.draft.selectedTriggers.contains(option.title),
+                            theme: .trigger,
+                            accessibilityIdentifier: "entry-trigger-\(option.title)"
+                        ) {
+                            toggle(option.title, in: &coordinator.draft.selectedTriggers)
+                        }
                     }
                 }
             }
@@ -494,12 +492,14 @@ private struct EntryNoteStepView: View {
         ) {
             EntryNoteCard(notes: $coordinator.draft.notes)
 
-            EntryFieldGroup(title: "Wie fühlst du dich gerade?") {
-                EntryTileGrid(minimumColumnWidth: 72) {
+            InputFlowFieldGroup(title: "Wie fühlst du dich gerade?") {
+                InputFlowTileGrid(minimumColumnWidth: 72) {
                     ForEach(feelingOptions) { option in
-                        EntryMoodTile(
-                            option: option,
+                        InputFlowSelectionTile(
+                            title: option.title,
+                            systemImage: option.symbolName,
                             isSelected: coordinator.draft.painCharacter == option.title,
+                            theme: .note,
                             accessibilityIdentifier: "entry-feeling-\(option.title)"
                         ) {
                             coordinator.draft.painCharacter = coordinator.draft.painCharacter == option.title ? "" : option.title
@@ -536,44 +536,40 @@ private struct EntryReviewStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            VStack(spacing: 0) {
-                EntryReviewSummarySection(
-                    step: .headache,
+            VStack(spacing: 12) {
+                ReviewSummaryCard(
+                    metadata: InputFlowStepCatalog.metadata(for: .headache),
                     lines: headacheSummary,
+                    accessibilityIdentifier: "entry-review-headache",
                     onEdit: { coordinator.edit(.headache) }
                 )
 
                 if shouldShowMedicationSummary {
-                    Divider()
-                    EntryReviewSummarySection(
-                        step: .medication,
+                    ReviewSummaryCard(
+                        metadata: InputFlowStepCatalog.metadata(for: .medication),
                         lines: medicationSummary,
+                        accessibilityIdentifier: "entry-review-medication",
                         onEdit: { coordinator.edit(.medication) }
                     )
                 }
 
                 if !coordinator.draft.selectedTriggers.isEmpty {
-                    Divider()
-                    EntryReviewSummarySection(
-                        step: .triggers,
+                    ReviewSummaryCard(
+                        metadata: InputFlowStepCatalog.metadata(for: .triggers),
                         lines: triggerSummary,
+                        accessibilityIdentifier: "entry-review-triggers",
                         onEdit: { coordinator.edit(.triggers) }
                     )
                 }
 
                 if shouldShowNoteSummary {
-                    Divider()
-                    EntryReviewSummarySection(
-                        step: .note,
+                    ReviewSummaryCard(
+                        metadata: InputFlowStepCatalog.metadata(for: .note),
                         lines: noteSummary,
+                        accessibilityIdentifier: "entry-review-note",
                         onEdit: { coordinator.edit(.note) }
                     )
                 }
-            }
-            .background(entryCardBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
             }
             .accessibilityElement(children: .contain)
 
@@ -663,10 +659,6 @@ private struct EntryReviewStepView: View {
         return lines
     }
 
-    private var entryCardBackground: some ShapeStyle {
-        Color(uiColor: .secondarySystemGroupedBackground)
-    }
-
     private func startedAtSummary(for startedAt: Date) -> String {
         let interval = abs(startedAt.timeIntervalSinceNow)
         if interval < 10 * 60 {
@@ -718,14 +710,20 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
 
     var body: some View {
         ZStack {
-            EntryFlowBackground()
+            InputFlowBackground()
                 .ignoresSafeArea()
 
             VStack(spacing: 0) {
-                EntryFlowTopBar(onBack: onBack, onCancel: onCancel)
+                InputFlowHeader(
+                    step: step.inputFlowStepID,
+                    currentStep: currentIndex,
+                    totalSteps: EntryFlowCoordinator.steps.count,
+                    onBack: onBack,
+                    onCancel: onCancel
+                )
 
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 22) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.flowSectionSpacing) {
                         Text(step.rawValue)
                             .font(.caption2)
                             .foregroundStyle(.clear)
@@ -734,13 +732,12 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
                             .accessibilityLabel("Flow-Schritt \(step.rawValue)")
                             .accessibilityIdentifier("entry-flow-step-\(step.rawValue)")
 
-                        EntryStepHero(step: step, currentIndex: currentIndex)
                         content
                     }
-                    .padding(.horizontal, 20)
+                    .padding(.horizontal, SymiSpacing.flowHorizontalPadding)
                     .padding(.top, 8)
                     .padding(.bottom, 24)
-                    .frame(maxWidth: 420, alignment: .leading)
+                    .frame(maxWidth: SymiSpacing.flowMaxContentWidth, alignment: .leading)
                     .frame(maxWidth: .infinity)
                 }
                 .scrollIndicators(.hidden)
@@ -749,10 +746,10 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
         }
         .safeAreaInset(edge: .bottom) {
             footer
-                .padding(.horizontal, 20)
-                .padding(.top, 10)
-                .padding(.bottom, 10)
-                .frame(maxWidth: 420)
+                .padding(.horizontal, SymiSpacing.flowHorizontalPadding)
+                .padding(.top, SymiSpacing.flowFooterTopPadding)
+                .padding(.bottom, SymiSpacing.flowFooterBottomPadding)
+                .frame(maxWidth: SymiSpacing.flowMaxContentWidth)
                 .frame(maxWidth: .infinity)
                 .background(.regularMaterial)
         }
@@ -760,385 +757,11 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
     }
 }
 
-private struct EntryFlowTopBar: View {
-    let onBack: () -> Void
-    let onCancel: () -> Void
-
-    var body: some View {
-        HStack {
-            Button(action: onBack) {
-                Image(systemName: "chevron.left")
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 44, height: 44)
-                    .background(.thinMaterial, in: Circle())
-                    .overlay {
-                        Circle()
-                            .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-                    }
-            }
-            .accessibilityLabel("Zurück")
-            .accessibilityIdentifier("entry-flow-back")
-
-            Spacer()
-
-            Button("Abbrechen", action: onCancel)
-                .font(.callout.weight(.medium))
-                .foregroundStyle(AppTheme.symiPetrol)
-                .frame(minHeight: 44)
-                .accessibilityIdentifier("entry-flow-cancel")
-        }
-        .padding(.horizontal, 20)
-        .padding(.top, 8)
-        .padding(.bottom, 2)
-        .frame(maxWidth: 420)
-        .frame(maxWidth: .infinity)
-    }
-}
-
-private struct EntryStepHero: View {
-    let step: EntryFlowStep
-    let currentIndex: Int
-
-    var body: some View {
-        let metadata = NewEntryStepCatalog.metadata(for: step.catalogID)
-
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 18) {
-                EntryProgressTrack(
-                    currentStep: currentIndex,
-                    totalSteps: EntryFlowCoordinator.steps.count,
-                    colorToken: metadata.colorToken
-                )
-
-                Text("von \(EntryFlowCoordinator.steps.count)")
-                    .font(.footnote.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Schritt \(currentIndex) von \(EntryFlowCoordinator.steps.count)")
-
-            Text(metadata.title)
-                .font(.title.weight(.bold))
-                .foregroundStyle(metadata.colorToken.color)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Text(metadata.subline)
-                .font(.callout)
-                .foregroundStyle(.primary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-}
-
-private struct EntryProgressTrack: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    let currentStep: Int
-    let totalSteps: Int
-    let colorToken: NewEntryStepColorToken
-
-    var body: some View {
-        GeometryReader { proxy in
-            let indicatorSize: CGFloat = 24
-            let progressWidth = max(proxy.size.width - indicatorSize, 1)
-            let xOffset = CGFloat(clampedCurrentStep - 1) / CGFloat(max(totalSteps - 1, 1)) * progressWidth
-
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(Color.secondary.opacity(0.18))
-                    .frame(height: 4)
-                    .offset(y: 10)
-
-                Capsule()
-                    .fill(colorToken.color(for: colorScheme))
-                    .frame(width: xOffset + indicatorSize / 2, height: 4)
-                    .offset(y: 10)
-
-                Text("\(clampedCurrentStep)")
-                    .font(.caption.weight(.bold))
-                    .monospacedDigit()
-                    .foregroundStyle(.white)
-                    .frame(width: indicatorSize, height: indicatorSize)
-                    .background(colorToken.color(for: colorScheme), in: Circle())
-                    .offset(x: xOffset)
-            }
-        }
-        .frame(height: 24)
-    }
-
-    private var clampedCurrentStep: Int {
-        min(max(currentStep, 1), max(totalSteps, 1))
-    }
-}
-
-private struct HeadacheIntensityCard: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    @Binding var intensity: Int
-
-    var body: some View {
-        VStack(spacing: 18) {
-            ZStack(alignment: .center) {
-                EntryGaugeArc()
-                    .stroke(
-                        LinearGradient(
-                            colors: [
-                                NewEntryStepColorToken.sageTeal.color,
-                                Color(red: 0.96, green: 0.79, blue: 0.48),
-                                NewEntryStepColorToken.coral.color
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        ),
-                        style: StrokeStyle(lineWidth: 13, lineCap: .round)
-                    )
-                    .frame(width: 212, height: 142)
-                    .accessibilityHidden(true)
-
-                VStack(spacing: 4) {
-                    Text("\(normalizedIntensity)")
-                        .font(.system(size: 58, weight: .bold, design: .rounded))
-                        .monospacedDigit()
-                        .foregroundStyle(AppTheme.symiPetrol)
-                        .minimumScaleFactor(0.75)
-
-                    Text("/10")
-                        .font(.headline)
-                        .foregroundStyle(.secondary)
-
-                    Text(intensityLabel)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(NewEntryStepColorToken.coral.color)
-                        .padding(.top, 8)
-                }
-                .padding(.top, 20)
-            }
-            .frame(maxWidth: .infinity)
-
-            VStack(spacing: 8) {
-                Slider(
-                    value: Binding(
-                        get: { Double(normalizedIntensity) },
-                        set: { intensity = Int($0) }
-                    ),
-                    in: 1 ... 10,
-                    step: 1
-                )
-                .tint(NewEntryStepColorToken.coral.color)
-                .accessibilityLabel("Kopfschmerzstärke \(normalizedIntensity) von 10, \(intensityLabel.lowercased())")
-                .accessibilityIdentifier("entry-intensity-slider")
-
-                HStack {
-                    Text("0")
-                    Spacer()
-                    Text("10")
-                }
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
-            }
-        }
-        .padding(22)
-        .frame(maxWidth: .infinity)
-        .background(entryCardBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(NewEntryStepColorToken.coral.border(for: colorScheme), lineWidth: 1)
-        }
-        .accessibilityIdentifier("entry-intensity-card")
-    }
-
-    private var entryCardBackground: some ShapeStyle {
-        Color(uiColor: .secondarySystemGroupedBackground)
-    }
-
-    private var normalizedIntensity: Int {
-        min(max(intensity, 1), 10)
-    }
-
-    private var intensityLabel: String {
-        switch normalizedIntensity {
-        case 1 ... 3:
-            "Leicht"
-        case 4 ... 6:
-            "Mittel"
-        case 7 ... 8:
-            "Stark"
-        default:
-            "Sehr stark"
-        }
-    }
-}
-
-private struct EntryGaugeArc: Shape {
-    func path(in rect: CGRect) -> Path {
-        let radius = min(rect.width / 2, rect.height) - 8
-        let center = CGPoint(x: rect.midX, y: rect.maxY - 8)
-        var path = Path()
-        path.addArc(
-            center: center,
-            radius: radius,
-            startAngle: .degrees(200),
-            endAngle: .degrees(340),
-            clockwise: false
-        )
-        return path
-    }
-}
-
-private struct EntryFieldGroup<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: Content
-
-    init(title: String, @ViewBuilder content: () -> Content) {
-        self.title = title
-        self.content = content()
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(title)
-                .font(.callout.weight(.medium))
-                .foregroundStyle(.primary)
-
-            content
-        }
-    }
-}
-
-private struct EntryTileGrid<Content: View>: View {
-    let minimumColumnWidth: CGFloat
-    @ViewBuilder let content: Content
-
-    init(minimumColumnWidth: CGFloat, @ViewBuilder content: () -> Content) {
-        self.minimumColumnWidth = minimumColumnWidth
-        self.content = content()
-    }
-
-    var body: some View {
-        LazyVGrid(
-            columns: [
-                GridItem(.adaptive(minimum: minimumColumnWidth), spacing: 10, alignment: .top)
-            ],
-            alignment: .leading,
-            spacing: 10
-        ) {
-            content
-        }
-    }
-}
-
-private struct EntryOptionTile: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    let title: String
-    let systemImage: String
-    let isSelected: Bool
-    let colorToken: NewEntryStepColorToken
-    let accessibilityIdentifier: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 10) {
-                Image(systemName: systemImage)
-                    .font(.title3.weight(.medium))
-                    .foregroundStyle(isSelected ? colorToken.color(for: colorScheme) : .secondary)
-                    .frame(height: 26)
-
-                Text(title)
-                    .font(.subheadline.weight(.medium))
-                    .multilineTextAlignment(.center)
-                    .foregroundStyle(.primary)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.8)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 14)
-            .frame(maxWidth: .infinity, minHeight: 82)
-            .background(tileBackground, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(isSelected ? colorToken.border(for: colorScheme) : Color.primary.opacity(0.09), lineWidth: 1)
-            }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
-        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
-        .accessibilityHint(isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus.")
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
-        .accessibilityIdentifier(accessibilityIdentifier)
-    }
-
-    private var tileBackground: Color {
-        if isSelected {
-            return colorToken.selectedFill(for: colorScheme)
-        }
-
-        return Color(uiColor: .secondarySystemGroupedBackground)
-    }
-}
-
-private struct EntryChipRow<Content: View>: View {
-    @ViewBuilder let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
-    var body: some View {
-        LazyVGrid(
-            columns: [
-                GridItem(.adaptive(minimum: 70), spacing: 8, alignment: .top)
-            ],
-            alignment: .leading,
-            spacing: 8
-        ) {
-            content
-        }
-    }
-}
-
-private struct EntrySelectionChip: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    let title: String
-    let isSelected: Bool
-    let colorToken: NewEntryStepColorToken
-    let accessibilityIdentifier: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .font(.footnote.weight(.medium))
-                .multilineTextAlignment(.center)
-                .lineLimit(2)
-                .minimumScaleFactor(0.82)
-                .foregroundStyle(isSelected ? colorToken.color(for: colorScheme) : .primary)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 9)
-                .frame(maxWidth: .infinity, minHeight: 44)
-                .background(isSelected ? colorToken.selectedFill(for: colorScheme) : Color(uiColor: .secondarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .stroke(isSelected ? colorToken.border(for: colorScheme) : Color.primary.opacity(0.08), lineWidth: 1)
-                }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
-        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
-        .accessibilityIdentifier(accessibilityIdentifier)
-    }
-}
-
 private struct EntryContinuousMedicationBlock: View {
     @Binding var checks: [ContinuousMedicationCheckDraft]
 
     var body: some View {
-        EntryFieldGroup(title: "Dauermedikation") {
+        InputFlowFieldGroup(title: "Dauermedikation") {
             VStack(spacing: 10) {
                 ForEach($checks) { $check in
                     Toggle(isOn: $check.wasTaken) {
@@ -1179,127 +802,78 @@ private struct EntryInfoBanner: View {
 }
 
 private struct EntryNoteCard: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     @Binding var notes: String
 
     private let limit = 500
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            TextEditor(text: $notes)
-                .font(.callout)
-                .scrollContentBackground(.hidden)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 12)
-                .frame(minHeight: 230)
-                .onChange(of: notes) { _, newValue in
-                    if newValue.count > limit {
-                        notes = String(newValue.prefix(limit))
+        InputFlowCard(theme: .note, isHighlighted: true) {
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $notes)
+                    .font(.callout)
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 4)
+                    .frame(minHeight: 220)
+                    .onChange(of: notes) { _, newValue in
+                        if newValue.count > limit {
+                            notes = String(newValue.prefix(limit))
+                        }
+                    }
+                    .accessibilityLabel("Notiz")
+                    .accessibilityIdentifier("entry-note-text")
+
+                if notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Was hat geholfen?")
+                        Text("Was war heute anders?")
+                    }
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 10)
+                    .allowsHitTesting(false)
+                }
+
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        Text("\(notes.count)/\(limit)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .padding(8)
                     }
                 }
-                .accessibilityLabel("Notiz")
-                .accessibilityIdentifier("entry-note-text")
-
-            if notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Was hat geholfen?")
-                    Text("Was war heute anders?")
-                }
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 20)
-                .allowsHitTesting(false)
-            }
-
-            VStack {
-                Spacer()
-                HStack {
-                    Spacer()
-                    Text("\(notes.count)/\(limit)")
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
-                        .padding(12)
-                }
             }
         }
-        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(NewEntryStepColorToken.warmAmber.border(for: colorScheme), lineWidth: 1)
-        }
-    }
-}
-
-private struct EntryMoodTile: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    let option: EntryFeelingOption
-    let isSelected: Bool
-    let accessibilityIdentifier: String
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 6) {
-                Image(systemName: option.symbolName)
-                    .font(.title3.weight(.medium))
-                    .foregroundStyle(isSelected ? NewEntryStepColorToken.warmAmber.color(for: colorScheme) : .secondary)
-                    .frame(height: 26)
-
-                Text(option.title)
-                    .font(.caption.weight(.medium))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, minHeight: 76)
-            .background(
-                isSelected ?
-                    NewEntryStepColorToken.warmAmber.selectedFill(for: colorScheme) :
-                    Color(uiColor: .secondarySystemGroupedBackground),
-                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
-            )
-            .overlay {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(isSelected ? NewEntryStepColorToken.warmAmber.border(for: colorScheme) : Color.primary.opacity(0.08), lineWidth: 1)
-            }
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(option.title)
-        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
-        .accessibilityIdentifier(accessibilityIdentifier)
     }
 }
 
 private struct EntryTodayLinkCard: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     @Binding var isOn: Bool
 
     var body: some View {
-        HStack(spacing: 14) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Zu heutigem Eintrag hinzufügen")
-                    .font(.subheadline.weight(.semibold))
-                Text("Diese Notiz wird mit deinem Eintrag von heute verknüpft.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+        InputFlowCard(theme: .note) {
+            HStack(spacing: 14) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Zu heutigem Eintrag hinzufügen")
+                        .font(.subheadline.weight(.semibold))
+                    Text("Diese Notiz wird mit deinem Eintrag von heute verknüpft.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+
+                Toggle("Zu heutigem Eintrag hinzufügen", isOn: $isOn)
+                    .labelsHidden()
+                    .tint(InputFlowStepTheme.note.accent)
+                    .accessibilityIdentifier("entry-note-link-toggle")
             }
-
-            Spacer(minLength: 8)
-
-            Toggle("Zu heutigem Eintrag hinzufügen", isOn: $isOn)
-                .labelsHidden()
-                .tint(NewEntryStepColorToken.warmAmber.color)
-                .accessibilityIdentifier("entry-note-link-toggle")
+            .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
         }
-        .padding(16)
-        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
-        .background(NewEntryStepColorToken.warmAmber.softFill(for: colorScheme), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }
 
@@ -1335,76 +909,24 @@ private struct EntryFlowFooter: View {
 
     var body: some View {
         VStack(spacing: 12) {
-            Button(action: onPrimary) {
-                HStack(spacing: 12) {
-                    Spacer(minLength: 0)
-
-                    if isSaving {
-                        ProgressView()
-                            .tint(.white)
-                    } else {
-                        Text(primaryTitle)
-                            .font(.headline.weight(.semibold))
-                        Image(systemName: primarySystemImage)
-                            .font(.headline.weight(.semibold))
-                    }
-
-                    Spacer(minLength: 0)
-                }
-                .foregroundStyle(.white)
-                .padding(.horizontal, 18)
-                .frame(maxWidth: .infinity, minHeight: 54)
-                .background(AppTheme.symiPetrol, in: Capsule())
-            }
-            .buttonStyle(.plain)
-            .disabled(isSaving)
-            .accessibilityIdentifier(primaryIdentifier)
+            InputFlowPrimaryButton(
+                title: primaryTitle,
+                systemImage: primarySystemImage,
+                isLoading: isSaving,
+                isDisabled: isSaving,
+                accessibilityIdentifier: primaryIdentifier,
+                action: onPrimary
+            )
 
             if let secondaryTitle, let onSecondary {
-                Button(secondaryTitle, action: onSecondary)
-                    .font(.callout.weight(.medium))
-                    .foregroundStyle(AppTheme.symiPetrol)
-                    .frame(minHeight: 44)
-                    .disabled(isSaving)
-                    .accessibilityIdentifier(secondaryIdentifier ?? "entry-flow-secondary")
+                InputFlowSecondaryAction(
+                    title: secondaryTitle,
+                    isDisabled: isSaving,
+                    accessibilityIdentifier: secondaryIdentifier ?? "entry-flow-secondary",
+                    action: onSecondary
+                )
             }
         }
-    }
-}
-
-private struct EntryReviewSummarySection: View {
-    let step: EntryFlowStep
-    let lines: [String]
-    let onEdit: () -> Void
-
-    var body: some View {
-        let metadata = NewEntryStepCatalog.metadata(for: step.catalogID)
-
-        HStack(alignment: .top, spacing: 12) {
-            StepIcon(metadata)
-                .frame(width: 42, height: 42)
-
-            VStack(alignment: .leading, spacing: 7) {
-                Text(metadata.title)
-                    .font(.headline.weight(.semibold))
-
-                ForEach(lines, id: \.self) { line in
-                    Text(line)
-                        .font(.subheadline)
-                        .foregroundStyle(.primary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-
-            Spacer(minLength: 8)
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .onTapGesture(perform: onEdit)
-        .accessibilityElement(children: .combine)
-        .accessibilityHint("Tippe doppelt, um diesen Schritt zu bearbeiten.")
-        .accessibilityIdentifier("entry-review-\(step.rawValue)")
     }
 }
 
@@ -1425,34 +947,6 @@ private struct EntryPatternHint: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(NewEntryStepColorToken.purple.softFill(for: colorScheme), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         .accessibilityIdentifier("entry-review-pattern-hint")
-    }
-}
-
-private struct EntryFlowBackground: View {
-    @Environment(\.colorScheme) private var colorScheme
-
-    var body: some View {
-        LinearGradient(
-            colors: colors,
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-        )
-    }
-
-    private var colors: [Color] {
-        if colorScheme == .dark {
-            return [
-                Color(red: 0.08, green: 0.09, blue: 0.10),
-                Color(red: 0.06, green: 0.10, blue: 0.10),
-                Color(red: 0.10, green: 0.09, blue: 0.08)
-            ]
-        }
-
-        return [
-            Color(red: 0.99, green: 0.98, blue: 0.96),
-            Color.white,
-            Color(red: 0.95, green: 0.98, blue: 0.97)
-        ]
     }
 }
 
@@ -1477,21 +971,4 @@ private struct EntryFeelingOption: Identifiable {
     let symbolName: String
 
     var id: String { title }
-}
-
-private extension EntryFlowStep {
-    var catalogID: NewEntryStepID {
-        switch self {
-        case .headache:
-            .headache
-        case .medication:
-            .medication
-        case .triggers:
-            .triggers
-        case .note:
-            .note
-        case .review:
-            .review
-        }
-    }
 }

--- a/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
+++ b/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
@@ -1,145 +1,12 @@
 import SwiftUI
 
-enum NewEntryStepID: String, CaseIterable, Identifiable, Sendable {
-    case headache
-    case medication
-    case triggers
-    case note
-    case review
-
-    var id: String { rawValue }
-}
-
-enum NewEntryStepStatus: String, Sendable {
-    case open
-    case active
-    case complete
-}
-
-struct NewEntryStepMetadata: Identifiable, Sendable {
-    let id: NewEntryStepID
-    let title: String
-    let subline: String
-    let symbolName: String
-    let colorToken: NewEntryStepColorToken
-    let status: NewEntryStepStatus?
-}
-
-enum NewEntryStepCatalog {
-    static let steps: [NewEntryStepMetadata] = [
-        NewEntryStepMetadata(
-            id: .headache,
-            title: "Kopfschmerz",
-            subline: "Wie stark ist es gerade?",
-            symbolName: "waveform.path.ecg",
-            colorToken: .coral,
-            status: nil
-        ),
-        NewEntryStepMetadata(
-            id: .medication,
-            title: "Medikation",
-            subline: "Hast du etwas genommen?",
-            symbolName: "pills.fill",
-            colorToken: .sageTeal,
-            status: nil
-        ),
-        NewEntryStepMetadata(
-            id: .triggers,
-            title: "Auslöser",
-            subline: "Was könnte eine Rolle gespielt haben?",
-            symbolName: "brain.head.profile",
-            colorToken: .blue,
-            status: nil
-        ),
-        NewEntryStepMetadata(
-            id: .note,
-            title: "Notiz",
-            subline: "Was möchtest du festhalten?",
-            symbolName: "note.text",
-            colorToken: .warmAmber,
-            status: nil
-        ),
-        NewEntryStepMetadata(
-            id: .review,
-            title: "Eintrag prüfen",
-            subline: "Alles bereit zum Speichern.",
-            symbolName: "checkmark.seal.fill",
-            colorToken: .purple,
-            status: nil
-        )
-    ]
-
-    static func metadata(for id: NewEntryStepID) -> NewEntryStepMetadata {
-        guard let metadata = steps.first(where: { $0.id == id }) else {
-            preconditionFailure("Fehlende Step-Metadaten für \(id.rawValue).")
-        }
-
-        return metadata
-    }
-}
-
-enum NewEntryStepColorToken: String, CaseIterable, Sendable {
-    case coral
-    case sageTeal
-    case blue
-    case warmAmber
-    case purple
-
-    var color: Color {
-        color(for: .light)
-    }
-
-    func color(for colorScheme: ColorScheme) -> Color {
-        let components = colorScheme == .dark ? darkComponents : lightComponents
-        return Color(red: components.red, green: components.green, blue: components.blue)
-    }
-
-    func softFill(for colorScheme: ColorScheme) -> Color {
-        color(for: colorScheme).opacity(0.16)
-    }
-
-    func selectedFill(for colorScheme: ColorScheme) -> Color {
-        color(for: colorScheme).opacity(0.24)
-    }
-
-    func border(for colorScheme: ColorScheme) -> Color {
-        color(for: colorScheme).opacity(0.36)
-    }
-
-    private var lightComponents: ColorComponents {
-        switch self {
-        case .coral:
-            ColorComponents(red: 0.98, green: 0.39, blue: 0.33)
-        case .sageTeal:
-            ColorComponents(red: 0.23, green: 0.61, blue: 0.52)
-        case .blue:
-            ColorComponents(red: 0.24, green: 0.47, blue: 0.84)
-        case .warmAmber:
-            ColorComponents(red: 0.82, green: 0.52, blue: 0.19)
-        case .purple:
-            ColorComponents(red: 0.54, green: 0.38, blue: 0.82)
-        }
-    }
-
-    private var darkComponents: ColorComponents {
-        switch self {
-        case .coral:
-            ColorComponents(red: 1.00, green: 0.56, blue: 0.50)
-        case .sageTeal:
-            ColorComponents(red: 0.48, green: 0.82, blue: 0.73)
-        case .blue:
-            ColorComponents(red: 0.50, green: 0.67, blue: 1.00)
-        case .warmAmber:
-            ColorComponents(red: 0.96, green: 0.70, blue: 0.38)
-        case .purple:
-            ColorComponents(red: 0.75, green: 0.62, blue: 1.00)
-        }
-    }
-}
+typealias NewEntryStepID = InputFlowStepID
+typealias NewEntryStepStatus = InputFlowStepStatus
+typealias NewEntryStepMetadata = InputFlowStepMetadata
+typealias NewEntryStepCatalog = InputFlowStepCatalog
+typealias NewEntryStepColorToken = InputFlowStepColorToken
 
 struct StepIcon: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     let metadata: NewEntryStepMetadata
 
     init(_ metadata: NewEntryStepMetadata) {
@@ -147,19 +14,11 @@ struct StepIcon: View {
     }
 
     var body: some View {
-        Image(systemName: metadata.symbolName)
-            .font(.title3.weight(.semibold))
-            .foregroundStyle(metadata.colorToken.color(for: colorScheme))
-            .frame(width: 44, height: 44)
-            .background(metadata.colorToken.softFill(for: colorScheme))
-            .clipShape(Circle())
-            .accessibilityHidden(true)
+        InputFlowStepIcon(metadata)
     }
 }
 
 struct ProgressIndicator: View {
-    @Environment(\.colorScheme) private var colorScheme
-
     let currentStep: Int
     let totalSteps: Int
     let colorToken: NewEntryStepColorToken
@@ -171,36 +30,11 @@ struct ProgressIndicator: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("\(clampedCurrentStep) von \(safeTotalSteps)")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .accessibilityLabel("Schritt \(clampedCurrentStep) von \(safeTotalSteps)")
-
-            GeometryReader { proxy in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.secondary.opacity(0.18))
-
-                    Capsule()
-                        .fill(colorToken.color(for: colorScheme))
-                        .frame(width: proxy.size.width * progress)
-                }
-            }
-            .frame(height: 6)
-        }
-    }
-
-    private var safeTotalSteps: Int {
-        max(totalSteps, 1)
-    }
-
-    private var clampedCurrentStep: Int {
-        min(max(currentStep, 1), safeTotalSteps)
-    }
-
-    private var progress: Double {
-        Double(clampedCurrentStep) / Double(safeTotalSteps)
+        InputFlowProgressView(
+            currentStep: currentStep,
+            totalSteps: totalSteps,
+            theme: InputFlowStepTheme(colorToken: colorToken)
+        )
     }
 }
 
@@ -302,10 +136,4 @@ struct MultiSelectGrid: View {
             selection.insert(option)
         }
     }
-}
-
-private struct ColorComponents: Sendable {
-    let red: Double
-    let green: Double
-    let blue: Double
 }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowActions.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowActions.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+struct InputFlowPrimaryButton: View {
+    let title: String
+    let systemImage: String
+    let isLoading: Bool
+    let isDisabled: Bool
+    let accessibilityIdentifier: String?
+    let action: () -> Void
+
+    init(
+        title: String,
+        systemImage: String = "arrow.right",
+        isLoading: Bool = false,
+        isDisabled: Bool = false,
+        accessibilityIdentifier: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.isLoading = isLoading
+        self.isDisabled = isDisabled
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                if isLoading {
+                    ProgressView()
+                        .tint(.white)
+                } else {
+                    Text(title)
+                        .font(SymiTypography.flowPrimaryButton)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.85)
+
+                    HStack {
+                        Spacer(minLength: 0)
+                        Image(systemName: systemImage)
+                            .font(.headline.weight(.semibold))
+                            .accessibilityHidden(true)
+                    }
+                    .padding(.trailing, 18)
+                }
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 18)
+            .frame(maxWidth: .infinity, minHeight: 54)
+            .background(buttonFill, in: Capsule())
+            .shadow(color: isDisabled ? .clear : SymiShadow.buttonColor, radius: SymiShadow.buttonRadius, x: 0, y: SymiShadow.buttonYOffset)
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled || isLoading)
+        .accessibilityIdentifier(accessibilityIdentifier ?? "input-flow-primary")
+    }
+
+    private var buttonFill: Color {
+        (isDisabled || isLoading) ? AppTheme.symiPetrol.opacity(0.55) : AppTheme.symiPetrol
+    }
+}
+
+struct InputFlowSecondaryAction: View {
+    let title: String
+    let isDisabled: Bool
+    let accessibilityIdentifier: String?
+    let action: () -> Void
+
+    init(
+        title: String,
+        isDisabled: Bool = false,
+        accessibilityIdentifier: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.isDisabled = isDisabled
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.action = action
+    }
+
+    var body: some View {
+        Button(title, action: action)
+            .font(SymiTypography.flowSecondaryAction)
+            .foregroundStyle(AppTheme.symiPetrol)
+            .frame(minHeight: 44)
+            .disabled(isDisabled)
+            .opacity(isDisabled ? 0.55 : 1)
+            .accessibilityIdentifier(accessibilityIdentifier ?? "input-flow-secondary")
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowCard.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowCard.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct InputFlowCard<Content: View>: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let theme: InputFlowStepTheme?
+    let isHighlighted: Bool
+    let content: Content
+
+    init(
+        theme: InputFlowStepTheme? = nil,
+        isHighlighted: Bool = false,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.theme = theme
+        self.isHighlighted = isHighlighted
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(SymiSpacing.cardPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(cardBackground, in: RoundedRectangle(cornerRadius: SymiRadius.flowCard, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: SymiRadius.flowCard, style: .continuous)
+                    .stroke(borderColor, lineWidth: 1)
+            }
+            .shadow(color: shadowColor, radius: SymiShadow.cardRadius, x: 0, y: SymiShadow.cardYOffset)
+    }
+
+    private var cardBackground: Color {
+        colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : SymiColors.card.color
+    }
+
+    private var borderColor: Color {
+        guard isHighlighted, let theme else {
+            return Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.08)
+        }
+
+        return theme.border(for: colorScheme)
+    }
+
+    private var shadowColor: Color {
+        colorScheme == .dark ? .clear : SymiShadow.cardColor
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowHeader.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowHeader.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct InputFlowHeader: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let step: InputFlowStepID
+    let currentStep: Int
+    let totalSteps: Int
+    let onBack: () -> Void
+    let onCancel: () -> Void
+
+    init(
+        step: InputFlowStepID,
+        currentStep: Int,
+        totalSteps: Int = InputFlowStepCatalog.steps.count,
+        onBack: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.step = step
+        self.currentStep = currentStep
+        self.totalSteps = totalSteps
+        self.onBack = onBack
+        self.onCancel = onCancel
+    }
+
+    var body: some View {
+        let metadata = InputFlowStepCatalog.metadata(for: step)
+
+        VStack(alignment: .leading, spacing: SymiSpacing.flowHeaderControlSpacing) {
+            HStack {
+                Button(action: onBack) {
+                    Image(systemName: "chevron.left")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .frame(width: 44, height: 44)
+                        .background(.thinMaterial, in: Circle())
+                        .overlay {
+                            Circle()
+                                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                        }
+                }
+                .accessibilityLabel("Zurück")
+                .accessibilityIdentifier("entry-flow-back")
+
+                Spacer()
+
+                Button("Abbrechen", action: onCancel)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(AppTheme.symiPetrol)
+                    .frame(minHeight: 44)
+                    .accessibilityIdentifier("entry-flow-cancel")
+            }
+
+            VStack(alignment: .leading, spacing: SymiSpacing.flowHeaderTitleSpacing) {
+                InputFlowProgressView(
+                    currentStep: currentStep,
+                    totalSteps: totalSteps,
+                    theme: metadata.theme
+                )
+
+                Text(metadata.title)
+                    .font(SymiTypography.flowTitle)
+                    .foregroundStyle(metadata.theme.accent(for: colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(metadata.subtitle)
+                    .font(SymiTypography.flowSubtitle)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, SymiSpacing.flowHorizontalPadding)
+        .padding(.top, SymiSpacing.flowHeaderTopPadding)
+        .padding(.bottom, 8)
+        .frame(maxWidth: SymiSpacing.flowMaxContentWidth, alignment: .leading)
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+struct InputFlowFieldGroup<Content: View>: View {
+    let title: String
+    let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(SymiTypography.flowSectionTitle)
+                .foregroundStyle(.primary)
+
+            content
+        }
+    }
+}
+
+struct InputFlowTileGrid<Content: View>: View {
+    let minimumColumnWidth: CGFloat
+    let content: Content
+
+    init(minimumColumnWidth: CGFloat, @ViewBuilder content: () -> Content) {
+        self.minimumColumnWidth = minimumColumnWidth
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.adaptive(minimum: minimumColumnWidth), spacing: SymiSpacing.tileSpacing, alignment: .top)
+            ],
+            alignment: .leading,
+            spacing: SymiSpacing.tileSpacing
+        ) {
+            content
+        }
+    }
+}
+
+struct InputFlowPillGrid<Content: View>: View {
+    let minimumColumnWidth: CGFloat
+    let content: Content
+
+    init(minimumColumnWidth: CGFloat = 70, @ViewBuilder content: () -> Content) {
+        self.minimumColumnWidth = minimumColumnWidth
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.adaptive(minimum: minimumColumnWidth), spacing: SymiSpacing.pillSpacing, alignment: .top)
+            ],
+            alignment: .leading,
+            spacing: SymiSpacing.pillSpacing
+        ) {
+            content
+        }
+    }
+}
+
+struct InputFlowBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        LinearGradient(
+            colors: colors,
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var colors: [Color] {
+        if colorScheme == .dark {
+            return [
+                Color(red: 0.08, green: 0.09, blue: 0.10),
+                Color(red: 0.06, green: 0.10, blue: 0.10),
+                Color(red: 0.10, green: 0.09, blue: 0.08)
+            ]
+        }
+
+        return [
+            SymiColors.warmBackground.color,
+            Color.white,
+            SymiColors.sage.color.opacity(0.18)
+        ]
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowPillOption.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowPillOption.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct InputFlowPillOption: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let title: String
+    let isSelected: Bool
+    let isDisabled: Bool
+    let theme: InputFlowStepTheme
+    let accessibilityIdentifier: String?
+    let action: () -> Void
+
+    init(
+        title: String,
+        isSelected: Bool,
+        isDisabled: Bool = false,
+        theme: InputFlowStepTheme,
+        accessibilityIdentifier: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.isSelected = isSelected
+        self.isDisabled = isDisabled
+        self.theme = theme
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption.weight(.bold))
+                        .accessibilityHidden(true)
+                }
+
+                Text(title)
+                    .font(SymiTypography.flowPillLabel)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.82)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .foregroundStyle(isSelected ? theme.accent(for: colorScheme) : .primary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .background(backgroundColor, in: Capsule())
+            .overlay {
+                Capsule()
+                    .stroke(borderColor, lineWidth: 1)
+            }
+            .opacity(isDisabled ? 0.55 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityIdentifier(accessibilityIdentifier ?? "input-flow-pill-\(title)")
+    }
+
+    private var backgroundColor: Color {
+        if isSelected {
+            return theme.selectedFill(for: colorScheme)
+        }
+
+        return colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : SymiColors.card.color
+    }
+
+    private var borderColor: Color {
+        if isSelected {
+            return theme.border(for: colorScheme)
+        }
+
+        return Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.08)
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowProgressView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowProgressView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct InputFlowProgressView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let currentStep: Int
+    let totalSteps: Int
+    let theme: InputFlowStepTheme
+
+    init(currentStep: Int, totalSteps: Int = InputFlowStepCatalog.steps.count, theme: InputFlowStepTheme) {
+        self.currentStep = currentStep
+        self.totalSteps = totalSteps
+        self.theme = theme
+    }
+
+    var body: some View {
+        HStack(spacing: 18) {
+            GeometryReader { proxy in
+                let indicatorSize: CGFloat = 24
+                let trackWidth = max(proxy.size.width - indicatorSize, 1)
+                let xOffset = progressPosition(in: trackWidth)
+                let activeWidth = min(xOffset + indicatorSize / 2, proxy.size.width)
+
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.primary.opacity(colorScheme == .dark ? 0.22 : 0.12))
+                        .frame(height: 4)
+                        .offset(y: indicatorSize / 2 - 2)
+
+                    Capsule()
+                        .fill(theme.accent(for: colorScheme))
+                        .frame(width: activeWidth, height: 4)
+                        .offset(y: indicatorSize / 2 - 2)
+
+                    Text("\(clampedCurrentStep)")
+                        .font(.caption.weight(.bold))
+                        .monospacedDigit()
+                        .foregroundStyle(.white)
+                        .frame(width: indicatorSize, height: indicatorSize)
+                        .background(theme.accent(for: colorScheme), in: Circle())
+                        .overlay {
+                            Circle()
+                                .stroke(.white.opacity(colorScheme == .dark ? 0.18 : 0.92), lineWidth: 1)
+                        }
+                        .offset(x: xOffset)
+                        .accessibilityHidden(true)
+                }
+            }
+            .frame(height: 24)
+
+            Text("von \(safeTotalSteps)")
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Schritt \(clampedCurrentStep) von \(safeTotalSteps)")
+    }
+
+    private var safeTotalSteps: Int {
+        max(totalSteps, 1)
+    }
+
+    private var clampedCurrentStep: Int {
+        min(max(currentStep, 1), safeTotalSteps)
+    }
+
+    private func progressPosition(in trackWidth: CGFloat) -> CGFloat {
+        guard safeTotalSteps > 1 else {
+            return trackWidth
+        }
+
+        return CGFloat(clampedCurrentStep - 1) / CGFloat(safeTotalSteps - 1) * trackWidth
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowSelectionTile.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowSelectionTile.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+enum InputFlowSelectionState: Equatable, Sendable {
+    case unselected
+    case selected
+    case disabled
+
+    var isSelected: Bool {
+        self == .selected
+    }
+
+    var isDisabled: Bool {
+        self == .disabled
+    }
+}
+
+struct InputFlowSelectionTile: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let title: String
+    let systemImage: String
+    let state: InputFlowSelectionState
+    let theme: InputFlowStepTheme
+    let accessibilityIdentifier: String?
+    let action: () -> Void
+
+    init(
+        title: String,
+        systemImage: String,
+        isSelected: Bool,
+        isDisabled: Bool = false,
+        theme: InputFlowStepTheme,
+        accessibilityIdentifier: String? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.state = isDisabled ? .disabled : (isSelected ? .selected : .unselected)
+        self.theme = theme
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 10) {
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: systemImage)
+                        .font(.title3.weight(.medium))
+                        .foregroundStyle(iconColor)
+                        .frame(width: 34, height: 30)
+
+                    if state.isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(theme.accent(for: colorScheme))
+                            .background(Color(uiColor: .systemBackground), in: Circle())
+                            .offset(x: 12, y: -6)
+                            .accessibilityHidden(true)
+                    }
+                }
+
+                Text(title)
+                    .font(SymiTypography.flowTileLabel)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(state.isDisabled ? .secondary : .primary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.82)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, minHeight: 84)
+            .background(tileBackground, in: RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous)
+                    .stroke(borderColor, lineWidth: state.isSelected ? 1.5 : 1)
+            }
+            .opacity(state.isDisabled ? 0.58 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(state.isDisabled)
+        .accessibilityLabel(title)
+        .accessibilityValue(accessibilityValue)
+        .accessibilityHint(accessibilityHint)
+        .accessibilityAddTraits(state.isSelected ? .isSelected : [])
+        .accessibilityIdentifier(accessibilityIdentifier ?? "input-flow-tile-\(title)")
+    }
+
+    private var iconColor: Color {
+        if state.isDisabled {
+            return .secondary
+        }
+
+        return state.isSelected ? theme.accent(for: colorScheme) : .secondary
+    }
+
+    private var tileBackground: Color {
+        if state.isSelected {
+            return theme.selectedFill(for: colorScheme)
+        }
+
+        return colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : SymiColors.card.color
+    }
+
+    private var borderColor: Color {
+        if state.isSelected {
+            return theme.border(for: colorScheme)
+        }
+
+        return Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.08)
+    }
+
+    private var accessibilityValue: String {
+        switch state {
+        case .selected:
+            "Ausgewählt"
+        case .unselected:
+            "Nicht ausgewählt"
+        case .disabled:
+            "Nicht verfügbar"
+        }
+    }
+
+    private var accessibilityHint: String {
+        state.isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus."
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+struct PainGaugeView: View {
+    @Binding var value: Int
+
+    let range: ClosedRange<Int>
+    let theme: InputFlowStepTheme
+
+    init(
+        value: Binding<Int>,
+        range: ClosedRange<Int> = 0 ... 10,
+        theme: InputFlowStepTheme = .pain
+    ) {
+        _value = value
+        self.range = range
+        self.theme = theme
+    }
+
+    var body: some View {
+        InputFlowCard(theme: theme, isHighlighted: true) {
+            VStack(spacing: 18) {
+                ZStack(alignment: .center) {
+                    PainGaugeArc()
+                        .stroke(
+                            LinearGradient(
+                                colors: [
+                                    InputFlowStepTheme.medication.accent,
+                                    SymiColors.noteAmber.color,
+                                    InputFlowStepTheme.pain.accent
+                                ],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            ),
+                            style: StrokeStyle(lineWidth: 13, lineCap: .round)
+                        )
+                        .frame(width: 212, height: 142)
+                        .accessibilityHidden(true)
+
+                    VStack(spacing: 4) {
+                        Text("\(normalizedValue)")
+                            .font(.system(size: 58, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundStyle(AppTheme.symiPetrol)
+                            .minimumScaleFactor(0.75)
+
+                        Text("/10")
+                            .font(.headline)
+                            .foregroundStyle(.secondary)
+
+                        Text(intensityLabel)
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(theme.accent)
+                            .padding(.top, 8)
+                            .minimumScaleFactor(0.85)
+                    }
+                    .padding(.top, 20)
+                }
+                .frame(maxWidth: .infinity)
+
+                VStack(spacing: 8) {
+                    Slider(
+                        value: Binding(
+                            get: { Double(normalizedValue) },
+                            set: { value = Int($0.rounded()) }
+                        ),
+                        in: Double(range.lowerBound) ... Double(range.upperBound),
+                        step: 1
+                    )
+                    .tint(theme.accent)
+                    .accessibilityLabel("Kopfschmerzstärke")
+                    .accessibilityValue("\(normalizedValue) von 10, \(intensityLabel.lowercased())")
+                    .accessibilityIdentifier("entry-intensity-slider")
+
+                    HStack {
+                        Text("\(range.lowerBound)")
+                        Spacer()
+                        Text("\(range.upperBound)")
+                    }
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("entry-intensity-card")
+    }
+
+    private var normalizedValue: Int {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    private var intensityLabel: String {
+        switch normalizedValue {
+        case ...0:
+            "Kein"
+        case 1 ... 3:
+            "Leicht"
+        case 4 ... 6:
+            "Mittel"
+        case 7 ... 8:
+            "Stark"
+        default:
+            "Sehr stark"
+        }
+    }
+}
+
+private struct PainGaugeArc: Shape {
+    func path(in rect: CGRect) -> Path {
+        let radius = min(rect.width / 2, rect.height) - 8
+        let center = CGPoint(x: rect.midX, y: rect.maxY - 8)
+        var path = Path()
+        path.addArc(
+            center: center,
+            radius: radius,
+            startAngle: .degrees(200),
+            endAngle: .degrees(340),
+            clockwise: false
+        )
+        return path
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Components/ReviewSummaryCard.swift
+++ b/Symi/Sources/Features/InputFlow/Components/ReviewSummaryCard.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct InputFlowStepIcon: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let metadata: InputFlowStepMetadata
+
+    init(_ metadata: InputFlowStepMetadata) {
+        self.metadata = metadata
+    }
+
+    var body: some View {
+        Image(systemName: metadata.symbolName)
+            .font(.title3.weight(.semibold))
+            .foregroundStyle(metadata.theme.accent(for: colorScheme))
+            .frame(width: 44, height: 44)
+            .background(metadata.theme.iconBackground(for: colorScheme), in: Circle())
+            .accessibilityHidden(true)
+    }
+}
+
+struct ReviewSummaryCard: View {
+    let metadata: InputFlowStepMetadata
+    let lines: [String]
+    let details: String?
+    let accessibilityIdentifier: String
+    let onEdit: (() -> Void)?
+
+    init(
+        metadata: InputFlowStepMetadata,
+        lines: [String],
+        details: String? = nil,
+        accessibilityIdentifier: String,
+        onEdit: (() -> Void)? = nil
+    ) {
+        self.metadata = metadata
+        self.lines = lines
+        self.details = details
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.onEdit = onEdit
+    }
+
+    var body: some View {
+        Group {
+            if let onEdit {
+                Button(action: onEdit) {
+                    content
+                }
+                .buttonStyle(.plain)
+            } else {
+                content
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(onEdit == nil ? "" : "Tippe doppelt, um diesen Schritt zu bearbeiten.")
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private var content: some View {
+        InputFlowCard {
+            HStack(alignment: .top, spacing: 12) {
+                InputFlowStepIcon(metadata)
+                    .frame(width: 42, height: 42)
+
+                VStack(alignment: .leading, spacing: 7) {
+                    Text(metadata.title)
+                        .font(SymiTypography.flowSummaryTitle)
+
+                    ForEach(lines, id: \.self) { line in
+                        Text(line)
+                            .font(SymiTypography.flowSummaryLine)
+                            .foregroundStyle(.primary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    if let details, !details.isEmpty {
+                        Text(details)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                if onEdit != nil {
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 3)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Styling/InputFlowTheme.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/InputFlowTheme.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+enum InputFlowStepID: String, CaseIterable, Identifiable, Sendable {
+    case headache
+    case medication
+    case triggers
+    case note
+    case review
+
+    var id: String { rawValue }
+}
+
+enum InputFlowStepStatus: String, Sendable {
+    case open
+    case active
+    case complete
+}
+
+struct InputFlowStepMetadata: Identifiable, Sendable {
+    let id: InputFlowStepID
+    let title: String
+    let subtitle: String
+    let symbolName: String
+    let theme: InputFlowStepTheme
+    let status: InputFlowStepStatus?
+
+    var subline: String { subtitle }
+    var colorToken: InputFlowStepColorToken { theme.colorToken }
+}
+
+enum InputFlowStepCatalog {
+    static let steps: [InputFlowStepMetadata] = [
+        InputFlowStepMetadata(
+            id: .headache,
+            title: "Kopfschmerz",
+            subtitle: "Wie stark ist es gerade?",
+            symbolName: "waveform.path.ecg",
+            theme: .pain,
+            status: nil
+        ),
+        InputFlowStepMetadata(
+            id: .medication,
+            title: "Medikation",
+            subtitle: "Hast du etwas genommen?",
+            symbolName: "pills.fill",
+            theme: .medication,
+            status: nil
+        ),
+        InputFlowStepMetadata(
+            id: .triggers,
+            title: "Auslöser",
+            subtitle: "Was könnte eine Rolle gespielt haben?",
+            symbolName: "brain.head.profile",
+            theme: .trigger,
+            status: nil
+        ),
+        InputFlowStepMetadata(
+            id: .note,
+            title: "Notiz",
+            subtitle: "Was möchtest du festhalten?",
+            symbolName: "note.text",
+            theme: .note,
+            status: nil
+        ),
+        InputFlowStepMetadata(
+            id: .review,
+            title: "Eintrag prüfen",
+            subtitle: "Alles bereit zum Speichern.",
+            symbolName: "checkmark.seal.fill",
+            theme: .review,
+            status: nil
+        )
+    ]
+
+    static func metadata(for id: InputFlowStepID) -> InputFlowStepMetadata {
+        guard let metadata = steps.first(where: { $0.id == id }) else {
+            preconditionFailure("Fehlende Step-Metadaten für \(id.rawValue).")
+        }
+
+        return metadata
+    }
+}
+
+struct InputFlowStepTheme: Equatable, Sendable {
+    let colorToken: InputFlowStepColorToken
+
+    static let pain = InputFlowStepTheme(colorToken: .coral)
+    static let medication = InputFlowStepTheme(colorToken: .sageTeal)
+    static let trigger = InputFlowStepTheme(colorToken: .blue)
+    static let note = InputFlowStepTheme(colorToken: .warmAmber)
+    static let review = InputFlowStepTheme(colorToken: .purple)
+
+    var accent: Color {
+        colorToken.color
+    }
+
+    var accentSoft: Color {
+        colorToken.softFill(for: .light)
+    }
+
+    var progress: Color {
+        colorToken.color
+    }
+
+    var iconBackground: Color {
+        colorToken.softFill(for: .light)
+    }
+
+    func accent(for colorScheme: ColorScheme) -> Color {
+        colorToken.color(for: colorScheme)
+    }
+
+    func accentSoft(for colorScheme: ColorScheme) -> Color {
+        colorToken.softFill(for: colorScheme)
+    }
+
+    func selectedFill(for colorScheme: ColorScheme) -> Color {
+        colorToken.selectedFill(for: colorScheme)
+    }
+
+    func border(for colorScheme: ColorScheme) -> Color {
+        colorToken.border(for: colorScheme)
+    }
+
+    func iconBackground(for colorScheme: ColorScheme) -> Color {
+        colorToken.softFill(for: colorScheme)
+    }
+}
+
+enum InputFlowStepColorToken: String, CaseIterable, Sendable {
+    case coral
+    case sageTeal
+    case blue
+    case warmAmber
+    case purple
+
+    var color: Color {
+        color(for: .light)
+    }
+
+    var lightColorValue: SymiColorValue {
+        switch self {
+        case .coral:
+            SymiColors.coral
+        case .sageTeal:
+            SymiColors.sage
+        case .blue:
+            SymiColors.triggerBlue
+        case .warmAmber:
+            SymiColors.noteAmber
+        case .purple:
+            SymiColors.reviewPurple
+        }
+    }
+
+    func color(for colorScheme: ColorScheme) -> Color {
+        let value = colorScheme == .dark ? darkColorValue : lightColorValue
+        return value.color
+    }
+
+    func softFill(for colorScheme: ColorScheme) -> Color {
+        color(for: colorScheme).opacity(colorScheme == .dark ? 0.22 : 0.16)
+    }
+
+    func selectedFill(for colorScheme: ColorScheme) -> Color {
+        color(for: colorScheme).opacity(colorScheme == .dark ? 0.30 : 0.24)
+    }
+
+    func border(for colorScheme: ColorScheme) -> Color {
+        color(for: colorScheme).opacity(colorScheme == .dark ? 0.48 : 0.36)
+    }
+
+    private var darkColorValue: SymiColorValue {
+        switch self {
+        case .coral:
+            SymiColorValue(hex: 0xFFA196)
+        case .sageTeal:
+            SymiColorValue(hex: 0xA9DEC9)
+        case .blue:
+            SymiColorValue(hex: 0x81A0F1)
+        case .warmAmber:
+            SymiColorValue(hex: 0xF0B867)
+        case .purple:
+            SymiColorValue(hex: 0xB096F2)
+        }
+    }
+}
+
+extension EntryFlowStep {
+    var inputFlowStepID: InputFlowStepID {
+        switch self {
+        case .headache:
+            .headache
+        case .medication:
+            .medication
+        case .triggers:
+            .triggers
+        case .note:
+            .note
+        case .review:
+            .review
+        }
+    }
+}

--- a/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct SymiColorValue: Equatable, Sendable {
+    let red: Double
+    let green: Double
+    let blue: Double
+
+    init(red: Double, green: Double, blue: Double) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+    }
+
+    init(hex: Int) {
+        red = Double((hex >> 16) & 0xFF) / 255
+        green = Double((hex >> 8) & 0xFF) / 255
+        blue = Double(hex & 0xFF) / 255
+    }
+
+    var color: Color {
+        Color(red: red, green: green, blue: blue)
+    }
+
+    var hexString: String {
+        "#\(Self.hexByte(red))\(Self.hexByte(green))\(Self.hexByte(blue))"
+    }
+
+    private static func hexByte(_ component: Double) -> String {
+        let byte = min(max(Int((component * 255).rounded()), 0), 255)
+        let digits = Array("0123456789ABCDEF")
+        return String([digits[byte / 16], digits[byte % 16]])
+    }
+}
+
+enum SymiColors {
+    static let primaryPetrol = SymiColorValue(hex: 0x0F3D3E)
+    static let sage = SymiColorValue(hex: 0x8ECDB8)
+    static let coral = SymiColorValue(hex: 0xFF8A7A)
+    static let warmBackground = SymiColorValue(hex: 0xF6F4EF)
+    static let card = SymiColorValue(hex: 0xFFFFFF)
+    static let textPrimary = SymiColorValue(hex: 0x1C1C1E)
+    static let textSecondary = SymiColorValue(hex: 0x6B6B6E)
+
+    static let triggerBlue = SymiColorValue(hex: 0x4A78D9)
+    static let noteAmber = SymiColorValue(hex: 0xD18A2B)
+    static let reviewPurple = SymiColorValue(hex: 0x8A65D6)
+}

--- a/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+enum SymiSpacing {
+    static let flowHorizontalPadding: CGFloat = 20
+    static let flowMaxContentWidth: CGFloat = 420
+    static let flowSectionSpacing: CGFloat = 22
+    static let flowHeaderTopPadding: CGFloat = 8
+    static let flowHeaderControlSpacing: CGFloat = 10
+    static let flowHeaderTitleSpacing: CGFloat = 8
+    static let flowFooterTopPadding: CGFloat = 10
+    static let flowFooterBottomPadding: CGFloat = 10
+    static let tileSpacing: CGFloat = 10
+    static let pillSpacing: CGFloat = 8
+    static let cardPadding: CGFloat = 18
+}
+
+enum SymiRadius {
+    static let flowCard: CGFloat = 18
+    static let flowTile: CGFloat = 14
+    static let flowPill: CGFloat = 12
+    static let flowBanner: CGFloat = 16
+}
+
+enum SymiShadow {
+    static let cardColor = AppTheme.symiPetrol.opacity(0.06)
+    static let cardRadius: CGFloat = 12
+    static let cardYOffset: CGFloat = 5
+    static let buttonColor = AppTheme.symiPetrol.opacity(0.16)
+    static let buttonRadius: CGFloat = 12
+    static let buttonYOffset: CGFloat = 6
+}

--- a/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+enum SymiTypography {
+    static let flowTitle = Font.title.weight(.bold)
+    static let flowSubtitle = Font.callout
+    static let flowSectionTitle = Font.callout.weight(.medium)
+    static let flowTileLabel = Font.subheadline.weight(.medium)
+    static let flowPillLabel = Font.footnote.weight(.medium)
+    static let flowPrimaryButton = Font.headline.weight(.semibold)
+    static let flowSecondaryAction = Font.callout.weight(.medium)
+    static let flowSummaryTitle = Font.headline.weight(.semibold)
+    static let flowSummaryLine = Font.subheadline
+}

--- a/SymiTests/NewEntryDesignSystemTests.swift
+++ b/SymiTests/NewEntryDesignSystemTests.swift
@@ -41,4 +41,45 @@ struct NewEntryDesignSystemTests {
         #expect(symbols.count == NewEntryStepCatalog.steps.count)
         #expect(colorTokens.count == NewEntryStepCatalog.steps.count)
     }
+
+    @Test
+    func symiColorTokensMatchInputFlowBasisColors() {
+        #expect(SymiColors.primaryPetrol.hexString == "#0F3D3E")
+        #expect(SymiColors.sage.hexString == "#8ECDB8")
+        #expect(SymiColors.coral.hexString == "#FF8A7A")
+        #expect(SymiColors.warmBackground.hexString == "#F6F4EF")
+        #expect(SymiColors.card.hexString == "#FFFFFF")
+        #expect(SymiColors.textPrimary.hexString == "#1C1C1E")
+        #expect(SymiColors.textSecondary.hexString == "#6B6B6E")
+    }
+
+    @Test
+    func stepThemesMapFlowStepsToExpectedAccentTokens() {
+        let expected: [NewEntryStepID: InputFlowStepTheme] = [
+            .headache: .pain,
+            .medication: .medication,
+            .triggers: .trigger,
+            .note: .note,
+            .review: .review
+        ]
+
+        for step in NewEntryStepCatalog.steps {
+            #expect(step.theme == expected[step.id, default: .pain])
+        }
+    }
+
+    @Test
+    func stepAccentTokensUseDesignSystemColors() {
+        let expected: [NewEntryStepColorToken: String] = [
+            .coral: "#FF8A7A",
+            .sageTeal: "#8ECDB8",
+            .blue: "#4A78D9",
+            .warmAmber: "#D18A2B",
+            .purple: "#8A65D6"
+        ]
+
+        for token in NewEntryStepColorToken.allCases {
+            #expect(token.lightColorValue.hexString == expected[token, default: ""])
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Extracts a reusable InputFlow design system with step themes, tokens, header/progress, cards, selection tiles, pills, actions, pain gauge, and review summary cards.
- Reworks the five-step entry flow to consume those shared components while preserving existing interaction and accessibility identifiers.
- Keeps the previous NewEntry design system names as a compatibility layer and expands tests for tokens and theme mapping.

## Validation
- xcodebuild -scheme Symi -destination 'generic/platform=iOS Simulator' build\n- xcodebuild test -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1'\n\nCloses #190