### PR TITLE
[codex] Build home pattern preview

### DIFF
--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -525,6 +525,34 @@ struct HomeOverviewData: Equatable {
     let episodeCount: Int
 }
 
+struct HomePatternPreviewData: Equatable {
+    let totalPainEpisodeCount: Int
+    let cards: [HomePatternPreviewCard]
+
+    var hasEnoughData: Bool {
+        totalPainEpisodeCount >= Self.minimumEpisodeCount
+    }
+
+    static let minimumEpisodeCount = 3
+}
+
+struct HomePatternPreviewCard: Identifiable, Equatable {
+    enum Kind: String, Equatable {
+        case frequentDay
+        case weatherSymptoms
+        case menstruationCycle
+    }
+
+    let kind: Kind
+    let title: String
+    let value: String
+    let detail: String
+    let systemImage: String
+    let isWide: Bool
+
+    var id: String { kind.rawValue }
+}
+
 struct LoadHomeOverviewUseCase {
     let repository: EpisodeRepository
 
@@ -541,6 +569,110 @@ struct LoadHomeOverviewUseCase {
                 episodeCount: episodes.count
             )
         }
+    }
+}
+
+struct LoadHomePatternPreviewUseCase {
+    let repository: EpisodeRepository
+
+    func execute() async throws -> HomePatternPreviewData {
+        let repository = repository
+        let episodes = try await Task.detached(priority: .userInitiated) {
+            try repository.fetchRecent()
+        }.value
+        return HomePatternPreviewBuilder.build(from: episodes)
+    }
+}
+
+enum HomePatternPreviewBuilder {
+    static func build(from episodes: [EpisodeRecord], calendar: Calendar = .current) -> HomePatternPreviewData {
+        let painEpisodes = episodes.filter { episode in
+            episode.type == .headache || episode.type == .migraine
+        }
+
+        guard painEpisodes.count >= HomePatternPreviewData.minimumEpisodeCount else {
+            return HomePatternPreviewData(totalPainEpisodeCount: painEpisodes.count, cards: [])
+        }
+
+        let cards = [
+            frequentDayCard(from: painEpisodes, calendar: calendar),
+            weatherSymptomsCard(from: painEpisodes),
+            menstruationCycleCard(from: painEpisodes)
+        ]
+        .compactMap { $0 }
+        .prefix(3)
+
+        return HomePatternPreviewData(totalPainEpisodeCount: painEpisodes.count, cards: Array(cards))
+    }
+
+    private static func frequentDayCard(from episodes: [EpisodeRecord], calendar: Calendar) -> HomePatternPreviewCard? {
+        let grouped = Dictionary(grouping: episodes) { calendar.component(.weekday, from: $0.startedAt) }
+        guard
+            let match = grouped.max(by: { lhs, rhs in lhs.value.count < rhs.value.count }),
+            match.value.count >= 2
+        else {
+            return nil
+        }
+
+        return HomePatternPreviewCard(
+            kind: .frequentDay,
+            title: "Häufigster Tag",
+            value: weekdayName(for: match.key, calendar: calendar),
+            detail: "An diesem Wochentag liegen in deinen bisherigen Einträgen etwas mehr Notizen.",
+            systemImage: "calendar",
+            isWide: false
+        )
+    }
+
+    private static func weatherSymptomsCard(from episodes: [EpisodeRecord]) -> HomePatternPreviewCard? {
+        let episodesWithWeatherAndSymptoms = episodes.filter { $0.weather != nil && !$0.symptoms.isEmpty }
+        guard episodesWithWeatherAndSymptoms.count >= HomePatternPreviewData.minimumEpisodeCount else {
+            return nil
+        }
+
+        let symptoms = episodesWithWeatherAndSymptoms.flatMap(\.symptoms)
+        guard let symptom = mostCommonValue(in: symptoms) else {
+            return nil
+        }
+
+        return HomePatternPreviewCard(
+            kind: .weatherSymptoms,
+            title: "Wetter & Symptome",
+            value: symptom,
+            detail: "Bei Einträgen mit Wetterkontext wurde dieses Symptom öfter notiert.",
+            systemImage: "cloud.sun",
+            isWide: false
+        )
+    }
+
+    private static func menstruationCycleCard(from episodes: [EpisodeRecord]) -> HomePatternPreviewCard? {
+        let cycleEpisodes = episodes.filter { $0.menstruationStatus == .active || $0.menstruationStatus == .expected }
+        guard cycleEpisodes.count >= 2 else {
+            return nil
+        }
+
+        return HomePatternPreviewCard(
+            kind: .menstruationCycle,
+            title: "Menstruationszyklus",
+            value: "\(cycleEpisodes.count) Einträge",
+            detail: "Bei einigen Einträgen ist Zykluskontext hinterlegt. Das ist nur ein vorsichtiger Hinweis.",
+            systemImage: "drop",
+            isWide: true
+        )
+    }
+
+    private static func mostCommonValue(in values: [String]) -> String? {
+        Dictionary(grouping: values.filter { !$0.isEmpty }, by: { $0 })
+            .max { lhs, rhs in lhs.value.count < rhs.value.count }?
+            .key
+    }
+
+    private static func weekdayName(for weekday: Int, calendar: Calendar) -> String {
+        let symbols = calendar.weekdaySymbols
+        guard symbols.indices.contains(weekday - 1) else {
+            return "Ein Wochentag"
+        }
+        return symbols[weekday - 1]
     }
 }
 

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -7,6 +7,7 @@ struct HomeView: View {
     @State private var displayedMonth = Calendar.current.startOfMonth(for: .now)
     @State private var selectedDay = Calendar.current.startOfDay(for: .now)
     @State private var calendarMonthData = HistoryMonthData(month: Calendar.current.startOfMonth(for: .now), episodesByDay: [:])
+    @State private var patternPreviewData = HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
     @State private var isPresentingEpisodeEditor = false
 
     init(appContainer: AppContainer) {
@@ -23,7 +24,7 @@ struct HomeView: View {
         }
         .navigationTitle(ProductBranding.displayName)
         .task(id: displayedMonth) {
-            await reloadCalendarMonth()
+            await reloadAll()
         }
         .refreshable {
             await reloadAll()
@@ -50,6 +51,10 @@ struct HomeView: View {
 
                 QuickEntryCard(selectedDay: selectedDay) {
                     isPresentingEpisodeEditor = true
+                }
+
+                HomePatternPreviewSection(data: patternPreviewData) {
+                    HomeInsightsView(data: patternPreviewData)
                 }
 
                 FeelingCheckInCard()
@@ -92,6 +97,9 @@ struct HomeView: View {
                     QuickEntryCard(selectedDay: selectedDay) {
                         isPresentingEpisodeEditor = true
                     }
+                    HomePatternPreviewSection(data: patternPreviewData) {
+                        HomeInsightsView(data: patternPreviewData)
+                    }
                     FeelingCheckInCard()
                 }
 
@@ -119,11 +127,16 @@ struct HomeView: View {
 
     private func reloadAll() async {
         await reloadCalendarMonth()
+        await reloadPatternPreview()
     }
 
     private func reloadCalendarMonth() async {
         let month = displayedMonth
         calendarMonthData = (try? await LoadHistoryMonthUseCase(repository: appContainer.episodeRepository).execute(month: month)) ?? HistoryMonthData(month: month, episodesByDay: [:])
+    }
+
+    private func reloadPatternPreview() async {
+        patternPreviewData = (try? await LoadHomePatternPreviewUseCase(repository: appContainer.episodeRepository).execute()) ?? HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
     }
 
     private func showPreviousMonth() {
@@ -417,6 +430,176 @@ private struct QuickEntryCard: View {
 private struct HomeCalendarDay: Identifiable {
     let id = UUID()
     let date: Date?
+}
+
+private struct HomePatternPreviewSection<Destination: View>: View {
+    let data: HomePatternPreviewData
+    @ViewBuilder let destination: Destination
+
+    init(data: HomePatternPreviewData, @ViewBuilder destination: () -> Destination) {
+        self.data = data
+        self.destination = destination()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.md) {
+            HStack(alignment: .firstTextBaseline, spacing: SymiSpacing.md) {
+                Text("Deine Muster")
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+
+                Spacer(minLength: SymiSpacing.sm)
+
+                NavigationLink {
+                    destination
+                } label: {
+                    Label("Mehr ansehen", systemImage: "chevron.right")
+                        .labelStyle(.titleOnly)
+                        .font(.subheadline.weight(.semibold))
+                }
+                .accessibilityHint("Öffnet die Insights-Ansicht.")
+            }
+
+            if data.hasEnoughData, !data.cards.isEmpty {
+                LazyVGrid(columns: columns, alignment: .leading, spacing: SymiSpacing.md) {
+                    ForEach(data.cards) { card in
+                        HomePatternCard(card: card)
+                            .gridCellColumns(card.isWide ? 2 : 1)
+                    }
+                }
+            } else {
+                HomePatternEmptyState(recordedCount: data.totalPainEpisodeCount)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var columns: [GridItem] {
+        [
+            GridItem(.flexible(minimum: 140), spacing: SymiSpacing.md, alignment: .top),
+            GridItem(.flexible(minimum: 140), spacing: SymiSpacing.md, alignment: .top)
+        ]
+    }
+}
+
+private struct HomePatternCard: View {
+    let card: HomePatternPreviewCard
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
+            Image(systemName: card.systemImage)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(AppTheme.symiPetrol)
+                .frame(width: SymiSize.homePatternIcon, height: SymiSize.homePatternIcon)
+                .background(AppTheme.symiSage.opacity(SymiOpacity.secondaryFill), in: Circle())
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+                Text(card.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(AppTheme.symiTextSecondary)
+                    .textCase(.uppercase)
+
+                Text(card.value)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(AppTheme.symiTextPrimary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(SymiTypography.compactScaleFactor)
+            }
+
+            Text(card.detail)
+                .font(.footnote)
+                .foregroundStyle(AppTheme.symiTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(SymiSpacing.lg)
+        .frame(maxWidth: .infinity, minHeight: card.isWide ? 138 : 168, alignment: .topLeading)
+        .background(AppTheme.cardGradient, in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous)
+                .stroke(AppTheme.symiPetrol.opacity(SymiOpacity.hairline), lineWidth: SymiStroke.hairline)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct HomePatternEmptyState: View {
+    let recordedCount: Int
+
+    var body: some View {
+        HStack(alignment: .top, spacing: SymiSpacing.md) {
+            Image(systemName: "sparkles")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(AppTheme.symiCoral)
+                .frame(width: SymiSize.homePatternEmptyIcon, height: SymiSize.homePatternEmptyIcon)
+                .background(AppTheme.symiCoral.opacity(SymiOpacity.clearAccent), in: Circle())
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: SymiSpacing.xs) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(AppTheme.symiTextPrimary)
+
+                Text(emptyStateText)
+                    .font(.subheadline)
+                    .foregroundStyle(AppTheme.symiTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(SymiSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(AppTheme.symiOnAccent.opacity(SymiOpacity.strongSurface), in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous)
+                .stroke(AppTheme.symiSage.opacity(SymiOpacity.selectedFill), lineWidth: SymiStroke.hairline)
+        }
+    }
+
+    private var emptyStateText: String {
+        if recordedCount >= HomePatternPreviewData.minimumEpisodeCount {
+            return "Es gibt schon genug Einträge, aber noch keinen wiederkehrenden Hinweis, den wir ruhig anzeigen würden."
+        }
+
+        if recordedCount == 0 {
+            return "Wenn du ein paar Schmerz- oder Migräneeinträge erfasst hast, zeigen wir hier vorsichtige Hinweise."
+        }
+
+        return "\(recordedCount) von 3 nötigen Schmerz- oder Migräneeinträgen sind vorhanden."
+    }
+
+    private var title: String {
+        recordedCount >= HomePatternPreviewData.minimumEpisodeCount ? "Noch kein ruhiger Hinweis" : "Noch nicht genug Einträge"
+    }
+}
+
+private struct HomeInsightsView: View {
+    let data: HomePatternPreviewData
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: SymiSpacing.xxl) {
+                Text("Diese Hinweise basieren nur auf deinen bisherigen Schmerz- und Migräneeinträgen. Sie ersetzen keine medizinische Einschätzung.")
+                    .font(.subheadline)
+                    .foregroundStyle(AppTheme.symiTextSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if data.hasEnoughData, !data.cards.isEmpty {
+                    VStack(alignment: .leading, spacing: SymiSpacing.md) {
+                        ForEach(data.cards) { card in
+                            HomePatternCard(card: card)
+                        }
+                    }
+                } else {
+                    HomePatternEmptyState(recordedCount: data.totalPainEpisodeCount)
+                }
+            }
+            .padding(.horizontal, SymiSpacing.xxl)
+            .padding(.vertical, SymiSpacing.xl)
+            .wideContent(maxWidth: AppTheme.readableContentMaxWidth)
+        }
+        .brandScreen()
+        .navigationTitle("Deine Muster")
+    }
 }
 
 struct AdaptiveDashboardCard<Content: View>: View {

--- a/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
@@ -115,6 +115,8 @@ nonisolated enum SymiSize {
     static let homeCalendarDayNumber: CGFloat = 36
     static let quickEntryIcon: CGFloat = 58
     static let quickEntryMinHeight: CGFloat = 108
+    static let homePatternIcon: CGFloat = 34
+    static let homePatternEmptyIcon: CGFloat = 38
     static let trendChartHeight: CGFloat = 88
     static let reviewStepIcon: CGFloat = 44
     static let reviewSummaryIcon: CGFloat = 42

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -224,6 +224,52 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func homePatternPreviewRequiresEnoughPainEpisodes() async throws {
+        let repository = EpisodeRepositoryMock()
+        repository.recentRecords = [
+            makeEpisode(id: UUID(), startedAt: .now, intensity: 5, type: .migraine),
+            makeEpisode(id: UUID(), startedAt: .now.addingTimeInterval(-86_400), intensity: 3, type: .unclear),
+            makeEpisode(id: UUID(), startedAt: .now.addingTimeInterval(-172_800), intensity: 4, type: .headache)
+        ]
+
+        let result = try await LoadHomePatternPreviewUseCase(repository: repository).execute()
+
+        #expect(result.totalPainEpisodeCount == 2)
+        #expect(result.hasEnoughData == false)
+        #expect(result.cards.isEmpty)
+    }
+
+    @Test
+    func homePatternPreviewBuildsCautiousCardsFromPainEpisodes() async throws {
+        let repository = EpisodeRepositoryMock()
+        let monday = Date(timeIntervalSince1970: 1_711_929_600)
+        let tuesday = monday.addingTimeInterval(86_400)
+        let weather = WeatherRecord(
+            recordedAt: monday,
+            condition: "Regen",
+            temperature: 12,
+            humidity: 80,
+            pressure: 1_004,
+            precipitation: 1.2,
+            weatherCode: 61,
+            source: "Apple Weather"
+        )
+        repository.recentRecords = [
+            makeEpisode(id: UUID(), startedAt: monday, intensity: 6, type: .migraine, symptoms: ["Übelkeit"], menstruationStatus: .active, weather: weather),
+            makeEpisode(id: UUID(), startedAt: monday.addingTimeInterval(3_600), intensity: 5, type: .headache, symptoms: ["Übelkeit"], menstruationStatus: .expected, weather: weather),
+            makeEpisode(id: UUID(), startedAt: tuesday, intensity: 4, type: .migraine, symptoms: ["Lichtempfindlichkeit"], weather: weather)
+        ]
+
+        let result = try await LoadHomePatternPreviewUseCase(repository: repository).execute()
+
+        #expect(result.hasEnoughData)
+        #expect(result.cards.map(\.kind) == [.frequentDay, .weatherSymptoms, .menstruationCycle])
+        #expect(result.cards.first?.title == "Häufigster Tag")
+        #expect(result.cards.contains { $0.title == "Wetter & Symptome" })
+        #expect(result.cards.contains { $0.isWide })
+    }
+
+    @Test
     func loadSettingsUseCaseCountsActiveTrashAndConflicts() async throws {
         let episodeRepository = EpisodeRepositoryMock()
         let medicationRepository = MedicationCatalogRepositoryMock()
@@ -361,25 +407,34 @@ private final class SyncServiceMock: SyncService {
     func resolveConflictUsingRemote(_ conflict: SyncConflict) async {}
 }
 
-private func makeEpisode(id: UUID, startedAt: Date, intensity: Int, deletedAt: Date? = nil) -> EpisodeRecord {
+private func makeEpisode(
+    id: UUID,
+    startedAt: Date,
+    intensity: Int,
+    deletedAt: Date? = nil,
+    type: EpisodeType = .migraine,
+    symptoms: [String] = [],
+    menstruationStatus: MenstruationStatus = .unknown,
+    weather: WeatherRecord? = nil
+) -> EpisodeRecord {
     EpisodeRecord(
         id: id,
         startedAt: startedAt,
         endedAt: nil,
         updatedAt: startedAt,
         deletedAt: deletedAt,
-        type: .migraine,
+        type: type,
         intensity: intensity,
         painLocation: "",
         painCharacter: "",
         notes: "",
-        symptoms: [],
+        symptoms: symptoms,
         triggers: [],
         functionalImpact: "",
-        menstruationStatus: .unknown,
+        menstruationStatus: menstruationStatus,
         medications: [],
         continuousMedicationChecks: [],
-        weather: nil,
+        weather: weather,
         healthContext: nil
     )
 }


### PR DESCRIPTION
## Summary
- add a cautious `Deine Muster` preview below quick entry on Home
- derive cards only from real headache and migraine entries when enough data exists
- add a calm empty state and a `Mehr ansehen` insights detail view
- cover the pattern data rules with CoreArchitecture tests

Closes #176

## Validation
- `xcodebuild test -project Symi.xcodeproj -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SymiTests/CoreArchitectureTests CODE_SIGNING_ALLOWED=NO`\n- `swiftlint`