### PR TITLE
[codex] Harden home redesign QA

### DIFF
--- a/Symi/Sources/App/AppShellView.swift
+++ b/Symi/Sources/App/AppShellView.swift
@@ -32,6 +32,7 @@ enum AppSection: String, CaseIterable, Identifiable {
 
 struct AppShellView: View {
     let appContainer: AppContainer
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var selectedSection: AppSection = .overview
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
@@ -44,8 +45,8 @@ struct AppShellView: View {
                 regularRoot
             }
         }
-        .tint(AppTheme.symiPetrol)
-        .toolbarBackground(AppTheme.symiPetrol.opacity(SymiOpacity.strongSurface), for: .navigationBar)
+        .tint(AppTheme.petrol(for: colorScheme))
+        .toolbarBackground(AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.strongSurface), for: .navigationBar)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
             appContainer.startDeferredMaintenanceIfNeeded()
@@ -61,6 +62,8 @@ struct AppShellView: View {
                 .tabItem {
                     Label(section.title, systemImage: section.systemImage)
                 }
+                .accessibilityLabel("\(section.title) Tab")
+                .accessibilityIdentifier("tab-\(section.rawValue)")
                 .tag(section)
             }
         }
@@ -78,7 +81,10 @@ struct AppShellView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .buttonStyle(.plain)
-                    .listRowBackground(selectedSection == section ? AppTheme.selectedFill : Color.clear)
+                    .listRowBackground(selectedSection == section ? AppTheme.selectedFill(for: colorScheme) : Color.clear)
+                    .accessibilityLabel("\(section.title) Bereich")
+                    .accessibilityValue(selectedSection == section ? "Ausgewählt" : "")
+                    .accessibilityIdentifier("sidebar-\(section.rawValue)")
                 }
             }
             .navigationTitle(ProductBranding.displayName)

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -182,6 +182,7 @@ private struct HomeMonthCalendarView: View {
     let onSelectDay: (Date) -> Void
     let onPrevious: () -> Void
     let onNext: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: SymiSpacing.xs), count: 7)
     private let calendar = Calendar.current
