### PR TITLE
[codex] Close home navigation redesign

### DIFF
--- a/Symi/Sources/App/AppShellView.swift
+++ b/Symi/Sources/App/AppShellView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 enum AppSection: String, CaseIterable, Identifiable {
-    case overview
-    case history
+    case diary
+    case insights
     case export
     case settings
     case information
@@ -11,8 +11,8 @@ enum AppSection: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .overview: "Heute"
-        case .history: "Tagebuch"
+        case .diary: "Tagebuch"
+        case .insights: "Insights"
         case .export: "Teilen"
         case .settings: "Einstellungen"
         case .information: "Hinweise"
@@ -21,8 +21,8 @@ enum AppSection: String, CaseIterable, Identifiable {
 
     var systemImage: String {
         switch self {
-        case .overview: "sparkles"
-        case .history: "book.closed"
+        case .diary: "book.closed"
+        case .insights: "chart.line.uptrend.xyaxis"
         case .export: "square.and.arrow.up"
         case .settings: "gearshape"
         case .information: "hand.raised"
@@ -34,7 +34,7 @@ struct AppShellView: View {
     let appContainer: AppContainer
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var selectedSection: AppSection = .overview
+    @State private var selectedSection: AppSection = .diary
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
     var body: some View {
@@ -55,7 +55,7 @@ struct AppShellView: View {
 
     private var compactRoot: some View {
         TabView(selection: $selectedSection) {
-            ForEach([AppSection.overview, .history, .export, .settings]) { section in
+            ForEach([AppSection.diary, .insights, .export, .settings]) { section in
                 NavigationStack {
                     content(for: section)
                 }
@@ -102,10 +102,10 @@ struct AppShellView: View {
     @ViewBuilder
     private func content(for section: AppSection) -> some View {
         switch section {
-        case .overview:
+        case .diary:
             HomeView(appContainer: appContainer)
-        case .history:
-            HistoryView(appContainer: appContainer)
+        case .insights:
+            InsightsView(appContainer: appContainer)
         case .export:
             DataExportView(appContainer: appContainer)
         case .settings:
@@ -118,7 +118,7 @@ struct AppShellView: View {
     @ViewBuilder
     private func regularContent(for section: AppSection) -> some View {
         switch section {
-        case .overview, .history:
+        case .diary, .insights:
             content(for: section)
         case .export, .settings, .information:
             RegularDetailSurface {

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -55,10 +55,13 @@ struct HomeView: View {
                 PrimaryEntryButton {
                     isPresentingEpisodeEditor = true
                 }
-                .padding(.bottom, SymiSpacing.xxxl)
+                .padding(.bottom, SymiSpacing.md)
+
+                HomeAllEntriesLink(appContainer: appContainer)
+                    .padding(.bottom, SymiSpacing.xxxl)
 
                 HomePatternPreviewSection(data: patternPreviewData) {
-                    HomeInsightsView(data: patternPreviewData)
+                    InsightsView(appContainer: appContainer)
                 }
                 .padding(.bottom, SymiSpacing.xxxl + SymiSpacing.xxs)
             }
@@ -85,10 +88,13 @@ struct HomeView: View {
                 PrimaryEntryButton {
                     isPresentingEpisodeEditor = true
                 }
-                .padding(.bottom, SymiSpacing.xxxl)
+                .padding(.bottom, SymiSpacing.md)
+
+                HomeAllEntriesLink(appContainer: appContainer)
+                    .padding(.bottom, SymiSpacing.xxxl)
 
                 HomePatternPreviewSection(data: patternPreviewData) {
-                    HomeInsightsView(data: patternPreviewData)
+                    InsightsView(appContainer: appContainer)
                 }
                 .padding(.bottom, SymiSpacing.xxxl + SymiSpacing.xxs)
             }
@@ -198,7 +204,7 @@ private struct HomeMonthCalendarView: View {
             Image(systemName: systemImage)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(AppTheme.petrol(for: colorScheme))
-                .frame(width: SymiSize.minInteractiveHeight, height: SymiSize.minInteractiveHeight)
+                .frame(width: SymiSize.minInteractiveHeight + 2, height: SymiSize.minInteractiveHeight + 2)
                 .background(AppTheme.sage(for: colorScheme).opacity(SymiOpacity.faintSurface), in: Circle())
         }
         .buttonStyle(.plain)
@@ -378,6 +384,44 @@ private struct PrimaryEntryButton: View {
     }
 }
 
+private struct HomeAllEntriesLink: View {
+    let appContainer: AppContainer
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        NavigationLink {
+            HistoryView(appContainer: appContainer)
+        } label: {
+            HStack(spacing: SymiSpacing.sm) {
+                Image(systemName: "list.bullet.rectangle")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(AppTheme.petrol(for: colorScheme))
+                    .accessibilityHidden(true)
+
+                Text("Alle Einträge")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(AppTheme.petrol(for: colorScheme))
+
+                Spacer(minLength: SymiSpacing.xs)
+
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, SymiSpacing.md)
+            .frame(maxWidth: .infinity, minHeight: SymiSize.minInteractiveHeight, alignment: .leading)
+            .background(
+                AppTheme.sage(for: colorScheme).opacity(SymiOpacity.faintSurface),
+                in: RoundedRectangle(cornerRadius: SymiRadius.button, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("home-all-entries")
+        .accessibilityHint("Öffnet die Liste aller Einträge.")
+    }
+}
+
 private struct HomeCalendarDay: Identifiable {
     let id = UUID()
     let date: Date?
@@ -525,33 +569,55 @@ private struct HomePatternEmptyState: View {
     }
 }
 
-private struct HomeInsightsView: View {
-    let data: HomePatternPreviewData
+struct InsightsView: View {
+    let appContainer: AppContainer
+    @State private var data = HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: SymiSpacing.xxl) {
-                Text("Diese Hinweise basieren nur auf deinen bisherigen Schmerz- und Migräneeinträgen. Sie ersetzen keine medizinische Einschätzung.")
-                    .font(.subheadline)
-                    .foregroundStyle(AppTheme.symiTextSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                if data.hasEnoughData, !data.cards.isEmpty {
-                    VStack(alignment: .leading, spacing: SymiSpacing.md) {
-                        ForEach(data.cards) { card in
-                            HomePatternCard(card: card)
-                        }
-                    }
-                } else {
-                    HomePatternEmptyState(recordedCount: data.totalPainEpisodeCount)
-                }
-            }
+            HomeInsightsContent(data: data)
             .padding(.horizontal, SymiSpacing.xxl)
             .padding(.vertical, SymiSpacing.xl)
             .wideContent(maxWidth: AppTheme.readableContentMaxWidth)
         }
         .brandScreen()
-        .navigationTitle("Deine Muster")
+        .navigationTitle("Insights")
+        .task {
+            await reload()
+        }
+        .refreshable {
+            await reload()
+        }
+    }
+
+    private func reload() async {
+        data = (try? await LoadHomePatternPreviewUseCase(repository: appContainer.episodeRepository).execute()) ?? HomePatternPreviewData(
+            totalPainEpisodeCount: 0,
+            cards: []
+        )
+    }
+}
+
+private struct HomeInsightsContent: View {
+    let data: HomePatternPreviewData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.xxl) {
+            Text("Diese Hinweise basieren nur auf deinen bisherigen Schmerz- und Migräneeinträgen. Sie ersetzen keine medizinische Einschätzung.")
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.symiTextSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if data.hasEnoughData, !data.cards.isEmpty {
+                VStack(alignment: .leading, spacing: SymiSpacing.md) {
+                    ForEach(data.cards) { card in
+                        HomePatternCard(card: card)
+                    }
+                }
+            } else {
+                HomePatternEmptyState(recordedCount: data.totalPainEpisodeCount)
+            }
+        }
     }
 }
 

--- a/SymiUITests/HomeRedesignUITests.swift
+++ b/SymiUITests/HomeRedesignUITests.swift
@@ -29,10 +29,36 @@ final class HomeRedesignUITests: XCTestCase {
         XCTAssertTrue(accessibilityElement(containing: "Eintrag erstellen", in: app).exists)
         XCTAssertFalse(app.sliders["home-feeling-slider"].exists)
 
+        let allEntries = app.descendants(matching: .any)["home-all-entries"]
+        scrollUntilVisible(allEntries, in: app)
+        XCTAssertTrue(allEntries.exists)
+        XCTAssertMinimumTouchTarget(allEntries)
+
         scrollUntilVisible(app.descendants(matching: .any)["home-patterns-section"], in: app)
         XCTAssertTrue(app.descendants(matching: .any)["home-patterns-section"].exists)
 
         attachScreenshot(named: "home-redesign-dark-large-type", app: app)
+    }
+
+    func testAppShellUsesRequestedTabs() {
+        let app = launchAppShell()
+
+        XCTAssertTrue(app.tabBars.buttons["Tagebuch"].waitForExistence(timeout: 6))
+        XCTAssertTrue(app.tabBars.buttons["Insights"].exists)
+        XCTAssertTrue(app.tabBars.buttons["Teilen"].exists)
+        XCTAssertTrue(app.tabBars.buttons["Einstellungen"].exists)
+        XCTAssertFalse(app.tabBars.buttons["Heute"].exists)
+    }
+
+    func testHomeOpensAllEntriesList() {
+        let app = launchHome()
+
+        let allEntries = app.descendants(matching: .any)["home-all-entries"]
+        scrollUntilVisible(allEntries, in: app)
+        XCTAssertTrue(allEntries.waitForExistence(timeout: 6))
+        allEntries.tap()
+
+        XCTAssertTrue(accessibilityElement(containing: "Ausgewählter Tag", in: app).waitForExistence(timeout: 6))
     }
 
     private func launchHome(extraArguments: [String] = []) -> XCUIApplication {
@@ -45,6 +71,12 @@ final class HomeRedesignUITests: XCTestCase {
             "default",
         ]
         app.launchArguments += extraArguments
+        app.launch()
+        return app
+    }
+
+    private func launchAppShell() -> XCUIApplication {
+        let app = XCUIApplication()
         app.launch()
         return app
     }


### PR DESCRIPTION
## Summary
- update the app shell tabs to Tagebuch, Insights, Teilen, Einstellungen
- keep Home as the Tagebuch start page and add a non-dominant Alle Einträge link to the previous entry list
- make Insights a standalone view that loads its own pattern preview data

## Validation
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SymiTests/CoreArchitectureTests -only-testing:SymiTests/NewEntryDesignSystemTests
- xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SymiUITests/HomeRedesignUITests
- xcodebuild build -project Symi.xcodeproj -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16'
- git diff --check

Closes #126
