### PR TITLE
[codex] Align headache entry flow with concept

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,6 +14,7 @@ only_rules:
   - no_magic_opacity
   - no_magic_font_size
   - no_magic_minimum_scale_factor
+  - no_magic_minimum_column_width
 
 excluded:
   - Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
@@ -92,4 +93,10 @@ custom_rules:
     name: "Keine rohen Minimum-Scale-Faktoren"
     regex: '\.minimumScaleFactor\(\d+(?:\.\d+)?\)'
     message: "Nutze SymiTypography-Tokens statt roher Minimum-Scale-Faktoren."
+    severity: warning
+
+  no_magic_minimum_column_width:
+    name: "Keine rohen Minimum-Spaltenbreiten"
+    regex: 'minimumColumnWidth:\s*\d+(?:\.\d+)?'
+    message: "Nutze SymiSize-Tokens statt roher minimumColumnWidth-Werte."
     severity: warning

--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -113,6 +113,7 @@ final class EntryFlowCoordinator {
     var isSaving = false
     var saveResult: EntryFlowSaveResult?
     var weatherLoadState: WeatherLoadState = .idle
+    var hasSeededDefaultPainLocation = false
     private(set) var isCancelled = false
 
     private let initialStartedAt: Date?
@@ -206,6 +207,7 @@ final class EntryFlowCoordinator {
         draft = EpisodeDraft.makeNew(initialStartedAt: initialStartedAt)
         medicationController.resetSelections()
         weatherLoadState = .idle
+        hasSeededDefaultPainLocation = false
         saveResult = nil
         isSaving = false
     }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -142,7 +142,6 @@ private struct EntryHeadacheStepView: View {
     let onCancel: () -> Void
 
     @State private var selectedStartedAtPreset: EntryStartedAtPreset = .now
-
     private let visiblePainLocations = ["Stirn", "Schläfen", "Nacken", "Einseitig"]
 
     var body: some View {
@@ -157,9 +156,9 @@ private struct EntryHeadacheStepView: View {
             PainGaugeView(value: $coordinator.draft.intensity)
 
             InputFlowFieldGroup(title: "Wo spürst du den Schmerz?") {
-                InputFlowTileGrid(minimumColumnWidth: 68) {
+                HeadacheLocationGrid {
                     ForEach(visiblePainLocations, id: \.self) { location in
-                        InputFlowSelectionTile(
+                        SelectionTile(
                             title: location,
                             systemImage: painLocationSymbol(for: location),
                             isSelected: coordinator.draft.selectedPainLocations.contains(location),
@@ -173,9 +172,9 @@ private struct EntryHeadacheStepView: View {
             }
 
             InputFlowFieldGroup(title: "Wann tritt es auf?") {
-                InputFlowPillGrid {
+                HeadachePresetGrid {
                     ForEach(EntryStartedAtPreset.allCases) { preset in
-                        InputFlowPillOption(
+                        PillOption(
                             title: preset.title,
                             isSelected: selectedStartedAtPreset == preset,
                             theme: .pain,
@@ -215,6 +214,7 @@ private struct EntryHeadacheStepView: View {
         .onAppear {
             coordinator.draft.type = .headache
             coordinator.draft.intensity = coordinator.draft.normalizedIntensity
+            seedDefaultPainLocationIfNeeded(coordinator: coordinator)
         }
     }
 
@@ -233,11 +233,75 @@ private struct EntryHeadacheStepView: View {
         }
     }
 
+    private func seedDefaultPainLocationIfNeeded(coordinator: EntryFlowCoordinator) {
+        guard !coordinator.hasSeededDefaultPainLocation else {
+            return
+        }
+
+        coordinator.hasSeededDefaultPainLocation = true
+        guard coordinator.draft.selectedPainLocations.isEmpty,
+              coordinator.draft.painLocation.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+
+        coordinator.draft.selectedPainLocations = ["Schläfen"]
+    }
+
     private func toggle(_ option: String, in selection: inout Set<String>) {
         if selection.contains(option) {
             selection.remove(option)
         } else {
             selection.insert(option)
+        }
+    }
+}
+
+private struct HeadacheLocationGrid<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: Array(
+                repeating: GridItem(
+                    .flexible(minimum: SymiSize.headacheOptionGridMinWidth),
+                    spacing: SymiSpacing.xs,
+                    alignment: .top
+                ),
+                count: SymiSize.headacheOptionGridColumnCount
+            ),
+            alignment: .leading,
+            spacing: SymiSpacing.xs
+        ) {
+            content
+        }
+    }
+}
+
+private struct HeadachePresetGrid<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: Array(
+                repeating: GridItem(
+                    .flexible(minimum: SymiSize.headacheOptionGridMinWidth),
+                    spacing: SymiSpacing.xs,
+                    alignment: .top
+                ),
+                count: SymiSize.headacheOptionGridColumnCount
+            ),
+            alignment: .leading,
+            spacing: SymiSpacing.xs
+        ) {
+            content
         }
     }
 }
@@ -271,7 +335,7 @@ private struct EntryMedicationStepView: View {
         ) {
             InputFlowFieldGroup(title: "Welche Medikation?") {
                 VStack(spacing: SymiSpacing.tileSpacing) {
-                    InputFlowTileGrid(minimumColumnWidth: 132) {
+                    InputFlowTileGrid(minimumColumnWidth: SymiSize.flowTwoColumnTileGridMinWidth) {
                         ForEach(medicationOptions) { option in
                             InputFlowSelectionTile(
                                 title: option.title,
@@ -428,7 +492,7 @@ private struct EntryTriggersStepView: View {
             onCancel: onCancel
         ) {
             InputFlowFieldGroup(title: "Wähle alle passenden aus.") {
-                InputFlowTileGrid(minimumColumnWidth: 132) {
+                InputFlowTileGrid(minimumColumnWidth: SymiSize.flowTwoColumnTileGridMinWidth) {
                     ForEach(triggerOptions) { option in
                         InputFlowSelectionTile(
                             title: option.title,
@@ -493,7 +557,7 @@ private struct EntryNoteStepView: View {
             EntryNoteCard(notes: $coordinator.draft.notes)
 
             InputFlowFieldGroup(title: "Wie fühlst du dich gerade?") {
-                InputFlowTileGrid(minimumColumnWidth: 72) {
+                InputFlowTileGrid(minimumColumnWidth: SymiSize.flowCompactTileGridMinWidth) {
                     ForEach(feelingOptions) { option in
                         InputFlowSelectionTile(
                             title: option.title,
@@ -735,8 +799,8 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
                         content
                     }
                     .padding(.horizontal, SymiSpacing.flowHorizontalPadding)
-                    .padding(.top, SymiSpacing.xs)
-                    .padding(.bottom, SymiSpacing.xxxl)
+                    .padding(.top, SymiSpacing.zero)
+                    .padding(.bottom, SymiSpacing.xxl)
                     .frame(maxWidth: SymiSpacing.flowMaxContentWidth, alignment: .leading)
                     .frame(maxWidth: .infinity)
                 }
@@ -751,7 +815,7 @@ private struct EntryFlowScreen<Content: View, Footer: View>: View {
                 .padding(.bottom, SymiSpacing.flowFooterBottomPadding)
                 .frame(maxWidth: SymiSpacing.flowMaxContentWidth)
                 .frame(maxWidth: .infinity)
-                .background(.regularMaterial)
+                .background(InputFlowBackground().opacity(SymiOpacity.footerBackground).ignoresSafeArea())
         }
         .navigationBarBackButtonHidden(true)
     }
@@ -911,7 +975,7 @@ private struct EntryFlowFooter: View {
     }
 
     var body: some View {
-        VStack(spacing: SymiSpacing.md) {
+        VStack(spacing: SymiSpacing.zero) {
             InputFlowPrimaryButton(
                 title: primaryTitle,
                 systemImage: primarySystemImage,

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowActions.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowActions.swift
@@ -88,10 +88,12 @@ struct InputFlowSecondaryAction: View {
     var body: some View {
         Button(title, action: action)
             .font(SymiTypography.flowSecondaryAction)
-            .foregroundStyle(AppTheme.symiPetrol)
+            .foregroundStyle(AppTheme.symiPetrol.opacity(SymiOpacity.secondaryActionText))
             .frame(minHeight: SymiSize.minInteractiveHeight)
             .disabled(isDisabled)
             .opacity(isDisabled ? SymiOpacity.disabledContent : SymiOpacity.opaque)
             .accessibilityIdentifier(accessibilityIdentifier ?? "input-flow-secondary")
     }
 }
+
+typealias SecondaryAction = InputFlowSecondaryAction

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowCard.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowCard.swift
@@ -35,10 +35,10 @@ struct InputFlowCard<Content: View>: View {
 
     private var borderColor: Color {
         guard isHighlighted, let theme else {
-            return SymiColors.subtleSeparator(for: colorScheme)
+            return SymiColors.subtleSeparator(for: colorScheme).opacity(SymiOpacity.strongSurface)
         }
 
-        return theme.border(for: colorScheme)
+        return theme.border(for: colorScheme).opacity(SymiOpacity.clearStroke)
     }
 
     private var shadowColor: Color {

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowHeader.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowHeader.swift
@@ -26,17 +26,17 @@ struct InputFlowHeader: View {
     var body: some View {
         let metadata = InputFlowStepCatalog.metadata(for: step)
 
-        VStack(alignment: .leading, spacing: SymiSpacing.flowHeaderControlSpacing) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
             HStack {
                 Button(action: onBack) {
                     Image(systemName: "chevron.left")
-                        .font(.headline.weight(.semibold))
-                        .foregroundStyle(.primary)
-                        .frame(width: SymiSize.minInteractiveHeight, height: SymiSize.minInteractiveHeight)
-                        .background(.thinMaterial, in: Circle())
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(AppTheme.symiTextPrimary)
+                        .frame(width: SymiSize.flowHeaderControlHeight, height: SymiSize.flowHeaderControlHeight)
+                        .background(SymiColors.elevatedCard(for: colorScheme), in: Circle())
                         .overlay {
                             Circle()
-                                .stroke(Color.primary.opacity(SymiOpacity.hairline), lineWidth: SymiStroke.hairline)
+                                .stroke(SymiColors.subtleSeparator(for: colorScheme), lineWidth: SymiStroke.hairline)
                         }
                 }
                 .accessibilityLabel("Zurück")
@@ -45,14 +45,14 @@ struct InputFlowHeader: View {
                 Spacer()
 
                 Button("Abbrechen", action: onCancel)
-                    .font(.callout.weight(.medium))
+                    .font(.subheadline.weight(.medium))
                     .foregroundStyle(AppTheme.symiPetrol)
-                    .frame(minHeight: SymiSize.minInteractiveHeight)
+                    .frame(minHeight: SymiSize.flowHeaderControlHeight)
                     .accessibilityIdentifier("entry-flow-cancel")
             }
 
             VStack(alignment: .leading, spacing: SymiSpacing.flowHeaderTitleSpacing) {
-                InputFlowProgressView(
+                InputFlowProgressBar(
                     currentStep: currentStep,
                     totalSteps: totalSteps,
                     theme: metadata.theme
@@ -61,17 +61,18 @@ struct InputFlowHeader: View {
                 Text(metadata.title)
                     .font(SymiTypography.flowTitle)
                     .foregroundStyle(metadata.theme.accent(for: colorScheme))
+                    .padding(.top, SymiSpacing.md)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(metadata.subtitle)
                     .font(SymiTypography.flowSubtitle)
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(AppTheme.symiTextSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(.horizontal, SymiSpacing.flowHorizontalPadding)
         .padding(.top, SymiSpacing.flowHeaderTopPadding)
-        .padding(.bottom, SymiSpacing.xs)
+        .padding(.bottom, SymiSpacing.zero)
         .frame(maxWidth: SymiSpacing.flowMaxContentWidth, alignment: .leading)
         .frame(maxWidth: .infinity)
     }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
@@ -10,10 +10,10 @@ struct InputFlowFieldGroup<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: SymiSpacing.md) {
+        VStack(alignment: .leading, spacing: SymiSpacing.lg) {
             Text(title)
                 .font(SymiTypography.flowSectionTitle)
-                .foregroundStyle(.primary)
+                .foregroundStyle(AppTheme.symiTextSecondary)
 
             content
         }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowPillOption.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowPillOption.swift
@@ -28,10 +28,13 @@ struct InputFlowPillOption: View {
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: SymiSpacing.compact) {
+            HStack(alignment: .firstTextBaseline, spacing: SymiSpacing.xs) {
                 if isSelected {
                     Image(systemName: "checkmark")
-                        .font(.caption.weight(.bold))
+                        .font(.caption2.weight(.bold))
+                        .alignmentGuide(.firstTextBaseline) { dimensions in
+                            dimensions[VerticalAlignment.center]
+                        }
                         .accessibilityHidden(true)
                 }
 
@@ -42,10 +45,14 @@ struct InputFlowPillOption: View {
                     .minimumScaleFactor(SymiTypography.compactScaleFactor)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .foregroundStyle(isSelected ? theme.accent(for: colorScheme) : .primary)
+            .foregroundStyle(isSelected ? theme.accent(for: colorScheme) : AppTheme.symiTextPrimary)
             .padding(.horizontal, SymiSpacing.md)
             .padding(.vertical, SymiSpacing.pillVerticalPadding)
-            .frame(maxWidth: .infinity, minHeight: SymiSize.minInteractiveHeight)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: SymiSize.minInteractiveHeight,
+                maxHeight: SymiSize.minInteractiveHeight
+            )
             .background(backgroundColor, in: Capsule())
             .overlay {
                 Capsule()
@@ -71,9 +78,11 @@ struct InputFlowPillOption: View {
 
     private var borderColor: Color {
         if isSelected {
-            return theme.border(for: colorScheme)
+            return theme.border(for: colorScheme).opacity(SymiOpacity.selectedStroke)
         }
 
-        return SymiColors.subtleSeparator(for: colorScheme)
+        return SymiColors.subtleSeparator(for: colorScheme).opacity(SymiOpacity.strongSurface)
     }
 }
+
+typealias PillOption = InputFlowPillOption

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowProgressView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowProgressView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
-struct InputFlowProgressView: View {
+typealias InputFlowProgressView = InputFlowProgressBar
+
+struct InputFlowProgressBar: View {
     @Environment(\.colorScheme) private var colorScheme
 
     let currentStep: Int
@@ -14,27 +16,22 @@ struct InputFlowProgressView: View {
     }
 
     var body: some View {
-        HStack(spacing: SymiSpacing.xl) {
+        HStack(alignment: .center, spacing: SymiSpacing.md) {
             GeometryReader { proxy in
                 let indicatorSize = SymiSize.progressIndicator
+                let trackHeight = SymiSize.progressTrackHeight
                 let trackWidth = max(proxy.size.width - indicatorSize, 1)
                 let xOffset = progressPosition(in: trackWidth)
                 let activeWidth = min(xOffset + indicatorSize / 2, proxy.size.width)
 
                 ZStack(alignment: .leading) {
                     Capsule()
-                        .fill(
-                            Color.primary.opacity(
-                                colorScheme == .dark ? SymiOpacity.progressTrackDark : SymiOpacity.progressTrackLight
-                            )
-                        )
-                        .frame(height: SymiSpacing.xxs)
-                        .offset(y: indicatorSize / 2 - SymiSpacing.micro)
+                        .fill(SymiColors.subtleSeparator(for: colorScheme))
+                        .frame(height: trackHeight)
 
                     Capsule()
                         .fill(theme.accent(for: colorScheme))
-                        .frame(width: activeWidth, height: SymiSpacing.xxs)
-                        .offset(y: indicatorSize / 2 - SymiSpacing.micro)
+                        .frame(width: activeWidth, height: trackHeight)
 
                     Text("\(clampedCurrentStep)")
                         .font(.caption.weight(.bold))
@@ -54,16 +51,19 @@ struct InputFlowProgressView: View {
                                 )
                         }
                         .offset(x: xOffset)
+                        .offset(y: SymiStroke.hairline)
                         .accessibilityHidden(true)
                 }
+                .frame(height: indicatorSize, alignment: .center)
             }
             .frame(height: SymiSize.progressIndicator)
 
             Text("von \(safeTotalSteps)")
-                .font(.footnote.weight(.medium))
-                .foregroundStyle(.secondary)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(AppTheme.symiPetrol.opacity(SymiOpacity.strongText))
                 .lineLimit(1)
                 .minimumScaleFactor(SymiTypography.compactScaleFactor)
+                .frame(width: SymiSize.progressTotalWidth, height: SymiSize.progressIndicator, alignment: .trailing)
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Schritt \(clampedCurrentStep) von \(safeTotalSteps)")

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowSelectionTile.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowSelectionTile.swift
@@ -43,38 +43,39 @@ struct InputFlowSelectionTile: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(spacing: SymiSpacing.sm) {
-                ZStack(alignment: .topTrailing) {
-                    Image(systemName: systemImage)
-                        .font(.title3.weight(.medium))
-                        .foregroundStyle(iconColor)
-                        .frame(width: SymiSize.inputSelectionIconWidth, height: SymiSize.inputSelectionIconHeight)
-
-                    if state.isSelected {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.caption.weight(.bold))
-                            .foregroundStyle(theme.accent(for: colorScheme))
-                            .background(AppTheme.symiCard, in: Circle())
-                            .offset(x: SymiSpacing.selectedCheckOffsetX, y: SymiSpacing.selectedCheckOffsetY)
-                            .accessibilityHidden(true)
-                    }
-                }
+            VStack(spacing: SymiSpacing.xs) {
+                Image(systemName: systemImage)
+                    .font(.title3.weight(.medium))
+                    .foregroundStyle(iconColor)
+                    .frame(width: SymiSize.inputSelectionIconWidth, height: SymiSize.inputSelectionIconHeight)
 
                 Text(title)
                     .font(SymiTypography.flowTileLabel)
                     .multilineTextAlignment(.center)
-                    .foregroundStyle(state.isDisabled ? .secondary : .primary)
+                    .foregroundStyle(state.isDisabled ? AppTheme.symiTextSecondary : AppTheme.symiTextPrimary)
                     .lineLimit(2)
                     .minimumScaleFactor(SymiTypography.compactScaleFactor)
                     .fixedSize(horizontal: false, vertical: true)
             }
             .padding(.horizontal, SymiSpacing.sm)
-            .padding(.vertical, SymiSpacing.flowHeaderControlSpacing + SymiSpacing.xxs)
+            .padding(.vertical, SymiSpacing.xs)
             .frame(maxWidth: .infinity, minHeight: SymiSize.inputSelectionTileMinHeight)
             .background(tileBackground, in: RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous))
             .overlay {
                 RoundedRectangle(cornerRadius: SymiRadius.flowTile, style: .continuous)
-                    .stroke(borderColor, lineWidth: state.isSelected ? SymiStroke.selectedHairline : SymiStroke.hairline)
+                    .stroke(borderColor, lineWidth: SymiStroke.hairline)
+            }
+            .overlay(alignment: .topTrailing) {
+                if state.isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(theme.accent(for: colorScheme))
+                        .background(SymiColors.elevatedCard(for: colorScheme), in: Circle())
+                        .padding(.top, SymiSpacing.sm)
+                        .padding(.trailing, SymiSpacing.sm)
+                        .accessibilityHidden(true)
+                        .transition(.scale.combined(with: .opacity))
+                }
             }
             .opacity(state.isDisabled ? SymiOpacity.disabledTile : SymiOpacity.opaque)
         }
@@ -89,10 +90,10 @@ struct InputFlowSelectionTile: View {
 
     private var iconColor: Color {
         if state.isDisabled {
-            return .secondary
+            return AppTheme.symiTextSecondary
         }
 
-        return state.isSelected ? theme.accent(for: colorScheme) : .secondary
+        return state.isSelected ? theme.accent(for: colorScheme) : AppTheme.symiTextSecondary.opacity(SymiOpacity.strongText)
     }
 
     private var tileBackground: Color {
@@ -105,10 +106,10 @@ struct InputFlowSelectionTile: View {
 
     private var borderColor: Color {
         if state.isSelected {
-            return theme.border(for: colorScheme)
+            return theme.border(for: colorScheme).opacity(SymiOpacity.selectedStroke)
         }
 
-        return SymiColors.subtleSeparator(for: colorScheme)
+        return SymiColors.subtleSeparator(for: colorScheme).opacity(SymiOpacity.strongSurface)
     }
 
     private var accessibilityValue: String {
@@ -126,3 +127,5 @@ struct InputFlowSelectionTile: View {
         state.isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus."
     }
 }
+
+typealias SelectionTile = InputFlowSelectionTile

--- a/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
@@ -17,16 +17,37 @@ struct PainGaugeView: View {
     }
 
     var body: some View {
+        PainGaugeCard(value: $value, range: range, theme: theme)
+    }
+}
+
+private struct PainGaugeCard: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @Binding var value: Int
+
+    let range: ClosedRange<Int>
+    let theme: InputFlowStepTheme
+
+    var body: some View {
         InputFlowCard(theme: theme, isHighlighted: true) {
-            VStack(spacing: SymiSpacing.xl) {
+            VStack(spacing: SymiSpacing.md) {
                 ZStack(alignment: .center) {
+                    PainGaugeArc()
+                        .stroke(
+                            SymiColors.subtleSeparator(for: colorScheme),
+                            style: StrokeStyle(lineWidth: SymiStroke.painGaugeArc, lineCap: .round)
+                        )
+                        .frame(width: SymiSize.painGaugeWidth, height: SymiSize.painGaugeHeight)
+                        .accessibilityHidden(true)
+
                     PainGaugeArc()
                         .stroke(
                             LinearGradient(
                                 colors: [
-                                    InputFlowStepTheme.medication.accent,
-                                    SymiColors.noteAmber.color,
-                                    InputFlowStepTheme.pain.accent
+                                    SymiColors.sage.color,
+                                    SymiColors.noteAmberDark.color,
+                                    SymiColors.coral.color
                                 ],
                                 startPoint: .leading,
                                 endPoint: .trailing
@@ -36,37 +57,33 @@ struct PainGaugeView: View {
                         .frame(width: SymiSize.painGaugeWidth, height: SymiSize.painGaugeHeight)
                         .accessibilityHidden(true)
 
-                    VStack(spacing: SymiSpacing.xxs) {
+                    VStack(spacing: SymiSpacing.zero) {
                         Text("\(normalizedValue)")
-                            .font(SymiTypography.largeMetric)
+                            .font(SymiTypography.painGaugeMetric)
                             .monospacedDigit()
                             .foregroundStyle(AppTheme.symiPetrol)
                             .minimumScaleFactor(SymiTypography.gaugeScaleFactor)
 
                         Text("/10")
-                            .font(.headline)
-                            .foregroundStyle(.secondary)
+                            .font(SymiTypography.painGaugeUnit)
+                            .foregroundStyle(AppTheme.symiTextSecondary)
 
                         Text(intensityLabel)
-                            .font(.title3.weight(.semibold))
+                            .font(SymiTypography.painGaugeLabel)
                             .foregroundStyle(theme.accent)
-                            .padding(.top, SymiSpacing.xs)
+                            .padding(.top, SymiSpacing.micro)
                             .minimumScaleFactor(SymiTypography.buttonScaleFactor)
                     }
                     .padding(.top, SymiSpacing.xxl)
                 }
                 .frame(maxWidth: .infinity)
 
-                VStack(spacing: SymiSpacing.xs) {
-                    Slider(
-                        value: Binding(
-                            get: { Double(normalizedValue) },
-                            set: { value = Int($0.rounded()) }
-                        ),
-                        in: Double(range.lowerBound) ... Double(range.upperBound),
-                        step: 1
+                VStack(spacing: SymiSpacing.compact) {
+                    PainGaugeSlider(
+                        value: $value,
+                        range: range,
+                        theme: theme
                     )
-                    .tint(theme.accent)
                     .accessibilityLabel("Kopfschmerzstärke")
                     .accessibilityValue("\(normalizedValue) von 10, \(intensityLabel.lowercased())")
                     .accessibilityIdentifier("entry-intensity-slider")
@@ -76,8 +93,8 @@ struct PainGaugeView: View {
                         Spacer()
                         Text("\(range.upperBound)")
                     }
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.secondary)
+                    .font(SymiTypography.caption.monospacedDigit())
+                    .foregroundStyle(AppTheme.symiTextSecondary)
                 }
             }
         }
@@ -105,16 +122,95 @@ struct PainGaugeView: View {
     }
 }
 
+private struct PainGaugeSlider: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @Binding var value: Int
+
+    let range: ClosedRange<Int>
+    let theme: InputFlowStepTheme
+
+    var body: some View {
+        GeometryReader { proxy in
+            let progress = normalizedProgress
+            let filledWidth = proxy.size.width * progress
+            let thumbX = proxy.size.width * progress
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(SymiColors.subtleSeparator(for: colorScheme))
+                    .frame(height: SymiSize.painSliderTrackHeight)
+
+                Capsule()
+                    .fill(AppTheme.symiCoral)
+                    .frame(width: filledWidth, height: SymiSize.painSliderTrackHeight)
+
+                Circle()
+                    .fill(AppTheme.symiOnAccent)
+                    .frame(width: SymiSize.painSliderThumbSize, height: SymiSize.painSliderThumbSize)
+                    .shadow(
+                        color: AppTheme.symiPetrol.opacity(SymiOpacity.sliderThumbShadow),
+                        radius: SymiShadow.sliderThumbRadius,
+                        y: SymiShadow.sliderThumbYOffset
+                    )
+                    .offset(x: thumbOffset(for: thumbX, width: proxy.size.width))
+            }
+            .frame(height: SymiSize.painSliderTouchHeight)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: SymiSpacing.zero)
+                    .onChanged { gesture in
+                        updateValue(for: gesture.location.x, width: proxy.size.width)
+                    }
+            )
+            .animation(.snappy, value: value)
+        }
+        .frame(height: SymiSize.painSliderTouchHeight)
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                value = min(value + 1, range.upperBound)
+            case .decrement:
+                value = max(value - 1, range.lowerBound)
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    private var normalizedProgress: CGFloat {
+        let span = max(range.upperBound - range.lowerBound, 1)
+        let clampedValue = min(max(value, range.lowerBound), range.upperBound)
+        return CGFloat(clampedValue - range.lowerBound) / CGFloat(span)
+    }
+
+    private func thumbOffset(for xPosition: CGFloat, width: CGFloat) -> CGFloat {
+        let halfThumb = SymiSize.painSliderThumbSize / 2
+        return min(max(xPosition - halfThumb, 0), max(width - SymiSize.painSliderThumbSize, 0))
+    }
+
+    private func updateValue(for xPosition: CGFloat, width: CGFloat) {
+        guard width > 0 else {
+            return
+        }
+
+        let clampedX = min(max(xPosition, 0), width)
+        let progress = clampedX / width
+        let span = range.upperBound - range.lowerBound
+        value = range.lowerBound + Int((CGFloat(span) * progress).rounded())
+    }
+}
+
 private struct PainGaugeArc: Shape {
     func path(in rect: CGRect) -> Path {
-        let radius = min(rect.width / 2, rect.height) - SymiSpacing.xs
-        let center = CGPoint(x: rect.midX, y: rect.maxY - SymiSpacing.xs)
+        let radius = min(rect.width / 2, rect.height) - SymiSpacing.sm
+        let center = CGPoint(x: rect.midX, y: rect.maxY - SymiSpacing.xxxl)
         var path = Path()
         path.addArc(
             center: center,
             radius: radius,
-            startAngle: .degrees(200),
-            endAngle: .degrees(340),
+            startAngle: .degrees(205),
+            endAngle: .degrees(335),
             clockwise: false
         )
         return path

--- a/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
@@ -18,22 +18,22 @@ nonisolated enum SymiSpacing {
     static let readableContentMaxWidth: CGFloat = 760
     static let flowHorizontalPadding: CGFloat = 20
     static let flowMaxContentWidth: CGFloat = 420
-    static let flowSectionSpacing: CGFloat = 22
-    static let flowHeaderTopPadding: CGFloat = 8
-    static let flowHeaderControlSpacing: CGFloat = 10
-    static let flowHeaderTitleSpacing: CGFloat = 8
-    static let flowFooterTopPadding: CGFloat = 10
-    static let flowFooterBottomPadding: CGFloat = 10
+    static let flowSectionSpacing: CGFloat = 12
+    static let flowHeaderTopPadding: CGFloat = 2
+    static let flowHeaderControlSpacing: CGFloat = 8
+    static let flowHeaderTitleSpacing: CGFloat = 4
+    static let flowFooterTopPadding: CGFloat = 2
+    static let flowFooterBottomPadding: CGFloat = 6
     static let tileSpacing: CGFloat = 10
     static let pillSpacing: CGFloat = 8
-    static let cardPadding: CGFloat = 18
+    static let cardPadding: CGFloat = 16
     static let buttonTrailingIconPadding: CGFloat = 18
-    static let pillVerticalPadding: CGFloat = 9
+    static let pillVerticalPadding: CGFloat = 7
     static let secondaryButtonVerticalPadding: CGFloat = 14
     static let chevronTopPadding: CGFloat = 3
     static let zero: CGFloat = 0
-    static let selectedCheckOffsetX: CGFloat = 12
-    static let selectedCheckOffsetY: CGFloat = -6
+    static let selectedCheckOffsetX: CGFloat = 8
+    static let selectedCheckOffsetY: CGFloat = -4
     static let heroWavePrimaryOffsetX: CGFloat = -10
     static let heroWavePrimaryOffsetY: CGFloat = 18
     static let heroWaveSecondaryOffsetX: CGFloat = 6
@@ -54,7 +54,7 @@ nonisolated enum SymiRadius {
 }
 
 enum SymiShadow {
-    static let cardColor = AppTheme.symiPetrol.opacity(SymiOpacity.clearAccent)
+    static let cardColor = AppTheme.symiPetrol.opacity(SymiOpacity.cardShadow)
     static let cardRadius: CGFloat = 12
     static let cardXOffset: CGFloat = 0
     static let cardYOffset: CGFloat = 5
@@ -62,20 +62,33 @@ enum SymiShadow {
     static let brandCardYOffset: CGFloat = 6
     static let heroTextRadius: CGFloat = 3
     static let heroTextYOffset: CGFloat = 1
-    static let buttonColor = AppTheme.symiPetrol.opacity(SymiOpacity.softFill)
-    static let buttonRadius: CGFloat = 12
+    static let buttonColor = AppTheme.symiPetrol.opacity(SymiOpacity.shadow)
+    static let buttonRadius: CGFloat = 8
     static let buttonXOffset: CGFloat = 0
     static let buttonYOffset: CGFloat = 6
+    static let sliderThumbRadius: CGFloat = 2
+    static let sliderThumbYOffset: CGFloat = 1
 }
 
 nonisolated enum SymiSize {
     static let accessibilityMarker: CGFloat = 1
     static let minInteractiveHeight: CGFloat = 44
-    static let primaryButtonHeight: CGFloat = 54
-    static let progressIndicator: CGFloat = 24
-    static let inputSelectionTileMinHeight: CGFloat = 84
+    static let flowHeaderControlHeight: CGFloat = 34
+    static let primaryButtonHeight: CGFloat = 48
+    static let progressIndicator: CGFloat = 22
+    static let progressTrackHeight: CGFloat = 4
+    static let progressTotalWidth: CGFloat = 44
+    static let inputSelectionTileMinHeight: CGFloat = 78
     static let inputSelectionIconWidth: CGFloat = 34
     static let inputSelectionIconHeight: CGFloat = 30
+    static let headacheLocationIconHeight: CGFloat = 26
+    static let headacheLocationTileMinHeight: CGFloat = 78
+    static let headachePresetMinHeight: CGFloat = 50
+    static let headacheOptionGridMinWidth: CGFloat = 58
+    static let headacheOptionGridColumnCount: Int = 4
+    static let painSliderTouchHeight: CGFloat = 44
+    static let painSliderTrackHeight: CGFloat = 5
+    static let painSliderThumbSize: CGFloat = 24
     static let medicationRowMinHeight: CGFloat = 72
     static let selectedMedicationRowMinHeight: CGFloat = 108
     static let medicationQuantityMinWidth: CGFloat = 24
@@ -89,6 +102,8 @@ nonisolated enum SymiSize {
     static let multiSelectGridMinWidth: CGFloat = 140
     static let tagGridMinWidth: CGFloat = 120
     static let pillGridMinWidth: CGFloat = 70
+    static let flowCompactTileGridMinWidth: CGFloat = 72
+    static let flowTwoColumnTileGridMinWidth: CGFloat = 132
     static let statusDot: CGFloat = 10
     static let calendarDot: CGFloat = 9
     static let calendarPlaceholderHeight: CGFloat = 16
@@ -104,8 +119,8 @@ nonisolated enum SymiSize {
     static let heroWaveSecondaryHeight: CGFloat = 44
     static let heroWaveAccentWidth: CGFloat = 132
     static let heroWaveAccentHeight: CGFloat = 34
-    static let painGaugeWidth: CGFloat = 212
-    static let painGaugeHeight: CGFloat = 142
+    static let painGaugeWidth: CGFloat = 218
+    static let painGaugeHeight: CGFloat = 148
     static let emptyStateMinHeight: CGFloat = 360
     static let defaultWindowWidth: CGFloat = 1280
     static let defaultWindowHeight: CGFloat = 800
@@ -124,13 +139,17 @@ nonisolated enum SymiStroke {
     static let heroWaveAccent: CGFloat = 4
     static let heroWaveSecondary: CGFloat = 5
     static let heroWavePrimary: CGFloat = 8
-    static let painGaugeArc: CGFloat = 13
+    static let painGaugeArc: CGFloat = 18
 }
 
 nonisolated enum SymiOpacity {
+    static let clearStroke: Double = 0.04
     static let clearAccent: Double = 0.06
+    static let cardShadow: Double = 0.07
     static let hairline: Double = 0.08
+    static let faintTrack: Double = 0.08
     static let shadow: Double = 0.10
+    static let sliderThumbShadow: Double = 0.18
     static let faintSurface: Double = 0.12
     static let softFill: Double = 0.16
     static let secondaryFill: Double = 0.18
@@ -152,11 +171,14 @@ nonisolated enum SymiOpacity {
     static let disabledContent: Double = 0.55
     static let disabledTile: Double = 0.58
     static let heroSecondaryWave: Double = 0.72
+    static let secondaryActionText: Double = 0.66
     static let appBackgroundSurface: Double = 0.72
     static let heroPrimaryWave: Double = 0.82
+    static let strongText: Double = 0.82
     static let heroSecondaryText: Double = 0.86
     static let heroAccentWave: Double = 0.92
     static let strongSurface: Double = 0.96
+    static let footerBackground: Double = 0.96
     static let opaque: Double = 1
     static let elevatedShadow: Double = 1.2
 }

--- a/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum SymiTypography {
     static let compactScaleFactor = 0.82
+    static let tightChipScaleFactor = 0.72
     static let buttonScaleFactor = 0.85
     static let gaugeScaleFactor = 0.75
     static let headline = Font.headline
@@ -10,14 +11,17 @@ enum SymiTypography {
     static let button = Font.headline.weight(.semibold)
     static let caption = Font.caption
     static let largeMetric = Font.system(size: 58, weight: .bold, design: .rounded)
+    static let painGaugeMetric = Font.system(size: 52, weight: .bold, design: .rounded)
+    static let painGaugeUnit = Font.footnote.weight(.medium)
+    static let painGaugeLabel = Font.title3.weight(.semibold)
     static let homeMetric = Font.system(size: 44, weight: .bold, design: .rounded)
-    static let flowTitle = Font.title.weight(.bold)
+    static let flowTitle = Font.system(size: 24, weight: .bold, design: .rounded)
     static let flowSubtitle = Font.callout
-    static let flowSectionTitle = Font.callout.weight(.medium)
+    static let flowSectionTitle = Font.subheadline.weight(.regular)
     static let flowTileLabel = Font.subheadline.weight(.medium)
     static let flowPillLabel = Font.footnote.weight(.medium)
     static let flowPrimaryButton = Font.headline.weight(.semibold)
-    static let flowSecondaryAction = Font.callout.weight(.medium)
+    static let flowSecondaryAction = Font.footnote.weight(.medium)
     static let flowSummaryTitle = Font.headline.weight(.semibold)
     static let flowSummaryLine = Font.subheadline
 }

--- a/SymiUITests/EntryFlowUITests.swift
+++ b/SymiUITests/EntryFlowUITests.swift
@@ -12,7 +12,6 @@ final class EntryFlowUITests: XCTestCase {
         XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
         assertHeadacheStepMatchesReference(in: app)
         attachScreenshot(named: "entry-flow-01-headache", app: app)
-        app.buttons["entry-location-Schläfen"].tap()
         app.buttons["entry-flow-next"].tap()
 
         XCTAssertTrue(step("medication", in: app).waitForExistence(timeout: 3))
@@ -82,7 +81,6 @@ final class EntryFlowUITests: XCTestCase {
 
         XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
         let templeButton = app.buttons["entry-location-Schläfen"]
-        templeButton.tap()
         app.buttons["entry-flow-next"].tap()
 
         XCTAssertTrue(step("medication", in: app).waitForExistence(timeout: 3))
@@ -96,14 +94,13 @@ final class EntryFlowUITests: XCTestCase {
         let app = launchEntryFlow()
 
         XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 6))
-        app.buttons["entry-location-Schläfen"].tap()
         app.buttons["entry-flow-next"].tap()
 
         XCTAssertTrue(step("medication", in: app).waitForExistence(timeout: 3))
         app.buttons["entry-flow-cancel"].tap()
 
         XCTAssertTrue(step("headache", in: app).waitForExistence(timeout: 3))
-        XCTAssertEqual(app.buttons["entry-location-Schläfen"].value as? String, "Nicht ausgewählt")
+        XCTAssertEqual(app.buttons["entry-location-Schläfen"].value as? String, "Ausgewählt")
     }
 
     func testAccessibilitySizeDarkModeAndTouchTargets() {
@@ -149,6 +146,7 @@ final class EntryFlowUITests: XCTestCase {
         XCTAssertVisibleText("Wo spürst du den Schmerz?", in: app)
         XCTAssertVisibleText("Wann tritt es auf?", in: app)
         XCTAssertTrue(app.buttons["entry-location-Schläfen"].exists)
+        XCTAssertEqual(app.buttons["entry-location-Schläfen"].value as? String, "Ausgewählt")
         XCTAssertTrue(app.buttons["entry-started-at-now"].exists)
         XCTAssertTrue(app.buttons["entry-flow-next"].exists)
         XCTAssertTrue(app.buttons["entry-flow-save-headache-only"].exists)


### PR DESCRIPTION
## Summary
- Aligns the headache entry step with the 5-screen concept flow: tighter header/progress, calmer typography, compact footer, and revised pain gauge layout.
- Refactors Step 1 onto reusable flow components: `InputFlowHeader`, `InputFlowProgressBar`, `PainGaugeCard`, `SelectionTile`, `PillOption`, existing `PrimaryButton`, and `SecondaryAction`.
- Applies final Apple Health-style polish: clear green-orange-coral gauge gradient, exact progress badge/track centering with optical 1pt adjustment, tighter slider-thumb shadow, clearer card-to-section rhythm, and lower-emphasis secondary action text.
- Polishes card softness, softer tile/pill borders, subtle card shadow, and a tokenized spacing rhythm.
- Moves UI sizing/font values including `minimumColumnWidth` into design tokens and adds a SwiftLint rule for raw `minimumColumnWidth` values.
- Updates entry-flow UI tests for the new default selection behavior.

## Validation
- `swiftlint`
- `git diff --check`
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 16'`
- `xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SymiUITests/EntryFlowUITests/testCancelInTheMiddleReturnsToFreshHeadacheStep -only-testing:SymiUITests/EntryFlowUITests/testBackNavigationKeepsDraftSelection`

Closes #189