@@ -191,7 +192,7 @@ private struct HomeMonthCalendarView: View {
             HStack(alignment: .center, spacing: SymiSpacing.md) {
                 Text(month.formatted(.dateTime.month(.wide).year()))
                     .font(.system(.largeTitle, design: .serif).weight(.regular))
-                    .foregroundStyle(AppTheme.symiPetrol)
+                    .foregroundStyle(AppTheme.petrol(for: colorScheme))
                     .lineLimit(1)
                     .minimumScaleFactor(SymiTypography.compactScaleFactor)
                     .accessibilityAddTraits(.isHeader)
@@ -208,7 +209,7 @@ private struct HomeMonthCalendarView: View {
                 ForEach(weekdaySymbols, id: \.self) { symbol in
                     Text(symbol)
                         .font(.caption.weight(.medium))
-                        .foregroundStyle(AppTheme.symiPetrol.opacity(SymiOpacity.heroSecondaryText))
+                        .foregroundStyle(AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.heroSecondaryText))
                         .frame(maxWidth: .infinity, minHeight: SymiSize.homeCalendarWeekdayHeight)
                         .accessibilityHidden(true)
                 }
@@ -235,19 +236,27 @@ private struct HomeMonthCalendarView: View {
         .padding(.vertical, SymiSpacing.xxl)
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .contain)
+        .accessibilityLabel("Monatskalender \(month.formatted(.dateTime.month(.wide).year()))")
+        .accessibilityIdentifier("home-calendar")
     }
 
     private func calendarNavigationButton(systemImage: String, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Image(systemName: systemImage)
                 .font(.title3.weight(.semibold))
-                .foregroundStyle(AppTheme.symiPetrol)
+                .foregroundStyle(AppTheme.petrol(for: colorScheme))
                 .frame(width: SymiSize.homeCalendarNavigationButton, height: SymiSize.homeCalendarNavigationButton)
-                .background(AppTheme.symiOnAccent, in: Circle())
-                .shadow(color: AppTheme.shadowColor.opacity(SymiOpacity.hairline), radius: 7, y: 3)
+                .background(AppTheme.cardBackground(for: colorScheme), in: Circle())
+                .shadow(
+                    color: AppTheme.shadowColor(for: colorScheme).opacity(SymiOpacity.hairline),
+                    radius: SymiShadow.calendarButtonRadius,
+                    y: SymiShadow.calendarButtonYOffset
+                )
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)
+        .accessibilityHint("Wechselt den angezeigten Monat im Home-Kalender.")
+        .accessibilityIdentifier(label == "Vorheriger Monat" ? "home-calendar-previous-month" : "home-calendar-next-month")
     }
 
     private var weekdaySymbols: [String] {
@@ -282,20 +291,22 @@ private struct HomeCalendarDayCell: View {
     let isToday: Bool
     let entries: [EpisodeRecord]
     let action: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         Button(action: action) {
             VStack(spacing: SymiSpacing.xxs) {
                 Text(date.formatted(.dateTime.day()))
-                    .font(.title3.weight(isSelected ? .semibold : .regular))
-                    .foregroundStyle(isSelected ? AppTheme.symiOnAccent : AppTheme.symiTextPrimary)
-                    .frame(width: SymiSize.homeCalendarDayNumber, height: SymiSize.homeCalendarDayNumber)
-                    .background(isSelected ? AppTheme.symiPetrol : Color.clear, in: Circle())
+                    .font(dayNumberFont)
+                    .foregroundStyle(isSelected ? AppTheme.symiOnAccent : AppTheme.textPrimary(for: colorScheme))
+                    .frame(width: dayNumberSize, height: dayNumberSize)
+                    .background(isSelected ? AppTheme.petrol(for: colorScheme) : Color.clear, in: Circle())
                     .overlay {
                         if isToday && !isSelected {
                             Circle()
-                                .stroke(AppTheme.symiPetrol.opacity(SymiOpacity.selectedFill), lineWidth: SymiStroke.hairline)
-                                .frame(width: SymiSize.homeCalendarDayNumber, height: SymiSize.homeCalendarDayNumber)
+                                .stroke(AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.selectedFill), lineWidth: SymiStroke.hairline)
+                                .frame(width: dayNumberSize, height: dayNumberSize)
                         }
                     }
 
@@ -314,24 +325,38 @@ private struct HomeCalendarDayCell: View {
                     .frame(height: SymiSize.calendarDot)
                 }
             }
-            .frame(maxWidth: .infinity, minHeight: SymiSize.calendarDayMinHeight)
+            .frame(maxWidth: .infinity, minHeight: calendarDayMinHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(isSelected ? "Ausgewählt" : "")
+        .accessibilityHint("Wählt diesen Tag für den Schnelleintrag aus.")
+        .accessibilityIdentifier("home-calendar-day-\(date.formatted(.dateTime.year().month(.twoDigits).day(.twoDigits)))")
     }
 
     private func dotColor(for entry: EpisodeRecord) -> Color {
         switch entry.intensity {
         case 8...10:
-            AppTheme.symiCoral
+            AppTheme.coral(for: colorScheme)
         case 5...7:
-            AppTheme.symiSage
+            AppTheme.sage(for: colorScheme)
         default:
-            AppTheme.symiPetrol.opacity(SymiOpacity.heroSecondaryText)
+            AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.heroSecondaryText)
         }
+    }
+
+    private var dayNumberFont: Font {
+        dynamicTypeSize.isAccessibilitySize ? .body.weight(isSelected ? .semibold : .regular) : .title3.weight(isSelected ? .semibold : .regular)
+    }
+
+    private var dayNumberSize: CGFloat {
+        dynamicTypeSize.isAccessibilitySize ? SymiSize.homeCalendarDayNumber + SymiSize.homeCalendarAccessibilityGrowth : SymiSize.homeCalendarDayNumber
+    }
+
+    private var calendarDayMinHeight: CGFloat {
+        dynamicTypeSize.isAccessibilitySize ? SymiSize.calendarDayMinHeight + SymiSize.homeCalendarDayAccessibilityGrowth : SymiSize.calendarDayMinHeight
     }
 
     private var accessibilityLabel: String {
@@ -358,6 +383,7 @@ private struct HomeCalendarDayCell: View {
 private struct QuickEntryCard: View {
     let selectedDay: Date
     let action: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: SymiSpacing.md) {
@@ -368,10 +394,10 @@ private struct QuickEntryCard: View {
 
                 Text("Neuer Flow")
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(AppTheme.symiPetrol)
+                    .foregroundStyle(AppTheme.petrol(for: colorScheme))
                     .padding(.horizontal, SymiSpacing.sm)
                     .padding(.vertical, SymiSpacing.xxs)
-                    .background(AppTheme.symiSage.opacity(SymiOpacity.secondaryFill), in: Capsule())
+                    .background(AppTheme.secondaryFill(for: colorScheme), in: Capsule())
                     .accessibilityLabel("Neuer Flow")
             }
 
@@ -381,18 +407,19 @@ private struct QuickEntryCard: View {
                         .font(.title.weight(.semibold))
                         .foregroundStyle(AppTheme.symiOnAccent)
                         .frame(width: SymiSize.quickEntryIcon, height: SymiSize.quickEntryIcon)
-                        .background(AppTheme.symiCoral, in: Circle())
+                        .background(AppTheme.coral(for: colorScheme), in: Circle())
+                        .accessibilityHidden(true)
 
                     VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                         Text("Neuen Eintrag erstellen")
                             .font(.title3.weight(.semibold))
-                            .foregroundStyle(AppTheme.symiTextPrimary)
+                            .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
                             .lineLimit(2)
                             .minimumScaleFactor(SymiTypography.compactScaleFactor)
 
                         Text("Startet mit \(selectedDay.formatted(date: .abbreviated, time: .omitted)) und führt dich Schritt für Schritt durch den Eintrag.")
                             .font(.subheadline)
-                            .foregroundStyle(AppTheme.symiTextSecondary)
+                            .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
                             .fixedSize(horizontal: false, vertical: true)
                     }
 
@@ -400,17 +427,18 @@ private struct QuickEntryCard: View {
 
                     Image(systemName: "chevron.right")
                         .font(.headline.weight(.semibold))
-                        .foregroundStyle(AppTheme.symiPetrol.opacity(SymiOpacity.heroSecondaryText))
+                        .foregroundStyle(AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.heroSecondaryText))
+                        .accessibilityHidden(true)
                 }
                 .padding(SymiSpacing.xl)
                 .frame(maxWidth: .infinity, minHeight: SymiSize.quickEntryMinHeight, alignment: .leading)
-                .background(AppTheme.cardGradient, in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
+                .background(AppTheme.cardGradient(for: colorScheme), in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
                 .overlay {
                     RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous)
-                        .stroke(AppTheme.symiCoral.opacity(SymiOpacity.selectedFill), lineWidth: SymiStroke.hairline)
+                        .stroke(AppTheme.coral(for: colorScheme).opacity(SymiOpacity.selectedFill), lineWidth: SymiStroke.hairline)
                 }
                 .shadow(
-                    color: AppTheme.shadowColor,
+                    color: AppTheme.shadowColor(for: colorScheme),
                     radius: SymiShadow.brandCardRadius,
                     x: SymiShadow.cardXOffset,
                     y: SymiShadow.brandCardYOffset
@@ -419,6 +447,7 @@ private struct QuickEntryCard: View {
             .buttonStyle(.plain)
             .keyboardShortcut("n", modifiers: .command)
             .hoverEffect(.highlight)
+            .accessibilityIdentifier("home-quick-entry")
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("Neuen Eintrag erstellen")
             .accessibilityHint("Startet den Schnelleintrag für \(selectedDay.formatted(date: .complete, time: .omitted)).")
@@ -458,6 +487,7 @@ private struct HomePatternPreviewSection<Destination: View>: View {
                         .font(.subheadline.weight(.semibold))
                 }
                 .accessibilityHint("Öffnet die Insights-Ansicht.")
+                .accessibilityIdentifier("home-patterns-show-more")
             }
 
             if data.hasEnoughData, !data.cards.isEmpty {
@@ -472,6 +502,7 @@ private struct HomePatternPreviewSection<Destination: View>: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier("home-patterns-section")
     }
 
     private var columns: [GridItem] {
@@ -484,75 +515,87 @@ private struct HomePatternPreviewSection<Destination: View>: View {
 
 private struct HomePatternCard: View {
     let card: HomePatternPreviewCard
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         VStack(alignment: .leading, spacing: SymiSpacing.sm) {
             Image(systemName: card.systemImage)
                 .font(.title3.weight(.semibold))
-                .foregroundStyle(AppTheme.symiPetrol)
+                .foregroundStyle(AppTheme.petrol(for: colorScheme))
                 .frame(width: SymiSize.homePatternIcon, height: SymiSize.homePatternIcon)
-                .background(AppTheme.symiSage.opacity(SymiOpacity.secondaryFill), in: Circle())
+                .background(AppTheme.secondaryFill(for: colorScheme), in: Circle())
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                 Text(card.title)
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(AppTheme.symiTextSecondary)
+                    .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
                     .textCase(.uppercase)
 
                 Text(card.value)
                     .font(.title3.weight(.semibold))
-                    .foregroundStyle(AppTheme.symiTextPrimary)
+                    .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
                     .lineLimit(2)
                     .minimumScaleFactor(SymiTypography.compactScaleFactor)
             }
 
             Text(card.detail)
                 .font(.footnote)
-                .foregroundStyle(AppTheme.symiTextSecondary)
+                .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(SymiSpacing.lg)
-        .frame(maxWidth: .infinity, minHeight: card.isWide ? 138 : 168, alignment: .topLeading)
-        .background(AppTheme.cardGradient, in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
+        .frame(maxWidth: .infinity, minHeight: cardMinHeight, alignment: .topLeading)
+        .background(AppTheme.cardGradient(for: colorScheme), in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous)
-                .stroke(AppTheme.symiPetrol.opacity(SymiOpacity.hairline), lineWidth: SymiStroke.hairline)
+                .stroke(AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.hairline), lineWidth: SymiStroke.hairline)
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(card.title), \(card.value). \(card.detail)")
+        .accessibilityIdentifier("home-pattern-card-\(card.title)")
+    }
+
+    private var cardMinHeight: CGFloat {
+        let baseHeight = card.isWide ? SymiSize.homePatternWideMinHeight : SymiSize.homePatternMinHeight
+        return dynamicTypeSize.isAccessibilitySize ? baseHeight + SymiSize.homePatternAccessibilityHeightGrowth : baseHeight
     }
 }
 
 private struct HomePatternEmptyState: View {
     let recordedCount: Int
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         HStack(alignment: .top, spacing: SymiSpacing.md) {
             Image(systemName: "sparkles")
                 .font(.title3.weight(.semibold))
-                .foregroundStyle(AppTheme.symiCoral)
+                .foregroundStyle(AppTheme.coral(for: colorScheme))
                 .frame(width: SymiSize.homePatternEmptyIcon, height: SymiSize.homePatternEmptyIcon)
-                .background(AppTheme.symiCoral.opacity(SymiOpacity.clearAccent), in: Circle())
+                .background(AppTheme.coral(for: colorScheme).opacity(SymiOpacity.clearAccent), in: Circle())
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: SymiSpacing.xs) {
                 Text(title)
                     .font(.headline)
-                    .foregroundStyle(AppTheme.symiTextPrimary)
+                    .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
 
                 Text(emptyStateText)
                     .font(.subheadline)
-                    .foregroundStyle(AppTheme.symiTextSecondary)
+                    .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
         .padding(SymiSpacing.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(AppTheme.symiOnAccent.opacity(SymiOpacity.strongSurface), in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
+        .background(AppTheme.cardBackground(for: colorScheme), in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous)
-                .stroke(AppTheme.symiSage.opacity(SymiOpacity.selectedFill), lineWidth: SymiStroke.hairline)
+                .stroke(AppTheme.sage(for: colorScheme).opacity(SymiOpacity.selectedFill), lineWidth: SymiStroke.hairline)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("home-patterns-empty-state")
     }
 
     private var emptyStateText: String {
@@ -605,6 +648,7 @@ private struct HomeInsightsView: View {
 struct AdaptiveDashboardCard<Content: View>: View {
     let title: String
     @ViewBuilder let content: Content
+    @Environment(\.colorScheme) private var colorScheme
 
     init(title: String, @ViewBuilder content: () -> Content) {
         self.title = title
@@ -615,6 +659,7 @@ struct AdaptiveDashboardCard<Content: View>: View {
         VStack(alignment: .leading, spacing: SymiSpacing.secondaryButtonVerticalPadding) {
             Text(title)
                 .font(.headline)
+                .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
                 .accessibilityAddTraits(.isHeader)
 
             VStack(alignment: .leading, spacing: SymiSpacing.md) {
@@ -630,6 +675,7 @@ struct AdaptiveDashboardCard<Content: View>: View {
 
 private struct FeelingCheckInCard: View {
     @State private var currentState = 4.0
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         AdaptiveDashboardCard(title: "Wie geht es dir heute?") {
@@ -637,20 +683,21 @@ private struct FeelingCheckInCard: View {
                 HStack(alignment: .firstTextBaseline) {
                     Text("\(Int(currentState))")
                         .font(SymiTypography.homeMetric)
-                        .foregroundStyle(AppTheme.symiPetrol)
+                        .foregroundStyle(AppTheme.petrol(for: colorScheme))
                     Text(feelingLabel)
                         .font(.headline)
-                        .foregroundStyle(AppTheme.symiTextSecondary)
+                        .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
                 }
 
                 Slider(value: $currentState, in: 0 ... 10, step: 1)
-                    .tint(AppTheme.symiCoral)
+                    .tint(AppTheme.coral(for: colorScheme))
                     .accessibilityLabel("Aktueller Zustand")
                     .accessibilityValue("\(Int(currentState)) von 10")
+                    .accessibilityIdentifier("home-feeling-slider")
 
                 Text("Eine schnelle Einschätzung reicht. Details kannst du im Eintrag ergänzen.")
                     .font(.subheadline)
-                    .foregroundStyle(AppTheme.symiTextSecondary)
+                    .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
             }
         }
     }

--- a/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
@@ -47,6 +47,7 @@ enum SymiColors {
     static let noteAmber = SymiColorValue(hex: 0xD18A2B)
     static let reviewPurple = SymiColorValue(hex: 0x8A65D6)
 
+    static let petrolDark = SymiColorValue(hex: 0x8ECDB8)
     static let coralDark = SymiColorValue(hex: 0xFFA196)
     static let sageDark = SymiColorValue(hex: 0xA9DEC9)
     static let triggerBlueDark = SymiColorValue(hex: 0x81A0F1)
@@ -56,9 +57,24 @@ enum SymiColors {
     static let darkBackgroundTop = SymiColorValue(hex: 0x14171A)
     static let darkBackgroundMiddle = SymiColorValue(hex: 0x0F1A1A)
     static let darkBackgroundBottom = SymiColorValue(hex: 0x1A1714)
+    static let darkCardBackground = SymiColorValue(hex: 0x202629)
+    static let darkTextPrimary = SymiColorValue(hex: 0xF5F7F6)
+    static let darkTextSecondary = SymiColorValue(hex: 0xC5CFCC)
+
+    static func cardBackground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? darkCardBackground.color : card.color
+    }
+
+    static func textPrimary(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? darkTextPrimary.color : textPrimary.color
+    }
+
+    static func textSecondary(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? darkTextSecondary.color : textSecondary.color
+    }
 
     static func elevatedCard(for colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark ? Color(uiColor: .secondarySystemGroupedBackground) : card.color
+        colorScheme == .dark ? darkCardBackground.color : card.color
     }
 
     static func subtleSeparator(for colorScheme: ColorScheme) -> Color {

--- a/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
@@ -66,6 +66,8 @@ enum SymiShadow {
     static let buttonRadius: CGFloat = 8
     static let buttonXOffset: CGFloat = 0
     static let buttonYOffset: CGFloat = 6
+    static let calendarButtonRadius: CGFloat = 7
+    static let calendarButtonYOffset: CGFloat = 3
     static let sliderThumbRadius: CGFloat = 2
     static let sliderThumbYOffset: CGFloat = 1
 }
@@ -113,9 +115,14 @@ nonisolated enum SymiSize {
     static let homeCalendarWeekdayHeight: CGFloat = 26
     static let homeCalendarNavigationButton: CGFloat = 50
     static let homeCalendarDayNumber: CGFloat = 36
+    static let homeCalendarAccessibilityGrowth: CGFloat = 10
+    static let homeCalendarDayAccessibilityGrowth: CGFloat = 14
     static let quickEntryIcon: CGFloat = 58
     static let quickEntryMinHeight: CGFloat = 108
     static let homePatternIcon: CGFloat = 34
+    static let homePatternWideMinHeight: CGFloat = 138
+    static let homePatternMinHeight: CGFloat = 168
+    static let homePatternAccessibilityHeightGrowth: CGFloat = 54
     static let homePatternEmptyIcon: CGFloat = 38
     static let trendChartHeight: CGFloat = 88
     static let reviewStepIcon: CGFloat = 44

--- a/Symi/Sources/Shared/AppTheme.swift
+++ b/Symi/Sources/Shared/AppTheme.swift
@@ -61,14 +61,90 @@ enum AppTheme {
     static let secondaryFill = symiSage.opacity(SymiOpacity.secondaryFill)
     static let cardBorder = Color.clear
     static let shadowColor = symiPetrol.opacity(SymiOpacity.shadow)
+
+    static func petrol(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? SymiColors.petrolDark.color : SymiColors.primaryPetrol.color
+    }
+
+    static func sage(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? SymiColors.sageDark.color : SymiColors.sage.color
+    }
+
+    static func coral(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? SymiColors.coralDark.color : SymiColors.coral.color
+    }
+
+    static func warmBackground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? SymiColors.darkBackgroundMiddle.color : SymiColors.warmBackground.color
+    }
+
+    static func cardBackground(for colorScheme: ColorScheme) -> Color {
+        SymiColors.cardBackground(for: colorScheme)
+    }
+
+    static func textPrimary(for colorScheme: ColorScheme) -> Color {
+        SymiColors.textPrimary(for: colorScheme)
+    }
+
+    static func textSecondary(for colorScheme: ColorScheme) -> Color {
+        SymiColors.textSecondary(for: colorScheme)
+    }
+
+    static func appBackground(for colorScheme: ColorScheme) -> LinearGradient {
+        let colors: [Color] = if colorScheme == .dark {
+            [
+                SymiColors.darkBackgroundTop.color,
+                SymiColors.darkBackgroundMiddle.color,
+                SymiColors.darkBackgroundBottom.color
+            ]
+        } else {
+            [
+                SymiColors.warmBackground.color,
+                SymiColors.onAccent.color.opacity(SymiOpacity.appBackgroundSurface),
+                SymiColors.sage.color.opacity(SymiOpacity.backgroundAccent)
+            ]
+        }
+
+        return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    static func cardGradient(for colorScheme: ColorScheme) -> LinearGradient {
+        let colors: [Color] = if colorScheme == .dark {
+            [
+                SymiColors.cardBackground(for: colorScheme),
+                SymiColors.sageDark.color.opacity(SymiOpacity.softFill)
+            ]
+        } else {
+            [
+                SymiColors.card.color,
+                SymiColors.onAccent.color.opacity(SymiOpacity.strongSurface)
+            ]
+        }
+
+        return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    static func selectedFill(for colorScheme: ColorScheme) -> Color {
+        sage(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.stepSelectedFillDark : SymiOpacity.selectedFill)
+    }
+
+    static func secondaryFill(for colorScheme: ColorScheme) -> Color {
+        sage(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.pressedFill : SymiOpacity.secondaryFill)
+    }
+
+    static func shadowColor(for colorScheme: ColorScheme) -> Color {
+        Color.black.opacity(colorScheme == .dark ? SymiOpacity.backgroundAccent : SymiOpacity.shadow)
+    }
 }
 
 private struct BrandScreenModifier: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
     func body(content: Content) -> some View {
         content
-            .tint(AppTheme.symiPetrol)
+            .tint(AppTheme.petrol(for: colorScheme))
             .scrollContentBackground(.hidden)
-            .background(AppTheme.appBackground.ignoresSafeArea())
+            .background(AppTheme.appBackground(for: colorScheme).ignoresSafeArea())
     }
 }
 
@@ -98,12 +174,14 @@ private struct WideContentModifier: ViewModifier {
 }
 
 private struct BrandCardModifier: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
     func body(content: Content) -> some View {
         content
-            .background(AppTheme.cardGradient)
+            .background(AppTheme.cardGradient(for: colorScheme))
             .clipShape(RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
             .shadow(
-                color: AppTheme.shadowColor,
+                color: AppTheme.shadowColor(for: colorScheme),
                 radius: SymiShadow.brandCardRadius,
                 x: SymiShadow.cardXOffset,
                 y: SymiShadow.brandCardYOffset
@@ -112,16 +190,18 @@ private struct BrandCardModifier: ViewModifier {
 }
 
 struct SymiPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.colorScheme) private var colorScheme
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(SymiTypography.button)
             .foregroundStyle(AppTheme.symiOnAccent)
             .padding(.vertical, SymiSpacing.lg)
             .frame(maxWidth: .infinity)
-            .background(AppTheme.symiCoral.opacity(configuration.isPressed ? SymiOpacity.heroPrimaryWave : SymiOpacity.opaque))
+            .background(AppTheme.coral(for: colorScheme).opacity(configuration.isPressed ? SymiOpacity.heroPrimaryWave : SymiOpacity.opaque))
             .clipShape(RoundedRectangle(cornerRadius: SymiRadius.button, style: .continuous))
             .shadow(
-                color: AppTheme.symiCoral.opacity(configuration.isPressed ? SymiOpacity.pressedShadow : SymiOpacity.backgroundAccent),
+                color: AppTheme.coral(for: colorScheme).opacity(configuration.isPressed ? SymiOpacity.pressedShadow : SymiOpacity.backgroundAccent),
                 radius: SymiShadow.buttonRadius,
                 y: SymiShadow.buttonYOffset
             )
@@ -129,13 +209,15 @@ struct SymiPrimaryButtonStyle: ButtonStyle {
 }
 
 struct SymiSecondaryButtonStyle: ButtonStyle {
+    @Environment(\.colorScheme) private var colorScheme
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(SymiTypography.button)
-            .foregroundStyle(AppTheme.symiPetrol)
+            .foregroundStyle(AppTheme.petrol(for: colorScheme))
             .padding(.vertical, SymiSpacing.secondaryButtonVerticalPadding)
             .frame(maxWidth: .infinity)
-            .background(AppTheme.symiSage.opacity(configuration.isPressed ? SymiOpacity.pressedFill : SymiOpacity.secondaryPressedFill))
+            .background(AppTheme.sage(for: colorScheme).opacity(configuration.isPressed ? SymiOpacity.pressedFill : SymiOpacity.secondaryPressedFill))
             .clipShape(RoundedRectangle(cornerRadius: SymiRadius.button, style: .continuous))
     }
 }

--- a/SymiTests/NewEntryDesignSystemTests.swift
+++ b/SymiTests/NewEntryDesignSystemTests.swift
@@ -55,6 +55,19 @@ struct NewEntryDesignSystemTests {
     }
 
     @Test
+    func symiDarkModeTokensUseReadableHomePalette() {
+        #expect(SymiColors.petrolDark.hexString == "#8ECDB8")
+        #expect(SymiColors.coralDark.hexString == "#FFA196")
+        #expect(SymiColors.sageDark.hexString == "#A9DEC9")
+        #expect(SymiColors.darkBackgroundTop.hexString == "#14171A")
+        #expect(SymiColors.darkBackgroundMiddle.hexString == "#0F1A1A")
+        #expect(SymiColors.darkBackgroundBottom.hexString == "#1A1714")
+        #expect(SymiColors.darkCardBackground.hexString == "#202629")
+        #expect(SymiColors.darkTextPrimary.hexString == "#F5F7F6")
+        #expect(SymiColors.darkTextSecondary.hexString == "#C5CFCC")
+    }
+
+    @Test
     func stepThemesMapFlowStepsToExpectedAccentTokens() {
         let expected: [NewEntryStepID: InputFlowStepTheme] = [
             .headache: .pain,

--- a/SymiUITests/HomeRedesignUITests.swift
+++ b/SymiUITests/HomeRedesignUITests.swift
@@ -1,0 +1,90 @@
+import XCTest
+
+@MainActor
+final class HomeRedesignUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testHomeSupportsDarkModeLargeTypeAndCoreAccessibilityLabels() {
+        let app = launchHome(
+            extraArguments: [
+                "-AppleInterfaceStyle", "Dark",
+                "-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityL"
+            ]
+        )
+
+        XCTAssertTrue(app.descendants(matching: .any)["home-calendar"].waitForExistence(timeout: 6))
+        XCTAssertTrue(accessibilityElement(containing: "Monatskalender", in: app).exists)
+        XCTAssertTrue(accessibilityElement(valueContaining: "Ausgewählt", in: app).exists)
+
+        let quickEntry = app.descendants(matching: .any)["home-quick-entry"]
+        scrollUntilVisible(quickEntry, in: app)
+        XCTAssertTrue(quickEntry.exists)
+
+        XCTAssertMinimumTouchTarget(app.buttons["home-calendar-previous-month"])
+        XCTAssertMinimumTouchTarget(app.buttons["home-calendar-next-month"])
+        XCTAssertMinimumTouchTarget(quickEntry)
+
+        XCTAssertTrue(accessibilityElement(containing: "Neuen Eintrag erstellen", in: app).exists)
+
+        scrollUntilVisible(app.descendants(matching: .any)["home-patterns-section"], in: app)
+        XCTAssertTrue(app.descendants(matching: .any)["home-patterns-section"].exists)
+
+        scrollUntilVisible(app.sliders["home-feeling-slider"], in: app)
+        XCTAssertTrue(app.sliders["home-feeling-slider"].exists)
+
+        attachScreenshot(named: "home-redesign-dark-large-type", app: app)
+    }
+
+    private func launchHome(extraArguments: [String] = []) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-ui_testing",
+            "-mt_screenshot_screen",
+            "home",
+            "-mt_screenshot_seed",
+            "default"
+        ]
+        app.launchArguments += extraArguments
+        app.launch()
+        return app
+    }
+
+    private func accessibilityElement(containing text: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)
+            .containing(NSPredicate(format: "label CONTAINS %@", text))
+            .firstMatch
+    }
+
+    private func accessibilityElement(valueContaining text: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)
+            .containing(NSPredicate(format: "value CONTAINS %@", text))
+            .firstMatch
+    }
+
+    private func scrollUntilVisible(_ element: XCUIElement, in app: XCUIApplication) {
+        let scrollView = app.scrollViews.firstMatch
+
+        for _ in 0 ..< 5 where !element.isHittable {
+            scrollView.swipeUp()
+        }
+    }
+
+    private func XCTAssertMinimumTouchTarget(
+        _ element: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(element.exists, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(element.frame.width, 44, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(element.frame.height, 44, file: file, line: line)
+    }
+
+    private func attachScreenshot(named name: String, app: XCUIApplication) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/SymiUITests/SymiScreenshotTests.swift
+++ b/SymiUITests/SymiScreenshotTests.swift
@@ -6,6 +6,19 @@ final class SymiScreenshotTests: XCTestCase {
         let route: String
         let germanSnapshotName: String
         let englishSnapshotName: String
+        let extraArguments: [String]
+
+        init(
+            route: String,
+            germanSnapshotName: String,
+            englishSnapshotName: String,
+            extraArguments: [String] = []
+        ) {
+            self.route = route
+            self.germanSnapshotName = germanSnapshotName
+            self.englishSnapshotName = englishSnapshotName
+            self.extraArguments = extraArguments
+        }
 
         func snapshotName(for language: String) -> String {
             language.localizedCaseInsensitiveContains("de") ? germanSnapshotName : englishSnapshotName
@@ -19,6 +32,15 @@ final class SymiScreenshotTests: XCTestCase {
     func testCaptureMainStoreScreens() throws {
         let screens: [Screen] = [
             .init(route: "home", germanSnapshotName: "01-mehr-gute-tage", englishSnapshotName: "01-more-good-days"),
+            .init(
+                route: "home",
+                germanSnapshotName: "01a-home-dunkel-grosse-schrift",
+                englishSnapshotName: "01a-home-dark-large-type",
+                extraArguments: [
+                    "-AppleInterfaceStyle", "Dark",
+                    "-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityL"
+                ]
+            ),
             .init(route: "new-entry", germanSnapshotName: "02-in-sekunden-eintragen", englishSnapshotName: "02-log-in-seconds"),
             .init(route: "history", germanSnapshotName: "03-erkenne-deine-muster", englishSnapshotName: "03-recognize-patterns"),
             .init(route: "episode-detail", germanSnapshotName: "04-alles-im-blick", englishSnapshotName: "04-everything-in-view"),
@@ -35,6 +57,7 @@ final class SymiScreenshotTests: XCTestCase {
                 "-mt_screenshot_seed",
                 "default"
             ]
+            app.launchArguments += screen.extraArguments
             app.launch()
             waitForStableLayout()
             snapshot(screen.snapshotName(for: Snapshot.deviceLanguage), waitForLoadingIndicator: false)


### PR DESCRIPTION
## Summary
- centralize Home color, surface, shadow, spacing, and Dynamic Type styling through Symi tokens
- improve Home accessibility labels and identifiers for calendar, CTA, pattern cards, and navigation
- add Dark Mode / large type UI coverage and extend screenshot capture for the Home screen

## Validation
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination "platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4.1" -only-testing:SymiTests/NewEntryDesignSystemTests
- xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination "platform=iOS Simulator,name=iPhone 17 Pro Max,OS=26.4.1" -only-testing:SymiUITests/HomeRedesignUITests/testHomeSupportsDarkModeLargeTypeAndCoreAccessibilityLabels

Closes #177