### PR TITLE
[codex] Enforce global design tokens

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -47,6 +47,12 @@ jobs:
           xcodebuild -version
           xcode-select -p
 
+      - name: SwiftLint installieren
+        run: brew install swiftlint
+
+      - name: Design-Token-Regeln prüfen
+        run: swiftlint lint --config .swiftlint.yml
+
       - name: Secrets prüfen
         run: |
           if [ -z "${APPLE_DEVELOPER_TEAM_ID}" ]; then

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,95 @@
+included:
+  - Symi
+
+only_rules:
+  - no_magic_padding
+  - no_magic_corner_radius
+  - no_direct_swiftui_colors
+  - no_direct_white_black_background
+  - no_free_shadow_values
+  - no_magic_frame_sizes
+  - no_magic_spacing
+  - no_magic_offsets
+  - no_magic_line_width
+  - no_magic_opacity
+  - no_magic_font_size
+  - no_magic_minimum_scale_factor
+
+excluded:
+  - Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
+  - Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+  - Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
+  - Symi/Sources/Features/Export/PDFExportWriter.swift
+
+custom_rules:
+  no_magic_padding:
+    name: "Keine rohen Padding-Werte"
+    regex: '\.padding\((?:\.(?:horizontal|vertical|top|bottom|leading|trailing),\s*)?\d+(?:\.\d+)?\)'
+    message: "Nutze SymiSpacing-Tokens statt roher Padding-Werte."
+    severity: warning
+
+  no_magic_corner_radius:
+    name: "Keine rohen Radius-Werte"
+    regex: 'cornerRadius:\s*\d+(?:\.\d+)?|\.cornerRadius\(\d+(?:\.\d+)?\)'
+    message: "Nutze SymiRadius-Tokens statt roher Radius-Werte."
+    severity: warning
+
+  no_direct_swiftui_colors:
+    name: "Keine direkten SwiftUI-Farben"
+    regex: 'Color\((?:red:|hex:|uiColor:)|\.(?:foregroundStyle|foregroundColor|tint)\(\.(?:white|black|red|blue|green|orange|yellow|pink|purple)\)'
+    message: "Nutze SymiColors/AppTheme-Tokens statt direkter Farben."
+    severity: warning
+
+  no_direct_white_black_background:
+    name: "Keine weißen oder schwarzen Backgrounds"
+    regex: '\.background\((?:Color\.)?(?:white|black)|\.background\(\.(?:white|black)'
+    message: "Nutze SymiColors/AppTheme-Tokens statt .white/.black im Hintergrund."
+    severity: warning
+
+  no_free_shadow_values:
+    name: "Keine freien Shadow-Werte"
+    regex: '\.shadow\([^)]*(?:radius:\s*\d+(?:\.\d+)?|x:\s*-?\d+(?:\.\d+)?|y:\s*-?\d+(?:\.\d+)?)'
+    message: "Nutze SymiShadow-Tokens statt freier Shadow-Werte."
+    severity: warning
+
+  no_magic_frame_sizes:
+    name: "Keine rohen Frame-Größen"
+    regex: '\.(?:frame|defaultSize)\([^)]*(?:width|height|minWidth|minHeight|maxWidth|maxHeight):\s*-?\d+(?:\.\d+)?'
+    message: "Nutze SymiSize-Tokens statt roher Frame- oder Fenstergrößen."
+    severity: warning
+
+  no_magic_spacing:
+    name: "Keine rohen Spacing-Werte"
+    regex: '(?:VStack|HStack|LazyVGrid|LazyHGrid|GridItem)\([^)]*spacing:\s*-?\d+(?:\.\d+)?'
+    message: "Nutze SymiSpacing-Tokens statt roher Spacing-Werte."
+    severity: warning
+
+  no_magic_offsets:
+    name: "Keine rohen Offset-Werte"
+    regex: '\.offset\([^)]*(?:x|y):\s*-?\d+(?:\.\d+)?'
+    message: "Nutze SymiSpacing- oder SymiSize-Tokens statt roher Offset-Werte."
+    severity: warning
+
+  no_magic_line_width:
+    name: "Keine rohen Linienbreiten"
+    regex: '(?:lineWidth:\s*\d+(?:\.\d+)?|\.setLineWidth\(\d+(?:\.\d+)?\))'
+    message: "Nutze SymiStroke-Tokens statt roher Linienbreiten."
+    severity: warning
+
+  no_magic_opacity:
+    name: "Keine rohen Opacity-Werte"
+    regex: '\.opacity\([^)]*\b\d+(?:\.\d+)?\b'
+    message: "Nutze SymiOpacity-Tokens statt roher Opacity-Werte."
+    severity: warning
+
+  no_magic_font_size:
+    name: "Keine rohen Font-Größen"
+    regex: '\.font\(\.system\(size:\s*\d+(?:\.\d+)?'
+    message: "Nutze SymiTypography-Tokens statt roher Font-Größen."
+    severity: warning
+
+  no_magic_minimum_scale_factor:
+    name: "Keine rohen Minimum-Scale-Faktoren"
+    regex: '\.minimumScaleFactor\(\d+(?:\.\d+)?\)'
+    message: "Nutze SymiTypography-Tokens statt roher Minimum-Scale-Faktoren."
+    severity: warning

--- a/Symi/Sources/App/AppShellView.swift
+++ b/Symi/Sources/App/AppShellView.swift
@@ -45,7 +45,7 @@ struct AppShellView: View {
             }
         }
         .tint(AppTheme.symiPetrol)
-        .toolbarBackground(AppTheme.symiPetrol.opacity(0.96), for: .navigationBar)
+        .toolbarBackground(AppTheme.symiPetrol.opacity(SymiOpacity.strongSurface), for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
             appContainer.startDeferredMaintenanceIfNeeded()
@@ -132,7 +132,7 @@ private struct RegularDetailSurface<Content: View>: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: SymiSpacing.zero) {
             Divider()
 
             content

--- a/Symi/Sources/App/StoreRecovery.swift
+++ b/Symi/Sources/App/StoreRecovery.swift
@@ -174,7 +174,7 @@ struct StoreRecoveryView: View {
         NavigationStack {
             Form {
                 Section {
-                    VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.md) {
                         Label("Lokale Daten wurden nicht gelöscht", systemImage: "externaldrive.badge.exclamationmark")
                             .font(.headline)
                             .foregroundStyle(AppTheme.symiPetrol)
@@ -187,7 +187,7 @@ struct StoreRecoveryView: View {
                             .font(.subheadline)
                             .foregroundStyle(AppTheme.symiTextSecondary)
                     }
-                    .padding(.vertical, 6)
+                    .padding(.vertical, SymiSpacing.compact)
                 }
 
                 Section("Sicherung und Migration") {

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -27,7 +27,7 @@ struct SymiApp: App {
             )
         }
         #if targetEnvironment(macCatalyst)
-        .defaultSize(width: 1280, height: 800)
+        .defaultSize(width: SymiSize.defaultWindowWidth, height: SymiSize.defaultWindowHeight)
         .windowResizability(.contentSize)
         #endif
     }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -536,7 +536,7 @@ private struct EntryReviewStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            VStack(spacing: 12) {
+            VStack(spacing: SymiSpacing.md) {
                 ReviewSummaryCard(
                     metadata: InputFlowStepCatalog.metadata(for: .headache),
                     lines: headacheSummary,
@@ -713,7 +713,7 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
             InputFlowBackground()
                 .ignoresSafeArea()
 
-            VStack(spacing: 0) {
+            VStack(spacing: SymiSpacing.zero) {
                 InputFlowHeader(
                     step: step.inputFlowStepID,
                     currentStep: currentIndex,
@@ -727,7 +727,7 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
                         Text(step.rawValue)
                             .font(.caption2)
                             .foregroundStyle(.clear)
-                            .frame(width: 1, height: 1)
+                            .frame(width: SymiSize.accessibilityMarker, height: SymiSize.accessibilityMarker)
                             .accessibilityElement()
                             .accessibilityLabel("Flow-Schritt \(step.rawValue)")
                             .accessibilityIdentifier("entry-flow-step-\(step.rawValue)")
@@ -735,8 +735,8 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
                         content
                     }
                     .padding(.horizontal, SymiSpacing.flowHorizontalPadding)
-                    .padding(.top, 8)
-                    .padding(.bottom, 24)
+                    .padding(.top, SymiSpacing.xs)
+                    .padding(.bottom, SymiSpacing.xxxl)
                     .frame(maxWidth: SymiSpacing.flowMaxContentWidth, alignment: .leading)
                     .frame(maxWidth: .infinity)
                 }
@@ -762,10 +762,10 @@ private struct EntryContinuousMedicationBlock: View {
 
     var body: some View {
         InputFlowFieldGroup(title: "Dauermedikation") {
-            VStack(spacing: 10) {
+            VStack(spacing: SymiSpacing.sm) {
                 ForEach($checks) { $check in
                     Toggle(isOn: $check.wasTaken) {
-                        VStack(alignment: .leading, spacing: 3) {
+                        VStack(alignment: .leading, spacing: SymiSpacing.chevronTopPadding) {
                             Text(check.name)
                                 .font(.subheadline.weight(.semibold))
                             if !check.detailText.isEmpty {
@@ -776,7 +776,7 @@ private struct EntryContinuousMedicationBlock: View {
                         }
                     }
                     .toggleStyle(.switch)
-                    .frame(minHeight: 44)
+                    .frame(minHeight: SymiSize.minInteractiveHeight)
                     .accessibilityLabel("\(check.name) heute genommen")
                 }
             }
@@ -793,10 +793,13 @@ private struct EntryInfoBanner: View {
         Label(text, systemImage: "info.circle")
             .font(.footnote.weight(.medium))
             .foregroundStyle(NewEntryStepColorToken.blue.color)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
+            .padding(.horizontal, SymiSpacing.lg)
+            .padding(.vertical, SymiSpacing.secondaryButtonVerticalPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(NewEntryStepColorToken.blue.softFill(for: colorScheme), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .background(
+                NewEntryStepColorToken.blue.softFill(for: colorScheme),
+                in: RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous)
+            )
             .accessibilityIdentifier("entry-trigger-info")
     }
 }
@@ -812,9 +815,9 @@ private struct EntryNoteCard: View {
                 TextEditor(text: $notes)
                     .font(.callout)
                     .scrollContentBackground(.hidden)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 4)
-                    .frame(minHeight: 220)
+                    .padding(.horizontal, SymiSpacing.xxs)
+                    .padding(.vertical, SymiSpacing.xxs)
+                    .frame(minHeight: SymiSize.noteEditorMinHeight)
                     .onChange(of: notes) { _, newValue in
                         if newValue.count > limit {
                             notes = String(newValue.prefix(limit))
@@ -824,14 +827,14 @@ private struct EntryNoteCard: View {
                     .accessibilityIdentifier("entry-note-text")
 
                 if notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.sm) {
                         Text("Was hat geholfen?")
                         Text("Was war heute anders?")
                     }
                     .font(.callout)
                     .foregroundStyle(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 10)
+                    .padding(.horizontal, SymiSpacing.sm)
+                    .padding(.vertical, SymiSpacing.sm)
                     .allowsHitTesting(false)
                 }
 
@@ -842,7 +845,7 @@ private struct EntryNoteCard: View {
                         Text("\(notes.count)/\(limit)")
                             .font(.caption.monospacedDigit())
                             .foregroundStyle(.secondary)
-                            .padding(8)
+                            .padding(SymiSpacing.xs)
                     }
                 }
             }
@@ -855,8 +858,8 @@ private struct EntryTodayLinkCard: View {
 
     var body: some View {
         InputFlowCard(theme: .note) {
-            HStack(spacing: 14) {
-                VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: SymiSpacing.secondaryButtonVerticalPadding) {
+                VStack(alignment: .leading, spacing: SymiSpacing.compact) {
                     Text("Zu heutigem Eintrag hinzufügen")
                         .font(.subheadline.weight(.semibold))
                     Text("Diese Notiz wird mit deinem Eintrag von heute verknüpft.")
@@ -865,14 +868,14 @@ private struct EntryTodayLinkCard: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                Spacer(minLength: 8)
+                Spacer(minLength: SymiSpacing.xs)
 
                 Toggle("Zu heutigem Eintrag hinzufügen", isOn: $isOn)
                     .labelsHidden()
                     .tint(InputFlowStepTheme.note.accent)
                     .accessibilityIdentifier("entry-note-link-toggle")
             }
-            .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: SymiSize.medicationRowMinHeight, alignment: .leading)
         }
     }
 }
@@ -908,7 +911,7 @@ private struct EntryFlowFooter: View {
     }
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: SymiSpacing.md) {
             InputFlowPrimaryButton(
                 title: primaryTitle,
                 systemImage: primarySystemImage,
@@ -943,9 +946,12 @@ private struct EntryPatternHint: View {
             Image(systemName: "sparkles")
                 .foregroundStyle(NewEntryStepColorToken.purple.color)
         }
-        .padding(16)
+        .padding(SymiSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(NewEntryStepColorToken.purple.softFill(for: colorScheme), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .background(
+            NewEntryStepColorToken.purple.softFill(for: colorScheme),
+            in: RoundedRectangle(cornerRadius: SymiRadius.flowBanner, style: .continuous)
+        )
         .accessibilityIdentifier("entry-review-pattern-hint")
     }
 }

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -167,7 +167,7 @@ private struct EpisodeScaleSection: View {
             }
             .pickerStyle(.segmented)
 
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: SymiSpacing.md) {
                 HStack {
                     Text("Intensität")
                     Spacer()
@@ -324,12 +324,12 @@ struct MedicationDefinitionGroupList: View {
                 description: Text("Passe den Suchbegriff an oder füge ein eigenes Medikament hinzu.")
             )
         } else {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: SymiSpacing.lg) {
                 ForEach(controller.filteredMedicationGroups) { group in
                     MedicationDefinitionGroupView(group: group, controller: controller)
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, SymiSpacing.xxs)
             .formAlignedRow()
         }
     }
@@ -340,14 +340,14 @@ private struct MedicationDefinitionGroupView: View {
     let controller: EpisodeMedicationSelectionController
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
             Text(group.title)
                 .font(.headline)
 
             LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 220), spacing: 12, alignment: .top)],
+                columns: [GridItem(.adaptive(minimum: SymiSize.medicationGridMinWidth), spacing: SymiSpacing.md, alignment: .top)],
                 alignment: .leading,
-                spacing: 12
+                spacing: SymiSpacing.md
             ) {
                 ForEach(group.items) { definition in
                     MedicationDefinitionRow(
@@ -362,7 +362,7 @@ private struct MedicationDefinitionGroupView: View {
                     )
                 }
             }
-            .padding(12)
+            .padding(SymiSpacing.md)
             .brandCard()
 
             if let footer = group.footer {
@@ -384,7 +384,7 @@ struct SelectedMedicationsSection: View {
                 .foregroundStyle(.secondary)
                 .formAlignedRow()
         } else {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: SymiSpacing.xs) {
                 Text("Ausgewählt")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
@@ -430,14 +430,14 @@ private struct WeatherStatusContent: View {
                 description: Text("Beim Laden wird dein ungefährer Standort verwendet, um Wetterdaten für den Episodenzeitpunkt abzurufen.")
             )
         case .loading:
-            HStack(spacing: 12) {
+            HStack(spacing: SymiSpacing.md) {
                 ProgressView()
                 Text("Wetter wird ermittelt …")
                     .foregroundStyle(.secondary)
             }
-            .padding(.vertical, 8)
+            .padding(.vertical, SymiSpacing.xs)
         case .loaded(let weather):
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: SymiSpacing.xs) {
                 detailRow("Zustand", weather.condition)
                 if let temperature = weather.temperature {
                     detailRow("Temperatur", temperature.formatted(.number.precision(.fractionLength(1))) + " °C")
@@ -456,9 +456,9 @@ private struct WeatherStatusContent: View {
                 }
                 WeatherAttributionView()
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, SymiSpacing.xxs)
         case .unavailable(let message):
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: SymiSpacing.md) {
                 Label(message, systemImage: "location.slash")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -474,12 +474,12 @@ private struct WeatherStatusContent: View {
                     .buttonStyle(SymiSecondaryButtonStyle())
                 }
             }
-            .padding(.vertical, 8)
+            .padding(.vertical, SymiSpacing.xs)
         }
     }
 
     private func detailRow(_ title: String, _ value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
             Text(title)
                 .font(.subheadline.weight(.semibold))
             Text(value)
@@ -501,7 +501,7 @@ struct IntensityPicker: View {
     @Binding var value: Double
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
             Slider(value: $value, in: 1 ... 10, step: 1)
                 .tint(AppTheme.symiCoral)
                 .accessibilityLabel("Intensität")
@@ -529,15 +529,15 @@ private struct MedicationDefinitionRow: View {
     let onDelete: (() -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
             Button(action: onToggle) {
-                HStack(alignment: .center, spacing: 12) {
+                HStack(alignment: .center, spacing: SymiSpacing.md) {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .imageScale(.large)
                         .foregroundStyle(isSelected ? AppTheme.ocean : .primary)
-                        .frame(width: 28, alignment: .center)
+                        .frame(width: SymiSize.productInfoIconWidth, alignment: .center)
 
-                    VStack(alignment: .leading, spacing: 3) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.chevronTopPadding) {
                         Text(definition.name)
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(.primary)
@@ -556,7 +556,7 @@ private struct MedicationDefinitionRow: View {
             .buttonStyle(.plain)
 
             if isSelected {
-                HStack(spacing: 10) {
+                HStack(spacing: SymiSpacing.sm) {
                     Text("Anzahl")
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(.secondary)
@@ -571,7 +571,7 @@ private struct MedicationDefinitionRow: View {
 
                     Text("\(quantity)")
                         .font(.headline.monospacedDigit())
-                        .frame(minWidth: 24)
+                        .frame(minWidth: SymiSize.medicationQuantityMinWidth)
 
                     Button(action: onIncrease) {
                         Image(systemName: "plus.circle")
@@ -581,14 +581,21 @@ private struct MedicationDefinitionRow: View {
                 }
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .frame(maxWidth: .infinity, minHeight: isSelected ? 108 : 72, alignment: .leading)
+        .padding(.horizontal, SymiSpacing.lg)
+        .padding(.vertical, SymiSpacing.secondaryButtonVerticalPadding)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: isSelected ? SymiSize.selectedMedicationRowMinHeight : SymiSize.medicationRowMinHeight,
+            alignment: .leading
+        )
         .background(isSelected ? AppTheme.selectedFill : AppTheme.secondaryFill)
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous))
         .overlay {
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(isSelected ? AppTheme.ocean.opacity(0.24) : Color.white.opacity(0.45), lineWidth: 1)
+            RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous)
+                .stroke(
+                    isSelected ? AppTheme.ocean.opacity(SymiOpacity.selectedStroke) : AppTheme.symiOnAccent.opacity(SymiOpacity.outline),
+                    lineWidth: SymiStroke.hairline
+                )
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
@@ -687,8 +694,8 @@ private struct SelectedMedicationSummaryRow: View {
     let onRemove: () -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: SymiSpacing.md) {
+            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                 Text(draft.name)
                     .font(.headline)
                     .foregroundStyle(.primary)
@@ -706,13 +713,13 @@ private struct SelectedMedicationSummaryRow: View {
             }
             .accessibilityLabel("\(draft.name) abwählen")
         }
-        .padding(12)
+        .padding(SymiSpacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(AppTheme.secondaryFill)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous))
         .overlay {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.white.opacity(0.45), lineWidth: 1)
+            RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous)
+                .stroke(AppTheme.symiOnAccent.opacity(SymiOpacity.outline), lineWidth: SymiStroke.hairline)
         }
     }
 

--- a/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
+++ b/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
@@ -65,7 +65,7 @@ struct SelectionChip: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 8) {
+            HStack(spacing: SymiSpacing.xs) {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                     .imageScale(.medium)
 
@@ -76,15 +76,18 @@ struct SelectionChip: View {
 
                 Spacer(minLength: 0)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .padding(.horizontal, SymiSpacing.md)
+            .padding(.vertical, SymiSpacing.sm)
+            .frame(maxWidth: .infinity, minHeight: SymiSize.minInteractiveHeight, alignment: .leading)
             .background(isSelected ? colorToken.selectedFill(for: colorScheme) : colorToken.softFill(for: colorScheme))
             .foregroundStyle(isSelected ? colorToken.color(for: colorScheme) : Color.primary)
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous))
             .overlay {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(isSelected ? colorToken.border(for: colorScheme) : Color.secondary.opacity(0.18), lineWidth: 1)
+                RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous)
+                    .stroke(
+                        isSelected ? colorToken.border(for: colorScheme) : Color.secondary.opacity(SymiOpacity.secondaryFill),
+                        lineWidth: SymiStroke.hairline
+                    )
             }
         }
         .buttonStyle(.plain)
@@ -111,7 +114,10 @@ struct MultiSelectGrid: View {
     }
 
     var body: some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 140), spacing: 10)], spacing: 10) {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: SymiSize.multiSelectGridMinWidth), spacing: SymiSpacing.tileSpacing)],
+            spacing: SymiSpacing.tileSpacing
+        ) {
             ForEach(options, id: \.self) { option in
                 let isSelected = selection.contains(option)
 

--- a/Symi/Sources/Features/Export/DataExportView.swift
+++ b/Symi/Sources/Features/Export/DataExportView.swift
@@ -49,7 +49,7 @@ struct DataExportView: View {
             }
 
             Section("Zeitraum") {
-                HStack(spacing: 16) {
+                HStack(spacing: SymiSpacing.lg) {
                     dateField(title: "Von", selection: $controller.startDate)
                     dateField(title: "Bis", selection: $controller.endDate)
                 }
@@ -109,7 +109,7 @@ struct DataExportView: View {
     }
 
     private func dateField(title: String, selection: Binding<Date>) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: SymiSpacing.compact) {
             Text(title)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -18,7 +18,7 @@ struct SettingsView: View {
                 NavigationLink {
                     SyncStatusView(controller: controller)
                 } label: {
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.sm) {
                         HStack {
                             Text("Status")
                             Spacer()
@@ -29,13 +29,13 @@ struct SettingsView: View {
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
 
-                        HStack(spacing: 16) {
+                        HStack(spacing: SymiSpacing.lg) {
                             statValue(title: "Ausstehend", value: "\(controller.syncStatus.queuedUpdates)")
                             statValue(title: "Ungesynct", value: "\(controller.syncStatus.unsyncedRecords)")
                             statValue(title: "Konflikte", value: "\(controller.conflicts.count)")
                         }
                     }
-                    .padding(.vertical, 6)
+                    .padding(.vertical, SymiSpacing.compact)
                     .brandGroupedRow()
                 }
 
@@ -54,7 +54,7 @@ struct SettingsView: View {
                 NavigationLink {
                     SyncLogView(controller: controller)
                 } label: {
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                         Label("Sync-Protokoll", systemImage: "text.document")
                         Text(logSubtitle)
                             .font(.subheadline)
@@ -72,7 +72,7 @@ struct SettingsView: View {
                 NavigationLink {
                     AppleHealthSettingsView(controller: controller)
                 } label: {
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.sm) {
                         HStack {
                             Label("Apple Health", systemImage: "heart.text.square")
                             Spacer()
@@ -84,7 +84,7 @@ struct SettingsView: View {
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }
-                    .padding(.vertical, 6)
+                    .padding(.vertical, SymiSpacing.compact)
                     .brandGroupedRow()
                 }
             } header: {
@@ -178,17 +178,17 @@ struct SettingsView: View {
     }
 
     private var statusBadge: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: SymiSpacing.xs) {
             Circle()
                 .fill(statusColor)
-                .frame(width: 10, height: 10)
+                .frame(width: SymiSize.statusDot, height: SymiSize.statusDot)
             Text(controller.syncStatus.state.displayTitle)
                 .foregroundStyle(.secondary)
         }
     }
 
     private func statValue(title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: SymiSpacing.micro) {
             Text(value)
                 .font(.headline)
                 .foregroundStyle(.primary)
@@ -325,9 +325,9 @@ private struct ContinuousMedicationSettingsRow: View {
     let onEnd: (() -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
             HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                     Text(medication.name)
                         .font(.headline)
                     if !medication.detailText.isEmpty {
@@ -356,7 +356,7 @@ private struct ContinuousMedicationSettingsRow: View {
             }
             .buttonStyle(.borderless)
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, SymiSpacing.xxs)
         .brandGroupedRow()
     }
 
@@ -515,7 +515,7 @@ private struct HealthDataTypeSection: View {
                     get: { enabledTypes.contains(definition.id) },
                     set: { onToggle($0, definition.id, direction) }
                 )) {
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                         Text(definition.displayName)
                         Text(definition.rationale)
                             .font(.caption)
@@ -542,13 +542,13 @@ private struct SyncStatusView: View {
                 statusRow("Letzter Upload", formatted(controller.syncStatus.lastUploadedAt))
 
                 if let lastError = controller.syncStatus.lastError {
-                    VStack(alignment: .leading, spacing: 6) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.compact) {
                         Text("Letzter Fehler")
                         Text(lastError)
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }
-                    .padding(.vertical, 4)
+                    .padding(.vertical, SymiSpacing.xxs)
                     .brandGroupedRow()
                 }
             } header: {
@@ -655,7 +655,7 @@ private struct ManageCloudDataView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(controller.conflicts) { conflict in
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
                             Text(conflictTitle(for: conflict))
                                 .font(.headline)
                             Text("Lokaler Stand und Cloud-Stand unterscheiden sich.")
@@ -668,7 +668,7 @@ private struct ManageCloudDataView: View {
                                 selectedConflict = conflict
                             }
                         }
-                        .padding(.vertical, 4)
+                        .padding(.vertical, SymiSpacing.xxs)
                         .brandGroupedRow()
                     }
                 }
@@ -681,7 +681,7 @@ private struct ManageCloudDataView: View {
                 } else {
                     ForEach(controller.deletedEpisodes) { episode in
                         HStack {
-                            VStack(alignment: .leading, spacing: 4) {
+                            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                                 Text(episode.startedAt.formatted(date: .abbreviated, time: .shortened))
                                 Text(episode.type.rawValue)
                                     .font(.subheadline)
@@ -697,7 +697,7 @@ private struct ManageCloudDataView: View {
 
                     ForEach(controller.deletedDefinitions) { definition in
                         HStack {
-                            VStack(alignment: .leading, spacing: 4) {
+                            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                                 Text(definition.name)
                                 Text(definition.category.rawValue)
                                     .font(.subheadline)
@@ -719,8 +719,8 @@ private struct ManageCloudDataView: View {
         .overlay {
             if isResolvingConflict {
                 ProgressView("Konflikt wird verarbeitet …")
-                    .padding(20)
-                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .padding(SymiSpacing.xxl)
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: SymiRadius.flowBanner, style: .continuous))
             }
         }
         .confirmationDialog(

--- a/Symi/Sources/Features/Export/PDFExportWriter.swift
+++ b/Symi/Sources/Features/Export/PDFExportWriter.swift
@@ -9,8 +9,7 @@ nonisolated enum PDFExportWriter {
     static func write(summary: ExportPeriodSummary, mode: PDFReportMode = .detailed) throws -> URL {
         let fileName = "\(localized("Symi-Bericht"))-\(dateStamp(summary.startDate))-\(dateStamp(summary.endDate)).pdf"
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
-        let pageRect = CGRect(x: 0, y: 0, width: 595, height: 842)
-        let layout = PDFLayout(pageRect: pageRect)
+        let layout = PDFLayout(pageRect: PDFLayout.defaultPageRect)
 
         try writeRawPDF(summary: summary, mode: mode, to: url, layout: layout)
         try finalizeDocument(at: url)
@@ -385,6 +384,10 @@ nonisolated private struct PDFChartRow {
 }
 
 nonisolated private struct PDFLayout {
+    static let defaultPageWidth: CGFloat = 595
+    static let defaultPageHeight: CGFloat = 842
+    static let defaultPageRect = CGRect(x: 0, y: 0, width: defaultPageWidth, height: defaultPageHeight)
+
     let pageRect: CGRect
     let margin: CGFloat = 40
     let logoSize: CGFloat = 44
@@ -403,11 +406,37 @@ nonisolated private struct PDFLayout {
     let separatorColor = CGColor(gray: 0.82, alpha: 1)
     let lineSpacing: CGFloat = 5
     let footerHeight: CGFloat = 108
+    let headerTopInset: CGFloat = 72
+    let footerTopInset: CGFloat = 10
+    let headerHeight: CGFloat = 48
+    let headerTextTopOffset: CGFloat = 2
+    let headerTextGap: CGFloat = 12
+    let panelHeight: CGFloat = 92
+    let panelInset: CGFloat = 12
+    let panelTextInset: CGFloat = 14
+    let panelTitleTopOffset: CGFloat = 14
+    let panelTitleHeight: CGFloat = 16
+    let panelBodyTopOffset: CGFloat = 34
+    let panelBodyHeight: CGFloat = 18
+    let panelLinkTopOffset: CGFloat = 48
+    let panelLinkHeight: CGFloat = 30
+    let chartMaxRows = 8
+    let chartRowHeight: CGFloat = 18
+    let chartTitleHeight: CGFloat = 24
+    let chartBottomPadding: CGFloat = 10
+    let chartLabelWidth: CGFloat = 132
+    let chartValueWidth: CGFloat = 60
+    let chartBarGap: CGFloat = 12
+    let chartBarInset: CGFloat = 4
+    let chartBarHeight: CGFloat = 8
+    let chartMinFillWidth: CGFloat = 2
+    let separatorHeight: CGFloat = 1
+    let panelCornerRadius: CGFloat = 6
 
     var contentWidth: CGFloat { pageRect.width - (margin * 2) }
-    var topY: CGFloat { margin + 72 }
+    var topY: CGFloat { margin + headerTopInset }
     var bottomY: CGFloat { pageRect.height - margin - footerHeight }
-    var footerTopY: CGFloat { pageRect.height - margin - footerHeight + 10 }
+    var footerTopY: CGFloat { pageRect.height - margin - footerHeight + footerTopInset }
 
     init(pageRect: CGRect) {
         self.pageRect = pageRect
@@ -458,8 +487,7 @@ nonisolated private struct PDFPageContext {
     }
 
     mutating func drawBrandHeader(title: String, logo: CGImage?) throws {
-        let headerHeight: CGFloat = 48
-        ensureSpace(headerHeight + 12)
+        ensureSpace(layout.headerHeight + layout.headerTextGap)
         let headerTop = cursorY
 
         if let logo {
@@ -469,19 +497,24 @@ nonisolated private struct PDFPageContext {
             drawLogoFallback(in: CGRect(x: layout.margin, y: headerTop, width: layout.logoSize, height: layout.logoSize))
         }
 
-        let textX = layout.margin + layout.logoSize + 12
-        let textWidth = layout.contentWidth - layout.logoSize - 12
+        let textX = layout.margin + layout.logoSize + layout.headerTextGap
+        let textWidth = layout.contentWidth - layout.logoSize - layout.headerTextGap
         try draw(
             text: title,
             font: layout.titleFont,
             color: layout.textColor,
-            rect: CGRect(x: textX, y: headerTop + 2, width: textWidth, height: height(for: title, font: layout.titleFont)),
+            rect: CGRect(
+                x: textX,
+                y: headerTop + layout.headerTextTopOffset,
+                width: textWidth,
+                height: height(for: title, font: layout.titleFont)
+            ),
             extraSpacing: 0
         )
 
-        cursorY = headerTop + headerHeight
+        cursorY = headerTop + layout.headerHeight
         drawSeparator()
-        addSpacing(14)
+        addSpacing(layout.panelTextInset)
     }
 
     mutating func drawSectionTitle(_ text: String) throws {
@@ -493,13 +526,12 @@ nonisolated private struct PDFPageContext {
     }
 
     mutating func drawAppStorePanel(title: String, body: String, linkLabel: String, url: String, qrCode: CGImage?) throws {
-        let panelHeight: CGFloat = 92
-        let panelRect = CGRect(x: layout.margin, y: layout.footerTopY, width: layout.contentWidth, height: panelHeight)
+        let panelRect = CGRect(x: layout.margin, y: layout.footerTopY, width: layout.contentWidth, height: layout.panelHeight)
         drawPanelBackground(panelRect)
 
         let qrRect = CGRect(
-            x: panelRect.maxX - layout.qrCodeSize - 12,
-            y: panelRect.minY + 12,
+            x: panelRect.maxX - layout.qrCodeSize - layout.panelInset,
+            y: panelRect.minY + layout.panelInset,
             width: layout.qrCodeSize,
             height: layout.qrCodeSize
         )
@@ -507,30 +539,63 @@ nonisolated private struct PDFPageContext {
             drawImage(qrCode, in: qrRect)
         }
 
-        let textX = panelRect.minX + 14
-        let textWidth = qrRect.minX - textX - 14
-        try draw(text: title, font: layout.brandFont, color: layout.textColor, rect: CGRect(x: textX, y: panelRect.minY + 14, width: textWidth, height: 16), extraSpacing: 0)
+        let textX = panelRect.minX + layout.panelTextInset
+        let textWidth = qrRect.minX - textX - layout.panelTextInset
+        try draw(
+            text: title,
+            font: layout.brandFont,
+            color: layout.textColor,
+            rect: CGRect(
+                x: textX,
+                y: panelRect.minY + layout.panelTitleTopOffset,
+                width: textWidth,
+                height: layout.panelTitleHeight
+            ),
+            extraSpacing: 0
+        )
         if !body.isEmpty {
-            try draw(text: body, font: layout.bodyFont, color: layout.textColor, rect: CGRect(x: textX, y: panelRect.minY + 34, width: textWidth, height: 18), extraSpacing: 0)
+            try draw(
+                text: body,
+                font: layout.bodyFont,
+                color: layout.textColor,
+                rect: CGRect(
+                    x: textX,
+                    y: panelRect.minY + layout.panelBodyTopOffset,
+                    width: textWidth,
+                    height: layout.panelBodyHeight
+                ),
+                extraSpacing: 0
+            )
         }
-        try draw(text: "\(linkLabel): \(url)", font: layout.smallFont, color: layout.mutedTextColor, rect: CGRect(x: textX, y: panelRect.minY + 48, width: textWidth, height: 30), extraSpacing: 0)
+        try draw(
+            text: "\(linkLabel): \(url)",
+            font: layout.smallFont,
+            color: layout.mutedTextColor,
+            rect: CGRect(
+                x: textX,
+                y: panelRect.minY + layout.panelLinkTopOffset,
+                width: textWidth,
+                height: layout.panelLinkHeight
+            ),
+            extraSpacing: 0
+        )
     }
 
     mutating func drawHorizontalBarChart(title: String, rows: [PDFChartRow], maximumValue: Int? = nil) throws {
         guard !rows.isEmpty else { return }
 
-        let chartRows = Array(rows.prefix(8))
-        let rowHeight: CGFloat = 18
-        let chartHeight = 24 + (CGFloat(chartRows.count) * rowHeight) + 10
+        let chartRows = Array(rows.prefix(layout.chartMaxRows))
+        let rowHeight = layout.chartRowHeight
+        let chartHeight = layout.chartTitleHeight + (CGFloat(chartRows.count) * rowHeight) + layout.chartBottomPadding
         ensureSpace(chartHeight)
 
         try draw(text: title, font: layout.brandFont, extraSpacing: 8)
 
         let maxValue = max(maximumValue ?? chartRows.map(\.value).max() ?? 1, 1)
-        let labelWidth: CGFloat = 132
-        let valueWidth: CGFloat = 60
+        let labelWidth = layout.chartLabelWidth
+        let valueWidth = layout.chartValueWidth
         let barX = layout.margin + labelWidth
-        let barWidth = layout.contentWidth - labelWidth - valueWidth - 12
+        let barWidth = layout.contentWidth - labelWidth - valueWidth - layout.chartBarGap
 
         for row in chartRows {
             let rowTop = cursorY
@@ -538,20 +603,28 @@ nonisolated private struct PDFPageContext {
                 text: row.label,
                 font: layout.smallFont,
                 color: layout.textColor,
-                rect: CGRect(x: layout.margin, y: rowTop, width: labelWidth - 8, height: rowHeight),
+                rect: CGRect(x: layout.margin, y: rowTop, width: labelWidth - layout.chartBarHeight, height: rowHeight),
                 extraSpacing: 0
             )
 
-            let trackRect = CGRect(x: barX, y: rowTop + 4, width: barWidth, height: 8)
+            let trackRect = CGRect(
+                x: barX,
+                y: rowTop + layout.chartBarInset,
+                width: barWidth,
+                height: layout.chartBarHeight
+            )
             drawRect(trackRect, color: layout.chartTrackColor)
-            let filledWidth = max(2, barWidth * CGFloat(row.value) / CGFloat(maxValue))
-            drawRect(CGRect(x: barX, y: rowTop + 4, width: filledWidth, height: 8), color: layout.chartFillColor)
+            let filledWidth = max(layout.chartMinFillWidth, barWidth * CGFloat(row.value) / CGFloat(maxValue))
+            drawRect(
+                CGRect(x: barX, y: rowTop + layout.chartBarInset, width: filledWidth, height: layout.chartBarHeight),
+                color: layout.chartFillColor
+            )
 
             try draw(
                 text: row.detail,
                 font: layout.smallFont,
                 color: layout.mutedTextColor,
-                rect: CGRect(x: barX + barWidth + 8, y: rowTop, width: valueWidth, height: rowHeight),
+                rect: CGRect(x: barX + barWidth + layout.chartBarHeight, y: rowTop, width: valueWidth, height: rowHeight),
                 extraSpacing: 0
             )
 
@@ -575,9 +648,9 @@ nonisolated private struct PDFPageContext {
             try drawBodyLine(line)
         }
 
-        addSpacing(8)
+        addSpacing(layout.chartBarHeight)
         drawSeparator()
-        addSpacing(10)
+        addSpacing(layout.footerTopInset)
     }
 
     mutating func addSpacing(_ value: CGFloat) {
@@ -633,13 +706,18 @@ nonisolated private struct PDFPageContext {
         context.setFillColor(layout.brandFillColor)
         context.fillEllipse(in: pdfRect)
         context.setStrokeColor(layout.brandStrokeColor)
-        context.setLineWidth(1)
+        context.setLineWidth(layout.separatorHeight)
         context.strokeEllipse(in: pdfRect)
         context.restoreGState()
     }
 
     private func drawPanelBackground(_ rect: CGRect) {
-        let path = unsafe CGPath(roundedRect: pdfRect(fromTopLeftRect: rect), cornerWidth: 6, cornerHeight: 6, transform: nil)
+        let path = unsafe CGPath(
+            roundedRect: pdfRect(fromTopLeftRect: rect),
+            cornerWidth: layout.panelCornerRadius,
+            cornerHeight: layout.panelCornerRadius,
+            transform: nil
+        )
         context.saveGState()
         context.setFillColor(layout.brandFillColor)
         context.addPath(path)
@@ -659,7 +737,12 @@ nonisolated private struct PDFPageContext {
 
     private func drawSeparator() {
         let separatorRect = pdfRect(
-            fromTopLeftRect: CGRect(x: layout.margin, y: cursorY, width: layout.contentWidth, height: 1)
+            fromTopLeftRect: CGRect(
+                x: layout.margin,
+                y: cursorY,
+                width: layout.contentWidth,
+                height: layout.separatorHeight
+            )
         )
         context.saveGState()
         context.setFillColor(layout.separatorColor)

--- a/Symi/Sources/Features/Export/SyncLogView.swift
+++ b/Symi/Sources/Features/Export/SyncLogView.swift
@@ -50,11 +50,11 @@ struct SyncLogView: View {
                     )
                 } else {
                     ForEach(controller.logEntries) { entry in
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(alignment: .top, spacing: 10) {
+                        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
+                            HStack(alignment: .top, spacing: SymiSpacing.sm) {
                                 Image(systemName: iconName(for: entry.level))
                                     .foregroundStyle(color(for: entry.level))
-                                VStack(alignment: .leading, spacing: 4) {
+                                VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                                     Text(entry.operation)
                                         .font(.headline)
                                     Text(entry.message)
@@ -73,7 +73,7 @@ struct SyncLogView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
-                        .padding(.vertical, 4)
+                        .padding(.vertical, SymiSpacing.xxs)
                         .brandGroupedRow()
                     }
                 }

--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -116,7 +116,7 @@ struct EpisodeDetailView: View {
                 if !episode.medications.isEmpty {
                     Section("Medikamente") {
                         ForEach(episode.medications.sorted(by: { $0.takenAt < $1.takenAt })) { medication in
-                            VStack(alignment: .leading, spacing: 4) {
+                            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                                 HStack(alignment: .firstTextBaseline) {
                                     Text(medication.name)
                                         .font(.headline)
@@ -153,7 +153,7 @@ struct EpisodeDetailView: View {
                                         .foregroundStyle(.secondary)
                                 }
                             }
-                            .padding(.vertical, 2)
+                            .padding(.vertical, SymiSpacing.micro)
                             .brandGroupedRow()
                         }
                     }
@@ -190,7 +190,7 @@ struct EpisodeDetailView: View {
                         }
                         detailRow("Erfasst", weatherSnapshot.recordedAt.formatted(date: .abbreviated, time: .shortened))
                         WeatherAttributionView()
-                            .padding(.vertical, 4)
+                            .padding(.vertical, SymiSpacing.xxs)
                     }
                 }
 
@@ -216,7 +216,13 @@ struct EpisodeDetailView: View {
         ScrollView {
             if let episode {
                 LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 320), spacing: AppTheme.dashboardSpacing, alignment: .top)],
+                    columns: [
+                        GridItem(
+                            .adaptive(minimum: SymiSize.dashboardColumnMinWidth),
+                            spacing: AppTheme.dashboardSpacing,
+                            alignment: .top
+                        )
+                    ],
                     alignment: .leading,
                     spacing: AppTheme.dashboardSpacing
                 ) {
@@ -256,7 +262,7 @@ struct EpisodeDetailView: View {
                     if !episode.medications.isEmpty {
                         AdaptiveDashboardCard(title: "Medikamente") {
                             ForEach(episode.medications.sorted(by: { $0.takenAt < $1.takenAt })) { medication in
-                                VStack(alignment: .leading, spacing: 4) {
+                                VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                                     HStack(alignment: .firstTextBaseline) {
                                         Text(medication.name)
                                             .font(.headline)
@@ -268,8 +274,8 @@ struct EpisodeDetailView: View {
                                     Text(medicationHeadline(for: medication))
                                         .foregroundStyle(.secondary)
                                 }
-                                .padding(12)
-                                .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                .padding(SymiSpacing.md)
+                                .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous))
                             }
                         }
                     }
@@ -314,30 +320,30 @@ struct EpisodeDetailView: View {
                         }
                     }
                 }
-                .padding(24)
+                .padding(SymiSpacing.xxxl)
                 .wideContent()
             } else {
                 ContentUnavailableView("Episode nicht gefunden", systemImage: "exclamationmark.triangle")
-                    .frame(maxWidth: .infinity, minHeight: 360)
+                    .frame(maxWidth: .infinity, minHeight: SymiSize.emptyStateMinHeight)
             }
         }
         .brandScreen()
     }
 
     private func detailRow(_ title: String, _ value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
             Text(title)
             Text(value)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, SymiSpacing.micro)
         .brandGroupedRow()
         .accessibilityElement(children: .combine)
     }
 
     private func detailValue(_ title: String, _ value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
             Text(title)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
@@ -348,12 +354,16 @@ struct EpisodeDetailView: View {
     }
 
     private func tagFlow(_ values: [String]) -> some View {
-        LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 8)], alignment: .leading, spacing: 8) {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: SymiSize.tagGridMinWidth), spacing: SymiSpacing.xs)],
+            alignment: .leading,
+            spacing: SymiSpacing.xs
+        ) {
             ForEach(values, id: \.self) { value in
                 Text(value)
                     .font(.subheadline.weight(.medium))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
+                    .padding(.horizontal, SymiSpacing.md)
+                    .padding(.vertical, SymiSpacing.xs)
                     .background(AppTheme.secondaryFill, in: Capsule())
             }
         }

--- a/Symi/Sources/Features/History/HistoryView.swift
+++ b/Symi/Sources/Features/History/HistoryView.swift
@@ -106,7 +106,7 @@ struct HistoryView: View {
     }
 
     private var compactContent: some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xxl) {
             insightSection
             calendarSection
 
@@ -120,8 +120,8 @@ struct HistoryView: View {
 
             selectedDaySection
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 20)
+        .padding(.horizontal, SymiSpacing.lg)
+        .padding(.vertical, SymiSpacing.xxl)
     }
 
     private var regularContent: some View {
@@ -130,12 +130,12 @@ struct HistoryView: View {
                 insightSection
                 calendarSection
             }
-            .frame(minWidth: 420, maxWidth: 560, alignment: .top)
+            .frame(minWidth: SymiSize.historySidebarMinWidth, maxWidth: SymiSize.historySidebarMaxWidth, alignment: .top)
 
             selectedDaySection
                 .frame(maxWidth: .infinity, alignment: .top)
         }
-        .padding(24)
+        .padding(SymiSpacing.xxxl)
         .wideContent()
     }
 
@@ -144,7 +144,7 @@ struct HistoryView: View {
             title: "Kalender",
             footer: "Weiche Punkte zeigen Tage mit Einträgen. Wähle einen Tag, um Details zu sehen."
         ) {
-            VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: SymiSpacing.lg) {
                 MonthHeader(
                     month: controller.displayedMonth,
                     onPrevious: controller.goToPreviousMonth,
@@ -165,7 +165,7 @@ struct HistoryView: View {
 
     private var insightSection: some View {
         contentSection(title: "Verstehen") {
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: SymiSpacing.secondaryButtonVerticalPadding) {
                 Text(insightTitle)
                     .font(.title3.weight(.bold))
                     .foregroundStyle(AppTheme.symiPetrol)
@@ -180,7 +180,7 @@ struct HistoryView: View {
                 .pickerStyle(.segmented)
 
                 SoftTrendChart(values: recentIntensityValues)
-                    .frame(height: 88)
+                    .frame(height: SymiSize.trendChartHeight)
                     .accessibilityLabel("Sanfte Verlaufsgrafik deiner letzten Einträge")
             }
         }
@@ -188,7 +188,7 @@ struct HistoryView: View {
 
     private var selectedDaySection: some View {
         contentSection(title: "Ausgewählter Tag") {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: SymiSpacing.md) {
                 daySummary
 
                 if controller.selectedDayEpisodes.isEmpty {
@@ -223,14 +223,14 @@ struct HistoryView: View {
 
     @ViewBuilder
     private func contentSection<Content: View>(title: String, footer: String? = nil, @ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
             Text(title)
                 .font(.headline)
 
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: SymiSpacing.md) {
                 content()
             }
-            .padding(16)
+            .padding(SymiSpacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)
             .brandCard()
 
@@ -243,7 +243,7 @@ struct HistoryView: View {
     }
 
     private var daySummary: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: SymiSpacing.compact) {
             Text(controller.daySummary.date.formatted(date: .complete, time: .omitted))
                 .font(.headline)
 
@@ -257,7 +257,7 @@ struct HistoryView: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, SymiSpacing.micro)
         .accessibilityElement(children: .combine)
     }
 
@@ -311,7 +311,7 @@ private struct EpisodeRow: View {
     let episode: EpisodeRecord
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: SymiSpacing.compact) {
             Text(episode.startedAt.formatted(date: .abbreviated, time: .omitted))
                 .font(.headline)
 
@@ -328,7 +328,7 @@ private struct EpisodeRow: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, SymiSpacing.micro)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilitySummary)
         .accessibilityHint("Öffnet die Detailansicht des Eintrags.")
@@ -373,8 +373,8 @@ private struct MonthHeader: View {
             Button(action: onPrevious) {
                 Image(systemName: "chevron.left")
             }
-            .padding(10)
-            .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .padding(SymiSpacing.sm)
+            .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous))
             .accessibilityLabel("Vorheriger Monat")
 
             Spacer()
@@ -388,12 +388,12 @@ private struct MonthHeader: View {
             Button(action: onNext) {
                 Image(systemName: "chevron.right")
             }
-            .padding(10)
-            .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .padding(SymiSpacing.sm)
+            .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous))
             .accessibilityLabel("Nächster Monat")
         }
         .buttonStyle(.plain)
-        .padding(.vertical, 4)
+        .padding(.vertical, SymiSpacing.xxs)
     }
 }
 
@@ -402,11 +402,11 @@ private struct MonthGrid: View {
     @Binding var selectedDay: Date
     let episodesByDay: [Date: [EpisodeRecord]]
 
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 7)
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: SymiSpacing.xs), count: 7)
 
     var body: some View {
-        VStack(spacing: 12) {
-            LazyVGrid(columns: columns, spacing: 8) {
+        VStack(spacing: SymiSpacing.md) {
+            LazyVGrid(columns: columns, spacing: SymiSpacing.xs) {
                 ForEach(weekdaySymbols, id: \.self) { symbol in
                     Text(symbol)
                         .font(.caption.weight(.semibold))
@@ -428,7 +428,7 @@ private struct MonthGrid: View {
                         .buttonStyle(.plain)
                     } else {
                         Color.clear
-                            .frame(height: 44)
+                            .frame(height: SymiSize.calendarWeekdayHeight)
                     }
                 }
             }
@@ -472,23 +472,23 @@ private struct DayCell: View {
     let peakIntensity: Int
 
     var body: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: SymiSpacing.xxs) {
             Text(date.formatted(.dateTime.day()))
                 .font(.subheadline.weight(.semibold))
 
             if episodeCount > 0 {
                 Circle()
                     .fill(intensityColor)
-                    .frame(width: 9, height: 9)
+                    .frame(width: SymiSize.calendarDot, height: SymiSize.calendarDot)
             } else {
                 Spacer()
-                    .frame(height: 16)
+                    .frame(height: SymiSize.calendarPlaceholderHeight)
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 52)
-        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, minHeight: SymiSize.calendarDayMinHeight)
+        .padding(.vertical, SymiSpacing.compact)
         .background(isSelected ? AppTheme.selectedFill : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(isSelected ? "Ausgewählt" : "")
@@ -525,8 +525,8 @@ private struct SoftTrendChart: View {
             let points = chartPoints(in: proxy.size)
 
             ZStack(alignment: .bottomLeading) {
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(AppTheme.symiSage.opacity(0.16))
+                RoundedRectangle(cornerRadius: SymiRadius.flowBanner, style: .continuous)
+                    .fill(AppTheme.symiSage.opacity(SymiOpacity.softFill))
 
                 Path { path in
                     guard let first = points.first else { return }
@@ -535,13 +535,16 @@ private struct SoftTrendChart: View {
                         path.addLine(to: point)
                     }
                 }
-                .stroke(AppTheme.symiPetrol, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+                .stroke(
+                    AppTheme.symiPetrol,
+                    style: StrokeStyle(lineWidth: SymiStroke.trendLine, lineCap: .round, lineJoin: .round)
+                )
 
                 ForEach(Array(points.enumerated()), id: \.offset) { _, point in
                     Circle()
                         .fill(AppTheme.symiCard)
-                        .frame(width: 9, height: 9)
-                        .overlay(Circle().stroke(AppTheme.symiPetrol, lineWidth: 2))
+                        .frame(width: SymiSize.calendarDot, height: SymiSize.calendarDot)
+                        .overlay(Circle().stroke(AppTheme.symiPetrol, lineWidth: SymiSpacing.micro))
                         .position(point)
                 }
             }

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -47,7 +47,7 @@ struct HomeView: View {
 
     private var compactDashboard: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: SymiSpacing.xl) {
                 DiaryWelcomeCard(overview: overview)
 
                 Button {
@@ -60,7 +60,7 @@ struct HomeView: View {
                 FeelingCheckInCard()
 
                 AdaptiveDashboardCard(title: "Vertrauen") {
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: SymiSpacing.sm) {
                         Label("Deine Daten gehören dir.", systemImage: "lock")
                             .font(.headline)
                         Text("Symi bleibt lokal nutzbar. Sync und Export passieren nur, wenn du sie aktiv nutzt.")
@@ -69,8 +69,8 @@ struct HomeView: View {
                     }
                 }
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 18)
+            .padding(.horizontal, SymiSpacing.xxl)
+            .padding(.vertical, SymiSpacing.xl)
         }
         .brandScreen()
     }
@@ -79,8 +79,8 @@ struct HomeView: View {
         ScrollView {
             LazyVGrid(
                 columns: [
-                    GridItem(.flexible(minimum: 360), spacing: AppTheme.dashboardSpacing, alignment: .top),
-                    GridItem(.flexible(minimum: 320), spacing: AppTheme.dashboardSpacing, alignment: .top)
+                    GridItem(.flexible(minimum: SymiSize.dashboardWideColumnMinWidth), spacing: AppTheme.dashboardSpacing, alignment: .top),
+                    GridItem(.flexible(minimum: SymiSize.dashboardColumnMinWidth), spacing: AppTheme.dashboardSpacing, alignment: .top)
                 ],
                 alignment: .leading,
                 spacing: AppTheme.dashboardSpacing
@@ -91,9 +91,9 @@ struct HomeView: View {
 
                     AdaptiveDashboardCard(title: "Schnellaktionen") {
                         LazyVGrid(
-                            columns: [GridItem(.adaptive(minimum: 180), spacing: 12)],
+                            columns: [GridItem(.adaptive(minimum: SymiSize.dashboardActionColumnMinWidth), spacing: SymiSpacing.md)],
                             alignment: .leading,
-                            spacing: 12
+                            spacing: SymiSpacing.md
                         ) {
                             QuickActionTile("Eintragen", systemImage: "plus") {
                                 isPresentingEpisodeEditor = true
@@ -105,7 +105,7 @@ struct HomeView: View {
 
                 VStack(alignment: .leading, spacing: AppTheme.dashboardSpacing) {
                     AdaptiveDashboardCard(title: "Vertrauen") {
-                        VStack(alignment: .leading, spacing: 10) {
+                        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
                             Label("Deine Daten gehören dir.", systemImage: "lock")
                                 .font(.headline)
                             Text("Website und Support: symiapp.com")
@@ -116,7 +116,7 @@ struct HomeView: View {
 
                 }
             }
-            .padding(24)
+            .padding(SymiSpacing.xxxl)
             .wideContent()
         }
         .brandScreen()
@@ -145,17 +145,17 @@ struct AdaptiveDashboardCard<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: SymiSpacing.secondaryButtonVerticalPadding) {
             Text(title)
                 .font(.headline)
                 .accessibilityAddTraits(.isHeader)
 
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: SymiSpacing.md) {
                 content
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(18)
+        .padding(SymiSpacing.xl)
         .frame(maxWidth: .infinity, alignment: .leading)
         .brandCard()
     }
@@ -176,9 +176,9 @@ private struct QuickActionTile: View {
         Button(action: action) {
             Label(title, systemImage: systemImage)
                 .font(.subheadline.weight(.semibold))
-                .frame(maxWidth: .infinity, minHeight: 54, alignment: .leading)
-                .padding(.horizontal, 14)
-                .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .frame(maxWidth: .infinity, minHeight: SymiSize.primaryButtonHeight, alignment: .leading)
+                .padding(.horizontal, SymiSpacing.secondaryButtonVerticalPadding)
+                .background(AppTheme.secondaryFill, in: RoundedRectangle(cornerRadius: SymiRadius.chip, style: .continuous))
                 .foregroundStyle(AppTheme.symiPetrol)
         }
         .buttonStyle(.plain)
@@ -190,75 +190,82 @@ private struct DiaryWelcomeCard: View {
     let overview: HomeOverviewData
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xl) {
             HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: SymiSpacing.secondaryButtonVerticalPadding) {
                     Text(greeting)
                         .font(.title2.weight(.semibold))
                         .foregroundStyle(AppTheme.foam)
 
                     Text(ProductBranding.marketingClaim)
                         .font(.largeTitle.weight(.bold))
-                        .foregroundStyle(Color.white)
+                        .foregroundStyle(AppTheme.symiOnAccent)
 
                     Text(summaryDetail)
                         .font(.subheadline)
-                        .foregroundStyle(AppTheme.foam.opacity(0.86))
+                        .foregroundStyle(AppTheme.foam.opacity(SymiOpacity.heroSecondaryText))
 
                     if overview.episodeCount > 0 {
                         statsRow
                     }
                 }
 
-                Spacer(minLength: 12)
+                Spacer(minLength: SymiSpacing.md)
 
-                VStack(spacing: 10) {
+                VStack(spacing: SymiSpacing.sm) {
                     Image(systemName: "book.closed.fill")
                         .font(.title2)
                         .foregroundStyle(AppTheme.foam)
                 }
-                .frame(width: 90, height: 120, alignment: .top)
-                .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .frame(width: SymiSize.heroSymbolWidth, height: SymiSize.heroSymbolHeight, alignment: .top)
+                .background(
+                    AppTheme.symiOnAccent.opacity(SymiOpacity.faintSurface),
+                    in: RoundedRectangle(cornerRadius: SymiRadius.button, style: .continuous)
+                )
             }
         }
-        .padding(24)
+        .padding(SymiSpacing.xxxl)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(AppTheme.heroGradient)
         .overlay(alignment: .bottomLeading) {
             WaveAccent()
-                .stroke(AppTheme.foam.opacity(0.82), lineWidth: 8)
-                .frame(height: 54)
-                .offset(x: -10, y: 18)
+                .stroke(AppTheme.foam.opacity(SymiOpacity.heroPrimaryWave), lineWidth: SymiStroke.heroWavePrimary)
+                .frame(height: SymiSize.heroWavePrimaryHeight)
+                .offset(x: SymiSpacing.heroWavePrimaryOffsetX, y: SymiSpacing.heroWavePrimaryOffsetY)
         }
         .overlay(alignment: .bottomLeading) {
             WaveAccent()
-                .stroke(AppTheme.seaGlass.opacity(0.72), lineWidth: 5)
-                .frame(height: 44)
-                .offset(x: 6, y: 24)
+                .stroke(AppTheme.seaGlass.opacity(SymiOpacity.heroSecondaryWave), lineWidth: SymiStroke.heroWaveSecondary)
+                .frame(height: SymiSize.heroWaveSecondaryHeight)
+                .offset(x: SymiSpacing.heroWaveSecondaryOffsetX, y: SymiSpacing.heroWaveSecondaryOffsetY)
         }
         .overlay(alignment: .bottomLeading) {
             WaveAccent()
-                .stroke(AppTheme.coral.opacity(0.92), lineWidth: 4)
-                .frame(width: 132, height: 34)
-                .offset(x: -8, y: 28)
+                .stroke(AppTheme.coral.opacity(SymiOpacity.heroAccentWave), lineWidth: SymiStroke.heroWaveAccent)
+                .frame(width: SymiSize.heroWaveAccentWidth, height: SymiSize.heroWaveAccentHeight)
+                .offset(x: SymiSpacing.heroWaveAccentOffsetX, y: SymiSpacing.heroWaveAccentOffsetY)
         }
-        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .shadow(color: AppTheme.shadowColor.opacity(1.2), radius: 24, y: 12)
+        .clipShape(RoundedRectangle(cornerRadius: SymiRadius.heroCard, style: .continuous))
+        .shadow(color: AppTheme.shadowColor.opacity(SymiOpacity.elevatedShadow), radius: SymiRadius.heroCard, y: SymiSpacing.md)
         .accessibilityElement(children: .combine)
     }
 
     private var statsRow: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
+        HStack(alignment: .firstTextBaseline, spacing: SymiSpacing.md) {
             Text("Bisher dokumentiert")
                 .font(.subheadline.weight(.semibold))
-                .foregroundStyle(AppTheme.foam.opacity(0.96))
+                .foregroundStyle(AppTheme.foam.opacity(SymiOpacity.strongSurface))
 
             Spacer(minLength: 12)
 
             Text("\(overview.episodeCount) Eintrag\(overview.episodeCount == 1 ? "" : "e")")
                 .font(.title3.weight(.bold))
-                .foregroundStyle(Color.white)
-                .shadow(color: AppTheme.ink.opacity(0.35), radius: 3, y: 1)
+                .foregroundStyle(AppTheme.symiOnAccent)
+                .shadow(
+                    color: AppTheme.ink.opacity(SymiOpacity.selectedFill),
+                    radius: SymiShadow.heroTextRadius,
+                    y: SymiShadow.heroTextYOffset
+                )
         }
     }
 
@@ -296,10 +303,10 @@ private struct FeelingCheckInCard: View {
 
     var body: some View {
         AdaptiveDashboardCard(title: "Wie geht es dir heute?") {
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: SymiSpacing.secondaryButtonVerticalPadding) {
                 HStack(alignment: .firstTextBaseline) {
                     Text("\(Int(currentState))")
-                        .font(.system(size: 44, weight: .bold, design: .rounded))
+                        .font(SymiTypography.homeMetric)
                         .foregroundStyle(AppTheme.symiPetrol)
                     Text(feelingLabel)
                         .font(.headline)

--- a/Symi/Sources/Features/Home/ProductInformationView.swift
+++ b/Symi/Sources/Features/Home/ProductInformationView.swift
@@ -165,14 +165,14 @@ struct ProductInformationView: View {
 
     @ViewBuilder
     private func infoRow(title: LocalizedStringKey, detail: LocalizedStringKey, systemImage: String) -> some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .top, spacing: SymiSpacing.md) {
             Image(systemName: systemImage)
                 .font(.title3)
                 .foregroundStyle(.accent)
-                .frame(width: 28)
+                .frame(width: SymiSize.productInfoIconWidth)
                 .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: SymiSpacing.compact) {
                 Text(title)
                     .font(.headline)
                 Text(detail)
@@ -180,7 +180,7 @@ struct ProductInformationView: View {
                     .foregroundStyle(.secondary)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, SymiSpacing.xxs)
         .brandGroupedRow()
     }
 }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowActions.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowActions.swift
@@ -29,13 +29,13 @@ struct InputFlowPrimaryButton: View {
             ZStack {
                 if isLoading {
                     ProgressView()
-                        .tint(.white)
+                        .tint(AppTheme.symiOnAccent)
                 } else {
                     Text(title)
                         .font(SymiTypography.flowPrimaryButton)
                         .multilineTextAlignment(.center)
                         .lineLimit(2)
-                        .minimumScaleFactor(0.85)
+                        .minimumScaleFactor(SymiTypography.buttonScaleFactor)
 
                     HStack {
                         Spacer(minLength: 0)
@@ -43,14 +43,19 @@ struct InputFlowPrimaryButton: View {
                             .font(.headline.weight(.semibold))
                             .accessibilityHidden(true)
                     }
-                    .padding(.trailing, 18)
+                    .padding(.trailing, SymiSpacing.buttonTrailingIconPadding)
                 }
             }
-            .foregroundStyle(.white)
-            .padding(.horizontal, 18)
-            .frame(maxWidth: .infinity, minHeight: 54)
+            .foregroundStyle(AppTheme.symiOnAccent)
+            .padding(.horizontal, SymiSpacing.xl)
+            .frame(maxWidth: .infinity, minHeight: SymiSize.primaryButtonHeight)
             .background(buttonFill, in: Capsule())
-            .shadow(color: isDisabled ? .clear : SymiShadow.buttonColor, radius: SymiShadow.buttonRadius, x: 0, y: SymiShadow.buttonYOffset)
+            .shadow(
+                color: isDisabled ? .clear : SymiShadow.buttonColor,
+                radius: SymiShadow.buttonRadius,
+                x: SymiShadow.buttonXOffset,
+                y: SymiShadow.buttonYOffset
+            )
         }
         .buttonStyle(.plain)
         .disabled(isDisabled || isLoading)
@@ -58,7 +63,7 @@ struct InputFlowPrimaryButton: View {
     }
 
     private var buttonFill: Color {
-        (isDisabled || isLoading) ? AppTheme.symiPetrol.opacity(0.55) : AppTheme.symiPetrol
+        (isDisabled || isLoading) ? AppTheme.symiPetrol.opacity(SymiOpacity.disabledFill) : AppTheme.symiPetrol
     }
 }
 
@@ -84,9 +89,9 @@ struct InputFlowSecondaryAction: View {
         Button(title, action: action)
             .font(SymiTypography.flowSecondaryAction)
             .foregroundStyle(AppTheme.symiPetrol)
-            .frame(minHeight: 44)
+            .frame(minHeight: SymiSize.minInteractiveHeight)
             .disabled(isDisabled)
-            .opacity(isDisabled ? 0.55 : 1)
+            .opacity(isDisabled ? SymiOpacity.disabledContent : SymiOpacity.opaque)
             .accessibilityIdentifier(accessibilityIdentifier ?? "input-flow-secondary")
     }
 }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowCard.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowCard.swift
@@ -24,24 +24,24 @@ struct InputFlowCard<Content: View>: View {
             .background(cardBackground, in: RoundedRectangle(cornerRadius: SymiRadius.flowCard, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: SymiRadius.flowCard, style: .continuous)
-                    .stroke(borderColor, lineWidth: 1)
+                    .stroke(borderColor, lineWidth: SymiStroke.hairline)
             }
-            .shadow(color: shadowColor, radius: SymiShadow.cardRadius, x: 0, y: SymiShadow.cardYOffset)
+            .shadow(color: shadowColor, radius: SymiShadow.cardRadius, x: SymiShadow.cardXOffset, y: SymiShadow.cardYOffset)
     }
 
     private var cardBackground: Color {
-        colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : SymiColors.card.color
+        SymiColors.elevatedCard(for: colorScheme)
     }
 
     private var borderColor: Color {
         guard isHighlighted, let theme else {
-            return Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.08)
+            return SymiColors.subtleSeparator(for: colorScheme)
         }
 
         return theme.border(for: colorScheme)
     }
 
     private var shadowColor: Color {
-        colorScheme == .dark ? .clear : SymiShadow.cardColor
+        colorScheme == .dark ? Color.clear : SymiShadow.cardColor
     }
 }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowHeader.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowHeader.swift
@@ -32,11 +32,11 @@ struct InputFlowHeader: View {
                     Image(systemName: "chevron.left")
                         .font(.headline.weight(.semibold))
                         .foregroundStyle(.primary)
-                        .frame(width: 44, height: 44)
+                        .frame(width: SymiSize.minInteractiveHeight, height: SymiSize.minInteractiveHeight)
                         .background(.thinMaterial, in: Circle())
                         .overlay {
                             Circle()
-                                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                                .stroke(Color.primary.opacity(SymiOpacity.hairline), lineWidth: SymiStroke.hairline)
                         }
                 }
                 .accessibilityLabel("Zurück")
@@ -47,7 +47,7 @@ struct InputFlowHeader: View {
                 Button("Abbrechen", action: onCancel)
                     .font(.callout.weight(.medium))
                     .foregroundStyle(AppTheme.symiPetrol)
-                    .frame(minHeight: 44)
+                    .frame(minHeight: SymiSize.minInteractiveHeight)
                     .accessibilityIdentifier("entry-flow-cancel")
             }
 
@@ -71,7 +71,7 @@ struct InputFlowHeader: View {
         }
         .padding(.horizontal, SymiSpacing.flowHorizontalPadding)
         .padding(.top, SymiSpacing.flowHeaderTopPadding)
-        .padding(.bottom, 8)
+        .padding(.bottom, SymiSpacing.xs)
         .frame(maxWidth: SymiSpacing.flowMaxContentWidth, alignment: .leading)
         .frame(maxWidth: .infinity)
     }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
@@ -10,7 +10,7 @@ struct InputFlowFieldGroup<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: SymiSpacing.md) {
             Text(title)
                 .font(SymiTypography.flowSectionTitle)
                 .foregroundStyle(.primary)
@@ -46,7 +46,7 @@ struct InputFlowPillGrid<Content: View>: View {
     let minimumColumnWidth: CGFloat
     let content: Content
 
-    init(minimumColumnWidth: CGFloat = 70, @ViewBuilder content: () -> Content) {
+    init(minimumColumnWidth: CGFloat = SymiSize.pillGridMinWidth, @ViewBuilder content: () -> Content) {
         self.minimumColumnWidth = minimumColumnWidth
         self.content = content()
     }
@@ -78,16 +78,16 @@ struct InputFlowBackground: View {
     private var colors: [Color] {
         if colorScheme == .dark {
             return [
-                Color(red: 0.08, green: 0.09, blue: 0.10),
-                Color(red: 0.06, green: 0.10, blue: 0.10),
-                Color(red: 0.10, green: 0.09, blue: 0.08)
+                SymiColors.darkBackgroundTop.color,
+                SymiColors.darkBackgroundMiddle.color,
+                SymiColors.darkBackgroundBottom.color
             ]
         }
 
         return [
             SymiColors.warmBackground.color,
-            Color.white,
-            SymiColors.sage.color.opacity(0.18)
+            SymiColors.onAccent.color,
+            SymiColors.sage.color.opacity(SymiOpacity.secondaryFill)
         ]
     }
 }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowPillOption.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowPillOption.swift
@@ -28,7 +28,7 @@ struct InputFlowPillOption: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 6) {
+            HStack(spacing: SymiSpacing.compact) {
                 if isSelected {
                     Image(systemName: "checkmark")
                         .font(.caption.weight(.bold))
@@ -39,19 +39,19 @@ struct InputFlowPillOption: View {
                     .font(SymiTypography.flowPillLabel)
                     .multilineTextAlignment(.center)
                     .lineLimit(2)
-                    .minimumScaleFactor(0.82)
+                    .minimumScaleFactor(SymiTypography.compactScaleFactor)
                     .fixedSize(horizontal: false, vertical: true)
             }
             .foregroundStyle(isSelected ? theme.accent(for: colorScheme) : .primary)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 9)
-            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.horizontal, SymiSpacing.md)
+            .padding(.vertical, SymiSpacing.pillVerticalPadding)
+            .frame(maxWidth: .infinity, minHeight: SymiSize.minInteractiveHeight)
             .background(backgroundColor, in: Capsule())
             .overlay {
                 Capsule()
-                    .stroke(borderColor, lineWidth: 1)
+                    .stroke(borderColor, lineWidth: SymiStroke.hairline)
             }
-            .opacity(isDisabled ? 0.55 : 1)
+            .opacity(isDisabled ? SymiOpacity.disabledContent : SymiOpacity.opaque)
         }
         .buttonStyle(.plain)
         .disabled(isDisabled)
@@ -66,7 +66,7 @@ struct InputFlowPillOption: View {
             return theme.selectedFill(for: colorScheme)
         }
 
-        return colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : SymiColors.card.color
+        return SymiColors.elevatedCard(for: colorScheme)
     }
 
     private var borderColor: Color {
@@ -74,6 +74,6 @@ struct InputFlowPillOption: View {
             return theme.border(for: colorScheme)
         }
 
-        return Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.08)
+        return SymiColors.subtleSeparator(for: colorScheme)
     }
 }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowProgressView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowProgressView.swift
@@ -14,45 +14,56 @@ struct InputFlowProgressView: View {
     }
 
     var body: some View {
-        HStack(spacing: 18) {
+        HStack(spacing: SymiSpacing.xl) {
             GeometryReader { proxy in
-                let indicatorSize: CGFloat = 24
+                let indicatorSize = SymiSize.progressIndicator
                 let trackWidth = max(proxy.size.width - indicatorSize, 1)
                 let xOffset = progressPosition(in: trackWidth)
                 let activeWidth = min(xOffset + indicatorSize / 2, proxy.size.width)
 
                 ZStack(alignment: .leading) {
                     Capsule()
-                        .fill(Color.primary.opacity(colorScheme == .dark ? 0.22 : 0.12))
-                        .frame(height: 4)
-                        .offset(y: indicatorSize / 2 - 2)
+                        .fill(
+                            Color.primary.opacity(
+                                colorScheme == .dark ? SymiOpacity.progressTrackDark : SymiOpacity.progressTrackLight
+                            )
+                        )
+                        .frame(height: SymiSpacing.xxs)
+                        .offset(y: indicatorSize / 2 - SymiSpacing.micro)
 
                     Capsule()
                         .fill(theme.accent(for: colorScheme))
-                        .frame(width: activeWidth, height: 4)
-                        .offset(y: indicatorSize / 2 - 2)
+                        .frame(width: activeWidth, height: SymiSpacing.xxs)
+                        .offset(y: indicatorSize / 2 - SymiSpacing.micro)
 
                     Text("\(clampedCurrentStep)")
                         .font(.caption.weight(.bold))
                         .monospacedDigit()
-                        .foregroundStyle(.white)
+                        .foregroundStyle(AppTheme.symiOnAccent)
                         .frame(width: indicatorSize, height: indicatorSize)
                         .background(theme.accent(for: colorScheme), in: Circle())
                         .overlay {
                             Circle()
-                                .stroke(.white.opacity(colorScheme == .dark ? 0.18 : 0.92), lineWidth: 1)
+                                .stroke(
+                                    AppTheme.symiOnAccent.opacity(
+                                        colorScheme == .dark
+                                            ? SymiOpacity.progressIndicatorStrokeDark
+                                            : SymiOpacity.progressIndicatorStrokeLight
+                                    ),
+                                    lineWidth: SymiStroke.hairline
+                                )
                         }
                         .offset(x: xOffset)
                         .accessibilityHidden(true)
                 }
             }
-            .frame(height: 24)
+            .frame(height: SymiSize.progressIndicator)
 
             Text("von \(safeTotalSteps)")
                 .font(.footnote.weight(.medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .minimumScaleFactor(0.82)
+                .minimumScaleFactor(SymiTypography.compactScaleFactor)
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Schritt \(clampedCurrentStep) von \(safeTotalSteps)")

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowSelectionTile.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowSelectionTile.swift
@@ -43,19 +43,19 @@ struct InputFlowSelectionTile: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(spacing: 10) {
+            VStack(spacing: SymiSpacing.sm) {
                 ZStack(alignment: .topTrailing) {
                     Image(systemName: systemImage)
                         .font(.title3.weight(.medium))
                         .foregroundStyle(iconColor)
-                        .frame(width: 34, height: 30)
+                        .frame(width: SymiSize.inputSelectionIconWidth, height: SymiSize.inputSelectionIconHeight)
 
                     if state.isSelected {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.caption.weight(.bold))
                             .foregroundStyle(theme.accent(for: colorScheme))
-                            .background(Color(uiColor: .systemBackground), in: Circle())
-                            .offset(x: 12, y: -6)
+                            .background(AppTheme.symiCard, in: Circle())
+                            .offset(x: SymiSpacing.selectedCheckOffsetX, y: SymiSpacing.selectedCheckOffsetY)
                             .accessibilityHidden(true)
                     }
                 }
@@ -65,18 +65,18 @@ struct InputFlowSelectionTile: View {
                     .multilineTextAlignment(.center)
                     .foregroundStyle(state.isDisabled ? .secondary : .primary)
                     .lineLimit(2)
-                    .minimumScaleFactor(0.82)
+                    .minimumScaleFactor(SymiTypography.compactScaleFactor)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 14)
-            .frame(maxWidth: .infinity, minHeight: 84)
+            .padding(.horizontal, SymiSpacing.sm)
+            .padding(.vertical, SymiSpacing.flowHeaderControlSpacing + SymiSpacing.xxs)
+            .frame(maxWidth: .infinity, minHeight: SymiSize.inputSelectionTileMinHeight)
             .background(tileBackground, in: RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous)
-                    .stroke(borderColor, lineWidth: state.isSelected ? 1.5 : 1)
+                    .stroke(borderColor, lineWidth: state.isSelected ? SymiStroke.selectedHairline : SymiStroke.hairline)
             }
-            .opacity(state.isDisabled ? 0.58 : 1)
+            .opacity(state.isDisabled ? SymiOpacity.disabledTile : SymiOpacity.opaque)
         }
         .buttonStyle(.plain)
         .disabled(state.isDisabled)
@@ -100,7 +100,7 @@ struct InputFlowSelectionTile: View {
             return theme.selectedFill(for: colorScheme)
         }
 
-        return colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : SymiColors.card.color
+        return SymiColors.elevatedCard(for: colorScheme)
     }
 
     private var borderColor: Color {
@@ -108,7 +108,7 @@ struct InputFlowSelectionTile: View {
             return theme.border(for: colorScheme)
         }
 
-        return Color.primary.opacity(colorScheme == .dark ? 0.16 : 0.08)
+        return SymiColors.subtleSeparator(for: colorScheme)
     }
 
     private var accessibilityValue: String {

--- a/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
@@ -18,7 +18,7 @@ struct PainGaugeView: View {
 
     var body: some View {
         InputFlowCard(theme: theme, isHighlighted: true) {
-            VStack(spacing: 18) {
+            VStack(spacing: SymiSpacing.xl) {
                 ZStack(alignment: .center) {
                     PainGaugeArc()
                         .stroke(
@@ -31,17 +31,17 @@ struct PainGaugeView: View {
                                 startPoint: .leading,
                                 endPoint: .trailing
                             ),
-                            style: StrokeStyle(lineWidth: 13, lineCap: .round)
+                            style: StrokeStyle(lineWidth: SymiStroke.painGaugeArc, lineCap: .round)
                         )
-                        .frame(width: 212, height: 142)
+                        .frame(width: SymiSize.painGaugeWidth, height: SymiSize.painGaugeHeight)
                         .accessibilityHidden(true)
 
-                    VStack(spacing: 4) {
+                    VStack(spacing: SymiSpacing.xxs) {
                         Text("\(normalizedValue)")
-                            .font(.system(size: 58, weight: .bold, design: .rounded))
+                            .font(SymiTypography.largeMetric)
                             .monospacedDigit()
                             .foregroundStyle(AppTheme.symiPetrol)
-                            .minimumScaleFactor(0.75)
+                            .minimumScaleFactor(SymiTypography.gaugeScaleFactor)
 
                         Text("/10")
                             .font(.headline)
@@ -50,14 +50,14 @@ struct PainGaugeView: View {
                         Text(intensityLabel)
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(theme.accent)
-                            .padding(.top, 8)
-                            .minimumScaleFactor(0.85)
+                            .padding(.top, SymiSpacing.xs)
+                            .minimumScaleFactor(SymiTypography.buttonScaleFactor)
                     }
-                    .padding(.top, 20)
+                    .padding(.top, SymiSpacing.xxl)
                 }
                 .frame(maxWidth: .infinity)
 
-                VStack(spacing: 8) {
+                VStack(spacing: SymiSpacing.xs) {
                     Slider(
                         value: Binding(
                             get: { Double(normalizedValue) },
@@ -107,8 +107,8 @@ struct PainGaugeView: View {
 
 private struct PainGaugeArc: Shape {
     func path(in rect: CGRect) -> Path {
-        let radius = min(rect.width / 2, rect.height) - 8
-        let center = CGPoint(x: rect.midX, y: rect.maxY - 8)
+        let radius = min(rect.width / 2, rect.height) - SymiSpacing.xs
+        let center = CGPoint(x: rect.midX, y: rect.maxY - SymiSpacing.xs)
         var path = Path()
         path.addArc(
             center: center,

--- a/Symi/Sources/Features/InputFlow/Components/ReviewSummaryCard.swift
+++ b/Symi/Sources/Features/InputFlow/Components/ReviewSummaryCard.swift
@@ -13,7 +13,7 @@ struct InputFlowStepIcon: View {
         Image(systemName: metadata.symbolName)
             .font(.title3.weight(.semibold))
             .foregroundStyle(metadata.theme.accent(for: colorScheme))
-            .frame(width: 44, height: 44)
+            .frame(width: SymiSize.reviewStepIcon, height: SymiSize.reviewStepIcon)
             .background(metadata.theme.iconBackground(for: colorScheme), in: Circle())
             .accessibilityHidden(true)
     }
@@ -58,11 +58,11 @@ struct ReviewSummaryCard: View {
 
     private var content: some View {
         InputFlowCard {
-            HStack(alignment: .top, spacing: 12) {
+            HStack(alignment: .top, spacing: SymiSpacing.md) {
                 InputFlowStepIcon(metadata)
-                    .frame(width: 42, height: 42)
+                    .frame(width: SymiSize.reviewSummaryIcon, height: SymiSize.reviewSummaryIcon)
 
-                VStack(alignment: .leading, spacing: 7) {
+                VStack(alignment: .leading, spacing: SymiSpacing.xs - SymiSize.accessibilityMarker) {
                     Text(metadata.title)
                         .font(SymiTypography.flowSummaryTitle)
 
@@ -81,13 +81,13 @@ struct ReviewSummaryCard: View {
                     }
                 }
 
-                Spacer(minLength: 8)
+                Spacer(minLength: SymiSpacing.xs)
 
                 if onEdit != nil {
                     Image(systemName: "chevron.right")
                         .font(.footnote.weight(.semibold))
                         .foregroundStyle(.secondary)
-                        .padding(.top, 3)
+                        .padding(.top, SymiSpacing.chevronTopPadding)
                         .accessibilityHidden(true)
                 }
             }

--- a/Symi/Sources/Features/InputFlow/Styling/InputFlowTheme.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/InputFlowTheme.swift
@@ -159,29 +159,29 @@ enum InputFlowStepColorToken: String, CaseIterable, Sendable {
     }
 
     func softFill(for colorScheme: ColorScheme) -> Color {
-        color(for: colorScheme).opacity(colorScheme == .dark ? 0.22 : 0.16)
+        color(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.progressTrackDark : SymiOpacity.softFill)
     }
 
     func selectedFill(for colorScheme: ColorScheme) -> Color {
-        color(for: colorScheme).opacity(colorScheme == .dark ? 0.30 : 0.24)
+        color(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.stepSelectedFillDark : SymiOpacity.selectedStroke)
     }
 
     func border(for colorScheme: ColorScheme) -> Color {
-        color(for: colorScheme).opacity(colorScheme == .dark ? 0.48 : 0.36)
+        color(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.stepBorderDark : SymiOpacity.stepBorderLight)
     }
 
     private var darkColorValue: SymiColorValue {
         switch self {
         case .coral:
-            SymiColorValue(hex: 0xFFA196)
+            SymiColors.coralDark
         case .sageTeal:
-            SymiColorValue(hex: 0xA9DEC9)
+            SymiColors.sageDark
         case .blue:
-            SymiColorValue(hex: 0x81A0F1)
+            SymiColors.triggerBlueDark
         case .warmAmber:
-            SymiColorValue(hex: 0xF0B867)
+            SymiColors.noteAmberDark
         case .purple:
-            SymiColorValue(hex: 0xB096F2)
+            SymiColors.reviewPurpleDark
         }
     }
 }

--- a/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
@@ -37,11 +37,31 @@ enum SymiColors {
     static let sage = SymiColorValue(hex: 0x8ECDB8)
     static let coral = SymiColorValue(hex: 0xFF8A7A)
     static let warmBackground = SymiColorValue(hex: 0xF6F4EF)
-    static let card = SymiColorValue(hex: 0xFFFFFF)
+    static let card = SymiColorValue(hex: 0xFFFEFB)
     static let textPrimary = SymiColorValue(hex: 0x1C1C1E)
     static let textSecondary = SymiColorValue(hex: 0x6B6B6E)
+    static let mist = SymiColorValue(hex: 0xECF7F4)
+    static let onAccent = SymiColorValue(hex: 0xFFFFFF)
 
     static let triggerBlue = SymiColorValue(hex: 0x4A78D9)
     static let noteAmber = SymiColorValue(hex: 0xD18A2B)
     static let reviewPurple = SymiColorValue(hex: 0x8A65D6)
+
+    static let coralDark = SymiColorValue(hex: 0xFFA196)
+    static let sageDark = SymiColorValue(hex: 0xA9DEC9)
+    static let triggerBlueDark = SymiColorValue(hex: 0x81A0F1)
+    static let noteAmberDark = SymiColorValue(hex: 0xF0B867)
+    static let reviewPurpleDark = SymiColorValue(hex: 0xB096F2)
+
+    static let darkBackgroundTop = SymiColorValue(hex: 0x14171A)
+    static let darkBackgroundMiddle = SymiColorValue(hex: 0x0F1A1A)
+    static let darkBackgroundBottom = SymiColorValue(hex: 0x1A1714)
+
+    static func elevatedCard(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : card.color
+    }
+
+    static func subtleSeparator(for colorScheme: ColorScheme) -> Color {
+        Color.primary.opacity(colorScheme == .dark ? SymiOpacity.softFill : SymiOpacity.hairline)
+    }
 }

--- a/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
@@ -1,6 +1,21 @@
 import SwiftUI
 
-enum SymiSpacing {
+nonisolated enum SymiSpacing {
+    static let xxs: CGFloat = 4
+    static let micro: CGFloat = 2
+    static let compact: CGFloat = 6
+    static let xs: CGFloat = 8
+    static let sm: CGFloat = 10
+    static let md: CGFloat = 12
+    static let lg: CGFloat = 16
+    static let xl: CGFloat = 18
+    static let xxl: CGFloat = 20
+    static let xxxl: CGFloat = 24
+    static let screenTopInset: CGFloat = 12
+    static let groupedHorizontalInset: CGFloat = 20
+    static let dashboardSpacing: CGFloat = 20
+    static let wideContentMaxWidth: CGFloat = 1180
+    static let readableContentMaxWidth: CGFloat = 760
     static let flowHorizontalPadding: CGFloat = 20
     static let flowMaxContentWidth: CGFloat = 420
     static let flowSectionSpacing: CGFloat = 22
@@ -12,9 +27,26 @@ enum SymiSpacing {
     static let tileSpacing: CGFloat = 10
     static let pillSpacing: CGFloat = 8
     static let cardPadding: CGFloat = 18
+    static let buttonTrailingIconPadding: CGFloat = 18
+    static let pillVerticalPadding: CGFloat = 9
+    static let secondaryButtonVerticalPadding: CGFloat = 14
+    static let chevronTopPadding: CGFloat = 3
+    static let zero: CGFloat = 0
+    static let selectedCheckOffsetX: CGFloat = 12
+    static let selectedCheckOffsetY: CGFloat = -6
+    static let heroWavePrimaryOffsetX: CGFloat = -10
+    static let heroWavePrimaryOffsetY: CGFloat = 18
+    static let heroWaveSecondaryOffsetX: CGFloat = 6
+    static let heroWaveSecondaryOffsetY: CGFloat = 24
+    static let heroWaveAccentOffsetX: CGFloat = -8
+    static let heroWaveAccentOffsetY: CGFloat = 28
 }
 
-enum SymiRadius {
+nonisolated enum SymiRadius {
+    static let card: CGFloat = 20
+    static let button: CGFloat = 18
+    static let chip: CGFloat = 12
+    static let heroCard: CGFloat = 24
     static let flowCard: CGFloat = 18
     static let flowTile: CGFloat = 14
     static let flowPill: CGFloat = 12
@@ -22,10 +54,109 @@ enum SymiRadius {
 }
 
 enum SymiShadow {
-    static let cardColor = AppTheme.symiPetrol.opacity(0.06)
+    static let cardColor = AppTheme.symiPetrol.opacity(SymiOpacity.clearAccent)
     static let cardRadius: CGFloat = 12
+    static let cardXOffset: CGFloat = 0
     static let cardYOffset: CGFloat = 5
-    static let buttonColor = AppTheme.symiPetrol.opacity(0.16)
+    static let brandCardRadius: CGFloat = 14
+    static let brandCardYOffset: CGFloat = 6
+    static let heroTextRadius: CGFloat = 3
+    static let heroTextYOffset: CGFloat = 1
+    static let buttonColor = AppTheme.symiPetrol.opacity(SymiOpacity.softFill)
     static let buttonRadius: CGFloat = 12
+    static let buttonXOffset: CGFloat = 0
     static let buttonYOffset: CGFloat = 6
+}
+
+nonisolated enum SymiSize {
+    static let accessibilityMarker: CGFloat = 1
+    static let minInteractiveHeight: CGFloat = 44
+    static let primaryButtonHeight: CGFloat = 54
+    static let progressIndicator: CGFloat = 24
+    static let inputSelectionTileMinHeight: CGFloat = 84
+    static let inputSelectionIconWidth: CGFloat = 34
+    static let inputSelectionIconHeight: CGFloat = 30
+    static let medicationRowMinHeight: CGFloat = 72
+    static let selectedMedicationRowMinHeight: CGFloat = 108
+    static let medicationQuantityMinWidth: CGFloat = 24
+    static let noteEditorMinHeight: CGFloat = 220
+    static let dashboardWideColumnMinWidth: CGFloat = 360
+    static let dashboardColumnMinWidth: CGFloat = 320
+    static let dashboardActionColumnMinWidth: CGFloat = 180
+    static let historySidebarMinWidth: CGFloat = 420
+    static let historySidebarMaxWidth: CGFloat = 560
+    static let medicationGridMinWidth: CGFloat = 220
+    static let multiSelectGridMinWidth: CGFloat = 140
+    static let tagGridMinWidth: CGFloat = 120
+    static let pillGridMinWidth: CGFloat = 70
+    static let statusDot: CGFloat = 10
+    static let calendarDot: CGFloat = 9
+    static let calendarPlaceholderHeight: CGFloat = 16
+    static let calendarDayMinHeight: CGFloat = 52
+    static let calendarWeekdayHeight: CGFloat = 44
+    static let trendChartHeight: CGFloat = 88
+    static let reviewStepIcon: CGFloat = 44
+    static let reviewSummaryIcon: CGFloat = 42
+    static let productInfoIconWidth: CGFloat = 28
+    static let heroSymbolWidth: CGFloat = 90
+    static let heroSymbolHeight: CGFloat = 120
+    static let heroWavePrimaryHeight: CGFloat = 54
+    static let heroWaveSecondaryHeight: CGFloat = 44
+    static let heroWaveAccentWidth: CGFloat = 132
+    static let heroWaveAccentHeight: CGFloat = 34
+    static let painGaugeWidth: CGFloat = 212
+    static let painGaugeHeight: CGFloat = 142
+    static let emptyStateMinHeight: CGFloat = 360
+    static let defaultWindowWidth: CGFloat = 1280
+    static let defaultWindowHeight: CGFloat = 800
+    static let weatherInlineLogoMaxWidth: CGFloat = 180
+    static let weatherInlineLogoMinHeight: CGFloat = 28
+    static let weatherInlineLogoMaxHeight: CGFloat = 48
+    static let weatherFooterLogoMaxWidth: CGFloat = 220
+    static let weatherFooterLogoMinHeight: CGFloat = 32
+    static let weatherFooterLogoMaxHeight: CGFloat = 56
+}
+
+nonisolated enum SymiStroke {
+    static let hairline: CGFloat = 1
+    static let selectedHairline: CGFloat = 1.5
+    static let trendLine: CGFloat = 3
+    static let heroWaveAccent: CGFloat = 4
+    static let heroWaveSecondary: CGFloat = 5
+    static let heroWavePrimary: CGFloat = 8
+    static let painGaugeArc: CGFloat = 13
+}
+
+nonisolated enum SymiOpacity {
+    static let clearAccent: Double = 0.06
+    static let hairline: Double = 0.08
+    static let shadow: Double = 0.10
+    static let faintSurface: Double = 0.12
+    static let softFill: Double = 0.16
+    static let secondaryFill: Double = 0.18
+    static let pressedShadow: Double = 0.10
+    static let pressedFill: Double = 0.20
+    static let backgroundAccent: Double = 0.22
+    static let progressTrackLight: Double = 0.12
+    static let progressTrackDark: Double = 0.22
+    static let progressIndicatorStrokeDark: Double = 0.18
+    static let progressIndicatorStrokeLight: Double = 0.92
+    static let selectedStroke: Double = 0.24
+    static let stepSelectedFillDark: Double = 0.30
+    static let secondaryPressedFill: Double = 0.32
+    static let selectedFill: Double = 0.35
+    static let stepBorderLight: Double = 0.36
+    static let outline: Double = 0.45
+    static let stepBorderDark: Double = 0.48
+    static let disabledFill: Double = 0.55
+    static let disabledContent: Double = 0.55
+    static let disabledTile: Double = 0.58
+    static let heroSecondaryWave: Double = 0.72
+    static let appBackgroundSurface: Double = 0.72
+    static let heroPrimaryWave: Double = 0.82
+    static let heroSecondaryText: Double = 0.86
+    static let heroAccentWave: Double = 0.92
+    static let strongSurface: Double = 0.96
+    static let opaque: Double = 1
+    static let elevatedShadow: Double = 1.2
 }

--- a/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 
 enum SymiTypography {
+    static let compactScaleFactor = 0.82
+    static let buttonScaleFactor = 0.85
+    static let gaugeScaleFactor = 0.75
+    static let headline = Font.headline
+    static let body = Font.body
+    static let secondary = Font.subheadline
+    static let button = Font.headline.weight(.semibold)
+    static let caption = Font.caption
+    static let largeMetric = Font.system(size: 58, weight: .bold, design: .rounded)
+    static let homeMetric = Font.system(size: 44, weight: .bold, design: .rounded)
     static let flowTitle = Font.title.weight(.bold)
     static let flowSubtitle = Font.callout
     static let flowSectionTitle = Font.callout.weight(.medium)

--- a/Symi/Sources/Shared/AppTheme.swift
+++ b/Symi/Sources/Shared/AppTheme.swift
@@ -1,33 +1,39 @@
 import SwiftUI
 
 enum AppTheme {
-    static let groupedHorizontalInset: CGFloat = 20
-    static let groupedTopInset: CGFloat = 12
-    static let groupedRowInsets = EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20)
-    static let wideContentMaxWidth: CGFloat = 1180
-    static let readableContentMaxWidth: CGFloat = 760
-    static let dashboardSpacing: CGFloat = 20
+    static let groupedHorizontalInset = SymiSpacing.groupedHorizontalInset
+    static let groupedTopInset = SymiSpacing.screenTopInset
+    static let groupedRowInsets = EdgeInsets(
+        top: SymiSpacing.sm,
+        leading: SymiSpacing.xxl,
+        bottom: SymiSpacing.sm,
+        trailing: SymiSpacing.xxl
+    )
+    static let wideContentMaxWidth = SymiSpacing.wideContentMaxWidth
+    static let readableContentMaxWidth = SymiSpacing.readableContentMaxWidth
+    static let dashboardSpacing = SymiSpacing.dashboardSpacing
 
-    static let symiPetrol = Color(red: 0.059, green: 0.239, blue: 0.243)
-    static let symiSage = Color(red: 0.557, green: 0.804, blue: 0.722)
-    static let symiCoral = Color(red: 1.000, green: 0.541, blue: 0.478)
-    static let symiBackground = Color(red: 0.965, green: 0.957, blue: 0.937)
-    static let symiCard = Color(red: 1.000, green: 0.996, blue: 0.984)
-    static let symiTextPrimary = Color(red: 0.110, green: 0.110, blue: 0.118)
-    static let symiTextSecondary = Color(red: 0.420, green: 0.420, blue: 0.431)
+    static let symiPetrol = SymiColors.primaryPetrol.color
+    static let symiSage = SymiColors.sage.color
+    static let symiCoral = SymiColors.coral.color
+    static let symiBackground = SymiColors.warmBackground.color
+    static let symiCard = SymiColors.card.color
+    static let symiTextPrimary = SymiColors.textPrimary.color
+    static let symiTextSecondary = SymiColors.textSecondary.color
+    static let symiOnAccent = SymiColors.onAccent.color
 
     static let ink = symiPetrol
     static let ocean = symiPetrol
     static let seaGlass = symiSage
     static let foam = symiBackground
     static let coral = symiCoral
-    static let mist = Color(red: 0.925, green: 0.969, blue: 0.955)
+    static let mist = SymiColors.mist.color
 
     static let appBackground = LinearGradient(
         colors: [
             symiBackground,
-            Color.white.opacity(0.72),
-            symiSage.opacity(0.22)
+            symiOnAccent.opacity(SymiOpacity.appBackgroundSurface),
+            symiSage.opacity(SymiOpacity.backgroundAccent)
         ],
         startPoint: .topLeading,
         endPoint: .bottomTrailing
@@ -45,16 +51,16 @@ enum AppTheme {
     static let cardGradient = LinearGradient(
         colors: [
             symiCard,
-            Color.white.opacity(0.96)
+            symiOnAccent.opacity(SymiOpacity.strongSurface)
         ],
         startPoint: .topLeading,
         endPoint: .bottomTrailing
     )
 
-    static let selectedFill = symiSage.opacity(0.35)
-    static let secondaryFill = symiSage.opacity(0.18)
+    static let selectedFill = symiSage.opacity(SymiOpacity.selectedFill)
+    static let secondaryFill = symiSage.opacity(SymiOpacity.secondaryFill)
     static let cardBorder = Color.clear
-    static let shadowColor = symiPetrol.opacity(0.10)
+    static let shadowColor = symiPetrol.opacity(SymiOpacity.shadow)
 }
 
 private struct BrandScreenModifier: ViewModifier {
@@ -95,33 +101,42 @@ private struct BrandCardModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(AppTheme.cardGradient)
-            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .shadow(color: AppTheme.shadowColor, radius: 14, x: 0, y: 6)
+            .clipShape(RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
+            .shadow(
+                color: AppTheme.shadowColor,
+                radius: SymiShadow.brandCardRadius,
+                x: SymiShadow.cardXOffset,
+                y: SymiShadow.brandCardYOffset
+            )
     }
 }
 
 struct SymiPrimaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.headline)
-            .foregroundStyle(.white)
-            .padding(.vertical, 16)
+            .font(SymiTypography.button)
+            .foregroundStyle(AppTheme.symiOnAccent)
+            .padding(.vertical, SymiSpacing.lg)
             .frame(maxWidth: .infinity)
-            .background(AppTheme.symiCoral.opacity(configuration.isPressed ? 0.82 : 1))
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-            .shadow(color: AppTheme.symiCoral.opacity(configuration.isPressed ? 0.10 : 0.22), radius: 12, y: 6)
+            .background(AppTheme.symiCoral.opacity(configuration.isPressed ? SymiOpacity.heroPrimaryWave : SymiOpacity.opaque))
+            .clipShape(RoundedRectangle(cornerRadius: SymiRadius.button, style: .continuous))
+            .shadow(
+                color: AppTheme.symiCoral.opacity(configuration.isPressed ? SymiOpacity.pressedShadow : SymiOpacity.backgroundAccent),
+                radius: SymiShadow.buttonRadius,
+                y: SymiShadow.buttonYOffset
+            )
     }
 }
 
 struct SymiSecondaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.headline)
+            .font(SymiTypography.button)
             .foregroundStyle(AppTheme.symiPetrol)
-            .padding(.vertical, 14)
+            .padding(.vertical, SymiSpacing.secondaryButtonVerticalPadding)
             .frame(maxWidth: .infinity)
-            .background(AppTheme.symiSage.opacity(configuration.isPressed ? 0.20 : 0.32))
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .background(AppTheme.symiSage.opacity(configuration.isPressed ? SymiOpacity.pressedFill : SymiOpacity.secondaryPressedFill))
+            .clipShape(RoundedRectangle(cornerRadius: SymiRadius.button, style: .continuous))
     }
 }
 

--- a/Symi/Sources/Shared/WeatherAttributionView.swift
+++ b/Symi/Sources/Shared/WeatherAttributionView.swift
@@ -8,7 +8,7 @@ struct WeatherAttributionView: View {
     var showsDescription = true
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
             if showsDescription {
                 Text(WeatherAttribution.modifiedSourceDescription)
                     .font(.footnote)
@@ -23,7 +23,12 @@ struct WeatherAttributionView: View {
                 } placeholder: {
                     weatherMarkFallback
                 }
-                .frame(maxWidth: 180, minHeight: 28, maxHeight: 48, alignment: .leading)
+                .frame(
+                    maxWidth: SymiSize.weatherInlineLogoMaxWidth,
+                    minHeight: SymiSize.weatherInlineLogoMinHeight,
+                    maxHeight: SymiSize.weatherInlineLogoMaxHeight,
+                    alignment: .leading
+                )
                 .accessibilityLabel(attribution.serviceName)
             } else {
                 weatherMarkFallback
@@ -68,7 +73,7 @@ private struct WeatherAttributionDetailView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: SymiSpacing.lg) {
                     weatherMark
 
                     if let legalAttributionText = attribution.legalAttributionText, !legalAttributionText.isEmpty {
@@ -111,7 +116,12 @@ private struct WeatherAttributionDetailView: View {
             } placeholder: {
                 weatherMarkFallback
             }
-            .frame(maxWidth: 220, minHeight: 32, maxHeight: 56, alignment: .leading)
+            .frame(
+                maxWidth: SymiSize.weatherFooterLogoMaxWidth,
+                minHeight: SymiSize.weatherFooterLogoMinHeight,
+                maxHeight: SymiSize.weatherFooterLogoMaxHeight,
+                alignment: .leading
+            )
             .accessibilityLabel(attribution.serviceName)
         } else {
             weatherMarkFallback

--- a/SymiTests/NewEntryDesignSystemTests.swift
+++ b/SymiTests/NewEntryDesignSystemTests.swift
@@ -48,9 +48,10 @@ struct NewEntryDesignSystemTests {
         #expect(SymiColors.sage.hexString == "#8ECDB8")
         #expect(SymiColors.coral.hexString == "#FF8A7A")
         #expect(SymiColors.warmBackground.hexString == "#F6F4EF")
-        #expect(SymiColors.card.hexString == "#FFFFFF")
+        #expect(SymiColors.card.hexString == "#FFFEFB")
         #expect(SymiColors.textPrimary.hexString == "#1C1C1E")
         #expect(SymiColors.textSecondary.hexString == "#6B6B6E")
+        #expect(SymiColors.onAccent.hexString == "#FFFFFF")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- consolidate SwiftUI magic numbers into shared Symi design tokens
- add SwiftLint custom rules for token enforcement in CI
- replace direct color, spacing, radius, frame, opacity, stroke, and typography literals across input flow and related views

## Verification
- swiftlint lint --config .swiftlint.yml --quiet
- git diff --check
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=macOS,arch=arm64,variant=Mac Catalyst' CODE_SIGNING_ALLOWED=NO\n\nCloses #191