### PR TITLE
Implement Insight Engine (#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16
 ## Weiterführende Dokumente
 
 - [docs/MVP-Konzept.md](/Users/mat/code/Symi/docs/MVP-Konzept.md)
+- [docs/Insight-Engine.md](/Users/mat/code/Symi/docs/Insight-Engine.md)
 - [docs/App-Store-Metadaten.md](/Users/mat/code/Symi/docs/App-Store-Metadaten.md)
 - [docs/Teststrategie-und-Release-Checkliste.md](/Users/mat/code/Symi/docs/Teststrategie-und-Release-Checkliste.md)
 - [Symi Support](https://symiapp.com)

--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -53,6 +53,16 @@
         }
       }
     },
+    "%@ %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        }
+      }
+    },
     "%@ %% Luftfeuchte" : {
       "localizations" : {
         "en" : {
@@ -376,6 +386,9 @@
       }
     },
     "Alle Details" : {
+
+    },
+    "Alle Einträge" : {
 
     },
     "Alles im Blick" : {
@@ -1676,6 +1689,7 @@
       }
     },
     "Heute" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1709,6 +1723,9 @@
       }
     },
     "In Sekunden eintragen" : {
+
+    },
+    "Insights" : {
 
     },
     "Intensität" : {
@@ -2390,6 +2407,9 @@
     "Öffnet die Insights-Ansicht." : {
 
     },
+    "Öffnet die Liste aller Einträge." : {
+
+    },
     "Öffnet einen neuen Tagebuch-Eintrag mit dem aktuell ausgewählten Kalendertag." : {
       "localizations" : {
         "en" : {
@@ -2825,6 +2845,9 @@
     "Skala" : {
 
     },
+    "So entstehen die Hinweise" : {
+
+    },
     "So entsteht schnell ein hilfreicher Tagebuch-Eintrag. Alles Weitere ist optional." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2954,6 +2977,9 @@
           }
         }
       }
+    },
+    "Symi wertet nur Migräne- und Kopfschmerz-Einträge aus. Ab %lld Einträgen entstehen Kandidaten für Wochentag, Trigger, Durchschnitt und Trend. Confidence kombiniert Musterstärke und Datenmenge; Importance kombiniert Relevanz und Intensität. Angezeigt wird erst ab 50 %% Confidence und 40 %% Importance, sortiert nach dem kombinierten Score." : {
+
     },
     "Symi-Bericht" : {
       "localizations" : {
@@ -3425,6 +3451,9 @@
           }
         }
       }
+    },
+    "Wichtigster Hinweis" : {
+
     },
     "Wiederherstellen" : {
       "localizations" : {

--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -18,6 +18,7 @@ final class AppContainer {
     let medicationCatalogRepository: MedicationCatalogRepository
     let continuousMedicationRepository: ContinuousMedicationRepository
     let exportRepository: ExportRepository
+    let insightEngine: InsightEngine
     let syncService: SyncService
     let appLogService: AppLogService
 
@@ -54,6 +55,7 @@ final class AppContainer {
         self.medicationCatalogRepository = SwiftDataMedicationCatalogRepository(modelContainer: modelContainer)
         self.continuousMedicationRepository = SwiftDataContinuousMedicationRepository(modelContainer: modelContainer)
         self.exportRepository = SwiftDataExportRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
+        self.insightEngine = InsightEngine()
         self.syncService = SyncServiceAdapter(coordinator: syncCoordinator)
         self.appLogService = appLogStore
     }

--- a/Symi/Sources/App/AppShellView.swift
+++ b/Symi/Sources/App/AppShellView.swift
@@ -21,8 +21,8 @@ enum AppSection: String, CaseIterable, Identifiable {
 
     var systemImage: String {
         switch self {
-        case .diary: "book.closed"
-        case .insights: "chart.line.uptrend.xyaxis"
+        case .diary: "book.pages"
+        case .insights: "sparkle.magnifyingglass"
         case .export: "square.and.arrow.up"
         case .settings: "gearshape"
         case .information: "hand.raised"

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -533,14 +533,38 @@ struct HomePatternPreviewData: Equatable {
         totalPainEpisodeCount >= Self.minimumEpisodeCount
     }
 
-    static let minimumEpisodeCount = 3
+    static let minimumEpisodeCount = InsightEngine.minimumQualifiedEpisodeCount
+
+    init(totalPainEpisodeCount: Int, cards: [HomePatternPreviewCard]) {
+        self.totalPainEpisodeCount = totalPainEpisodeCount
+        self.cards = cards
+    }
+
+    init(result: InsightResult) {
+        totalPainEpisodeCount = result.totalQualifiedEpisodeCount
+        cards = result.insights.map(HomePatternPreviewCard.init)
+    }
 }
 
 struct HomePatternPreviewCard: Identifiable, Equatable {
     enum Kind: String, Equatable {
-        case frequentDay
-        case weatherSymptoms
-        case menstruationCycle
+        case weekdayPattern
+        case triggerCorrelation
+        case averageIntensity
+        case trend
+
+        init(category: InsightCategory) {
+            switch category {
+            case .weekdayPattern:
+                self = .weekdayPattern
+            case .triggerCorrelation:
+                self = .triggerCorrelation
+            case .averageIntensity:
+                self = .averageIntensity
+            case .trend:
+                self = .trend
+            }
+        }
     }
 
     let kind: Kind
@@ -551,6 +575,31 @@ struct HomePatternPreviewCard: Identifiable, Equatable {
     let isWide: Bool
 
     var id: String { kind.rawValue }
+
+    init(
+        kind: Kind,
+        title: String,
+        value: String,
+        detail: String,
+        systemImage: String,
+        isWide: Bool
+    ) {
+        self.kind = kind
+        self.title = title
+        self.value = value
+        self.detail = detail
+        self.systemImage = systemImage
+        self.isWide = isWide
+    }
+
+    init(insight: Insight) {
+        kind = Kind(category: insight.category)
+        title = insight.category.displayTitle
+        value = insight.title
+        detail = insight.description
+        systemImage = insight.systemImage ?? insight.category.fallbackSystemImage
+        isWide = insight.category == .trend
+    }
 }
 
 struct LoadHomeOverviewUseCase {
@@ -574,105 +623,29 @@ struct LoadHomeOverviewUseCase {
 
 struct LoadHomePatternPreviewUseCase {
     let repository: EpisodeRepository
+    let insightEngine: InsightEngine
 
     func execute() async throws -> HomePatternPreviewData {
+        let result = try await LoadInsightResultUseCase(
+            repository: repository,
+            insightEngine: insightEngine
+        ).execute()
+
+        return HomePatternPreviewData(result: result)
+    }
+}
+
+struct LoadInsightResultUseCase {
+    let repository: EpisodeRepository
+    let insightEngine: InsightEngine
+
+    func execute() async throws -> InsightResult {
         let repository = repository
         let episodes = try await Task.detached(priority: .userInitiated) {
             try repository.fetchRecent()
         }.value
-        return HomePatternPreviewBuilder.build(from: episodes)
-    }
-}
 
-enum HomePatternPreviewBuilder {
-    static func build(from episodes: [EpisodeRecord], calendar: Calendar = .current) -> HomePatternPreviewData {
-        let painEpisodes = episodes.filter { episode in
-            episode.type == .headache || episode.type == .migraine
-        }
-
-        guard painEpisodes.count >= HomePatternPreviewData.minimumEpisodeCount else {
-            return HomePatternPreviewData(totalPainEpisodeCount: painEpisodes.count, cards: [])
-        }
-
-        let cards = [
-            frequentDayCard(from: painEpisodes, calendar: calendar),
-            weatherSymptomsCard(from: painEpisodes),
-            menstruationCycleCard(from: painEpisodes)
-        ]
-        .compactMap { $0 }
-        .prefix(3)
-
-        return HomePatternPreviewData(totalPainEpisodeCount: painEpisodes.count, cards: Array(cards))
-    }
-
-    private static func frequentDayCard(from episodes: [EpisodeRecord], calendar: Calendar) -> HomePatternPreviewCard? {
-        let grouped = Dictionary(grouping: episodes) { calendar.component(.weekday, from: $0.startedAt) }
-        guard
-            let match = grouped.max(by: { lhs, rhs in lhs.value.count < rhs.value.count }),
-            match.value.count >= 2
-        else {
-            return nil
-        }
-
-        return HomePatternPreviewCard(
-            kind: .frequentDay,
-            title: "Häufigster Tag",
-            value: weekdayName(for: match.key, calendar: calendar),
-            detail: "An diesem Wochentag liegen in deinen bisherigen Einträgen etwas mehr Notizen.",
-            systemImage: "calendar",
-            isWide: false
-        )
-    }
-
-    private static func weatherSymptomsCard(from episodes: [EpisodeRecord]) -> HomePatternPreviewCard? {
-        let episodesWithWeatherAndSymptoms = episodes.filter { $0.weather != nil && !$0.symptoms.isEmpty }
-        guard episodesWithWeatherAndSymptoms.count >= HomePatternPreviewData.minimumEpisodeCount else {
-            return nil
-        }
-
-        let symptoms = episodesWithWeatherAndSymptoms.flatMap(\.symptoms)
-        guard let symptom = mostCommonValue(in: symptoms) else {
-            return nil
-        }
-
-        return HomePatternPreviewCard(
-            kind: .weatherSymptoms,
-            title: "Wetter & Symptome",
-            value: symptom,
-            detail: "Bei Einträgen mit Wetterkontext wurde dieses Symptom öfter notiert.",
-            systemImage: "cloud.sun",
-            isWide: false
-        )
-    }
-
-    private static func menstruationCycleCard(from episodes: [EpisodeRecord]) -> HomePatternPreviewCard? {
-        let cycleEpisodes = episodes.filter { $0.menstruationStatus == .active || $0.menstruationStatus == .expected }
-        guard cycleEpisodes.count >= 2 else {
-            return nil
-        }
-
-        return HomePatternPreviewCard(
-            kind: .menstruationCycle,
-            title: "Menstruationszyklus",
-            value: "\(cycleEpisodes.count) Einträge",
-            detail: "Bei einigen Einträgen ist Zykluskontext hinterlegt. Das ist nur ein vorsichtiger Hinweis.",
-            systemImage: "drop",
-            isWide: true
-        )
-    }
-
-    private static func mostCommonValue(in values: [String]) -> String? {
-        Dictionary(grouping: values.filter { !$0.isEmpty }, by: { $0 })
-            .max { lhs, rhs in lhs.value.count < rhs.value.count }?
-            .key
-    }
-
-    private static func weekdayName(for weekday: Int, calendar: Calendar) -> String {
-        let symbols = calendar.weekdaySymbols
-        guard symbols.indices.contains(weekday - 1) else {
-            return "Ein Wochentag"
-        }
-        return symbols[weekday - 1]
+        return insightEngine.evaluate(episodes: episodes)
     }
 }
 

--- a/Symi/Sources/Core/Insights/InsightCore.swift
+++ b/Symi/Sources/Core/Insights/InsightCore.swift
@@ -1,0 +1,497 @@
+import Foundation
+
+struct Insight: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let description: String
+    let confidence: Double
+    let importance: Double
+    let category: InsightCategory
+    let systemImage: String?
+}
+
+enum InsightCategory: String, CaseIterable, Equatable, Sendable {
+    case weekdayPattern
+    case triggerCorrelation
+    case averageIntensity
+    case trend
+
+    var displayTitle: String {
+        switch self {
+        case .weekdayPattern:
+            "Wochentag"
+        case .triggerCorrelation:
+            "Trigger"
+        case .averageIntensity:
+            "Durchschnitt"
+        case .trend:
+            "Trend"
+        }
+    }
+
+    var fallbackSystemImage: String {
+        switch self {
+        case .weekdayPattern:
+            "calendar"
+        case .triggerCorrelation:
+            "tag"
+        case .averageIntensity:
+            "gauge.medium"
+        case .trend:
+            "chart.line.uptrend.xyaxis"
+        }
+    }
+}
+
+struct InsightResult: Equatable, Sendable {
+    let totalQualifiedEpisodeCount: Int
+    let insights: [Insight]
+
+    var heroInsight: Insight? {
+        insights.first
+    }
+
+    var hasEnoughData: Bool {
+        totalQualifiedEpisodeCount >= InsightEngine.minimumQualifiedEpisodeCount
+    }
+}
+
+final class InsightEngine: @unchecked Sendable {
+    static let minimumQualifiedEpisodeCount = 5
+
+    private var cachedFingerprint: String?
+    private var cachedResult: InsightResult?
+    private let cacheLock = NSLock()
+
+    func evaluate(episodes: [EpisodeRecord], calendar: Calendar = .current) -> InsightResult {
+        let fingerprint = DataAggregator.fingerprint(for: episodes, calendar: calendar)
+
+        cacheLock.lock()
+        if fingerprint == cachedFingerprint, let cachedResult {
+            cacheLock.unlock()
+            return cachedResult
+        }
+        cacheLock.unlock()
+
+        let aggregate = DataAggregator.aggregate(episodes: episodes, calendar: calendar)
+        let result: InsightResult
+
+        if aggregate.qualifiedEpisodes.count < Self.minimumQualifiedEpisodeCount {
+            result = InsightResult(totalQualifiedEpisodeCount: aggregate.qualifiedEpisodes.count, insights: [])
+        } else {
+            let insights = PatternDetector.detect(in: aggregate)
+                .compactMap { InsightScorer.score($0, aggregate: aggregate) }
+                .filter { $0.confidence >= InsightScorer.confidenceThreshold && $0.importance >= InsightScorer.importanceThreshold }
+                .sorted { lhs, rhs in
+                    if lhs.sortScore != rhs.sortScore {
+                        return lhs.sortScore > rhs.sortScore
+                    }
+
+                    if lhs.confidence != rhs.confidence {
+                        return lhs.confidence > rhs.confidence
+                    }
+
+                    return lhs.insight.title.localizedStandardCompare(rhs.insight.title) == .orderedAscending
+                }
+                .map(\.insight)
+
+            result = InsightResult(totalQualifiedEpisodeCount: aggregate.qualifiedEpisodes.count, insights: insights)
+        }
+
+        cacheLock.lock()
+        cachedFingerprint = fingerprint
+        cachedResult = result
+        cacheLock.unlock()
+
+        return result
+    }
+}
+
+enum DataAggregator {
+    static func aggregate(episodes: [EpisodeRecord], calendar: Calendar) -> InsightAggregate {
+        let qualifiedEpisodes = qualifiedEpisodes(from: episodes).sorted { lhs, rhs in
+            if lhs.startedAt != rhs.startedAt {
+                return lhs.startedAt < rhs.startedAt
+            }
+
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+
+        let intensities = qualifiedEpisodes.map(\.intensity)
+        let averageIntensity = average(intensities.map(Double.init))
+        let weekdayGroups = Dictionary(grouping: qualifiedEpisodes) { episode in
+            calendar.component(.weekday, from: episode.startedAt)
+        }
+        let weekdayCounts = weekdayGroups.mapValues(\.count)
+        let weekdayAverageIntensities = weekdayGroups.mapValues { episodes in
+            average(episodes.map { Double($0.intensity) })
+        }
+
+        let triggerCounts = qualifiedEpisodes.reduce(into: [String: Int]()) { counts, episode in
+            for trigger in normalizedTriggers(from: episode) {
+                counts[trigger, default: 0] += 1
+            }
+        }
+
+        return InsightAggregate(
+            qualifiedEpisodes: qualifiedEpisodes,
+            averageIntensity: averageIntensity,
+            weekdayCounts: weekdayCounts,
+            weekdayAverageIntensities: weekdayAverageIntensities,
+            triggerCounts: triggerCounts
+        )
+    }
+
+    static func fingerprint(for episodes: [EpisodeRecord], calendar: Calendar) -> String {
+        let calendarPart = [
+            "\(calendar.identifier)",
+            calendar.timeZone.identifier,
+            "\(calendar.firstWeekday)"
+        ].joined(separator: "|")
+
+        let episodeParts = qualifiedEpisodes(from: episodes)
+            .sorted { $0.id.uuidString < $1.id.uuidString }
+            .map { episode in
+                [
+                    episode.id.uuidString,
+                    "\(episode.startedAt.timeIntervalSinceReferenceDate)",
+                    "\(episode.updatedAt.timeIntervalSinceReferenceDate)",
+                    episode.type.rawValue,
+                    "\(episode.intensity)",
+                    normalizedTriggers(from: episode).joined(separator: ","),
+                    episode.weather == nil ? "no-weather" : "weather"
+                ].joined(separator: "|")
+            }
+
+        return ([calendarPart] + episodeParts).joined(separator: "\n")
+    }
+
+    static func qualifiedEpisodes(from episodes: [EpisodeRecord]) -> [EpisodeRecord] {
+        episodes.filter { episode in
+            !episode.isDeleted && (episode.type == .migraine || episode.type == .headache)
+        }
+    }
+
+    static func normalizedTriggers(from episode: EpisodeRecord) -> [String] {
+        Array(Set(episode.triggers.map(normalizeLabel).filter { !$0.isEmpty })).sorted()
+    }
+
+    static func normalizeLabel(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func average(_ values: [Double]) -> Double {
+        guard !values.isEmpty else {
+            return 0
+        }
+
+        return values.reduce(0, +) / Double(values.count)
+    }
+}
+
+struct InsightAggregate: Equatable, Sendable {
+    let qualifiedEpisodes: [EpisodeRecord]
+    let averageIntensity: Double
+    let weekdayCounts: [Int: Int]
+    let weekdayAverageIntensities: [Int: Double]
+    let triggerCounts: [String: Int]
+}
+
+enum PatternDetector {
+    static func detect(in aggregate: InsightAggregate) -> [InsightCandidate] {
+        [
+            weekdayPattern(in: aggregate),
+            triggerCorrelation(in: aggregate),
+            averageIntensity(in: aggregate),
+            trend(in: aggregate)
+        ].compactMap { $0 }
+    }
+
+    private static func weekdayPattern(in aggregate: InsightAggregate) -> InsightCandidate? {
+        guard
+            let match = aggregate.weekdayCounts.sorted(by: weekdaySort).first,
+            match.value >= 2
+        else {
+            return nil
+        }
+
+        let totalCount = aggregate.qualifiedEpisodes.count
+        let share = Double(match.value) / Double(totalCount)
+        let randomWeekdayBaseline = 1.0 / 7.0
+        let patternStrength = clamped((share - randomWeekdayBaseline) / (1.0 - randomWeekdayBaseline))
+        let matchingAverage = aggregate.weekdayAverageIntensities[match.key] ?? aggregate.averageIntensity
+
+        return InsightCandidate(
+            category: .weekdayPattern,
+            key: "\(match.key)",
+            supportCount: match.value,
+            patternStrength: patternStrength,
+            relevantAverageIntensity: matchingAverage,
+            payload: .weekday(weekday: match.key, count: match.value, share: share)
+        )
+    }
+
+    private static func triggerCorrelation(in aggregate: InsightAggregate) -> InsightCandidate? {
+        guard
+            let match = aggregate.triggerCounts.sorted(by: triggerSort).first,
+            match.value >= 2
+        else {
+            return nil
+        }
+
+        let totalCount = aggregate.qualifiedEpisodes.count
+        let share = Double(match.value) / Double(totalCount)
+        let matchingAverage = DataAggregator.average(
+            aggregate.qualifiedEpisodes
+                .filter { DataAggregator.normalizedTriggers(from: $0).contains(match.key) }
+                .map { Double($0.intensity) }
+        )
+
+        return InsightCandidate(
+            category: .triggerCorrelation,
+            key: DataAggregator.normalizeLabel(match.key).lowercased(),
+            supportCount: match.value,
+            patternStrength: clamped(share),
+            relevantAverageIntensity: matchingAverage,
+            payload: .trigger(name: match.key, count: match.value, share: share)
+        )
+    }
+
+    private static func averageIntensity(in aggregate: InsightAggregate) -> InsightCandidate? {
+        InsightCandidate(
+            category: .averageIntensity,
+            key: "all",
+            supportCount: aggregate.qualifiedEpisodes.count,
+            patternStrength: clamped(aggregate.averageIntensity / 10.0),
+            relevantAverageIntensity: aggregate.averageIntensity,
+            payload: .averageIntensity(value: aggregate.averageIntensity, count: aggregate.qualifiedEpisodes.count)
+        )
+    }
+
+    private static func trend(in aggregate: InsightAggregate) -> InsightCandidate? {
+        let episodes = aggregate.qualifiedEpisodes
+        guard episodes.count >= InsightEngine.minimumQualifiedEpisodeCount else {
+            return nil
+        }
+
+        let olderCount = episodes.count / 2
+        let olderEpisodes = Array(episodes.prefix(olderCount))
+        let newerEpisodes = Array(episodes.suffix(episodes.count - olderCount))
+        let olderAverage = DataAggregator.average(olderEpisodes.map { Double($0.intensity) })
+        let newerAverage = DataAggregator.average(newerEpisodes.map { Double($0.intensity) })
+        let difference = newerAverage - olderAverage
+
+        guard abs(difference) >= 1.0 else {
+            return nil
+        }
+
+        let direction: TrendDirection = difference > 0 ? .rising : .falling
+
+        return InsightCandidate(
+            category: .trend,
+            key: direction.rawValue,
+            supportCount: episodes.count,
+            patternStrength: clamped(abs(difference) / 3.0),
+            relevantAverageIntensity: max(olderAverage, newerAverage),
+            payload: .trend(
+                direction: direction,
+                olderAverage: olderAverage,
+                newerAverage: newerAverage,
+                difference: difference
+            )
+        )
+    }
+
+    private static func weekdaySort(lhs: (key: Int, value: Int), rhs: (key: Int, value: Int)) -> Bool {
+        if lhs.value != rhs.value {
+            return lhs.value > rhs.value
+        }
+
+        return lhs.key < rhs.key
+    }
+
+    private static func triggerSort(lhs: (key: String, value: Int), rhs: (key: String, value: Int)) -> Bool {
+        if lhs.value != rhs.value {
+            return lhs.value > rhs.value
+        }
+
+        return lhs.key.localizedStandardCompare(rhs.key) == .orderedAscending
+    }
+
+    private static func clamped(_ value: Double) -> Double {
+        min(max(value, 0), 1)
+    }
+}
+
+struct InsightCandidate: Equatable, Sendable {
+    let category: InsightCategory
+    let key: String
+    let supportCount: Int
+    let patternStrength: Double
+    let relevantAverageIntensity: Double
+    let payload: InsightPayload
+}
+
+enum InsightPayload: Equatable, Sendable {
+    case weekday(weekday: Int, count: Int, share: Double)
+    case trigger(name: String, count: Int, share: Double)
+    case averageIntensity(value: Double, count: Int)
+    case trend(direction: TrendDirection, olderAverage: Double, newerAverage: Double, difference: Double)
+}
+
+enum TrendDirection: String, Equatable, Sendable {
+    case rising
+    case falling
+}
+
+enum InsightScorer {
+    static let confidenceThreshold = 0.50
+    static let importanceThreshold = 0.40
+
+    static func score(_ candidate: InsightCandidate, aggregate: InsightAggregate) -> ScoredInsight? {
+        let sampleCoverage = min(1, Double(candidate.supportCount) / 8.0)
+        let confidence = clamped((0.6 * candidate.patternStrength) + (0.4 * sampleCoverage))
+        let intensityFactor = clamped(candidate.relevantAverageIntensity / 10.0)
+        let importance: Double
+
+        if candidate.category == .averageIntensity {
+            importance = intensityFactor
+        } else {
+            importance = clamped((0.55 * candidate.patternStrength) + (0.45 * intensityFactor))
+        }
+
+        let insight = InsightFormatter.format(
+            candidate,
+            aggregate: aggregate,
+            confidence: confidence,
+            importance: importance
+        )
+        let sortScore = (0.6 * importance) + (0.4 * confidence)
+
+        return ScoredInsight(insight: insight, confidence: confidence, importance: importance, sortScore: sortScore)
+    }
+
+    private static func clamped(_ value: Double) -> Double {
+        min(max(value, 0), 1)
+    }
+}
+
+struct ScoredInsight: Equatable, Sendable {
+    let insight: Insight
+    let confidence: Double
+    let importance: Double
+    let sortScore: Double
+}
+
+enum InsightFormatter {
+    static func format(
+        _ candidate: InsightCandidate,
+        aggregate: InsightAggregate,
+        confidence: Double,
+        importance: Double
+    ) -> Insight {
+        Insight(
+            id: "\(candidate.category.rawValue):\(candidate.key)",
+            title: title(for: candidate),
+            description: description(for: candidate, totalCount: aggregate.qualifiedEpisodes.count),
+            confidence: confidence,
+            importance: importance,
+            category: candidate.category,
+            systemImage: systemImage(for: candidate)
+        )
+    }
+
+    private static func title(for candidate: InsightCandidate) -> String {
+        switch candidate.payload {
+        case .weekday(let weekday, _, _):
+            "Auffälliger \(weekdayName(for: weekday))"
+        case .trigger(let name, _, _):
+            "\(name) fällt öfter auf"
+        case .averageIntensity(let value, _):
+            "Durchschnitt \(formattedIntensity(value))/10"
+        case .trend(let direction, _, _, _):
+            direction == .rising ? "Intensität steigt" : "Intensität fällt"
+        }
+    }
+
+    private static func description(for candidate: InsightCandidate, totalCount: Int) -> String {
+        switch candidate.payload {
+        case .weekday(let weekday, let count, _):
+            "\(entryCountText(count)) von \(entryCountText(totalCount)) liegen auf \(weekdayName(for: weekday)). Das ist ein Muster in deinen bisherigen Einträgen, keine Vorhersage."
+        case .trigger(let name, let count, _):
+            "\(name) wurde bei \(entryCountText(count)) von \(entryCountText(totalCount)) notiert. Symi wertet das als Häufung, nicht als Ursache."
+        case .averageIntensity(let value, let count):
+            "Die durchschnittliche Intensität deiner \(entryCountText(count)) liegt bei \(formattedIntensity(value)) von 10."
+        case .trend(_, let olderAverage, let newerAverage, _):
+            "Neuere Einträge liegen im Durchschnitt bei \(formattedIntensity(newerAverage))/10, ältere bei \(formattedIntensity(olderAverage))/10. Das beschreibt nur den Verlauf deiner dokumentierten Einträge."
+        }
+    }
+
+    private static func systemImage(for candidate: InsightCandidate) -> String {
+        switch candidate.payload {
+        case .trigger(let name, _, _):
+            triggerSystemImage(for: name)
+        default:
+            candidate.category.fallbackSystemImage
+        }
+    }
+
+    private static func triggerSystemImage(for name: String) -> String {
+        switch name.lowercased() {
+        case "stress", "erhöhte arbeitsbelastung":
+            "brain.head.profile"
+        case "wetter":
+            "cloud.sun"
+        case "schlaf", "schlafdauer":
+            "moon"
+        case "ernährung":
+            "fork.knife.circle"
+        case "bildschirmzeit":
+            "ipad.landscape.and.iphone"
+        case "zyklus", "regel":
+            "drop"
+        case "bewegung", "sport":
+            "figure.run"
+        case "flüssigkeit":
+            "waterbottle"
+        default:
+            "tag"
+        }
+    }
+
+    private static func weekdayName(for weekday: Int) -> String {
+        switch weekday {
+        case 1:
+            "Sonntag"
+        case 2:
+            "Montag"
+        case 3:
+            "Dienstag"
+        case 4:
+            "Mittwoch"
+        case 5:
+            "Donnerstag"
+        case 6:
+            "Freitag"
+        case 7:
+            "Samstag"
+        default:
+            "ein Wochentag"
+        }
+    }
+
+    private static func formattedIntensity(_ value: Double) -> String {
+        let rounded = (value * 10).rounded() / 10
+
+        if rounded.rounded() == rounded {
+            return "\(Int(rounded))"
+        }
+
+        let tenths = Int((rounded * 10).rounded())
+        return "\(tenths / 10),\(abs(tenths % 10))"
+    }
+
+    private static func entryCountText(_ count: Int) -> String {
+        "\(count) \(count == 1 ? "Eintrag" : "Einträge")"
+    }
+}

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -118,7 +118,10 @@ struct HomeView: View {
     }
 
     private func reloadPatternPreview() async {
-        patternPreviewData = (try? await LoadHomePatternPreviewUseCase(repository: appContainer.episodeRepository).execute()) ?? HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
+        patternPreviewData = (try? await LoadHomePatternPreviewUseCase(
+            repository: appContainer.episodeRepository,
+            insightEngine: appContainer.insightEngine
+        ).execute()) ?? HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
     }
 
     private func showPreviousMonth() {
@@ -557,7 +560,7 @@ private struct HomePatternEmptyState: View {
             return "Wenn du ein paar Schmerz- oder Migräneeinträge erfasst hast, zeigen wir hier vorsichtige Hinweise."
         }
 
-        return "\(recordedCount) von 3 nötigen Schmerz- oder Migräneeinträgen sind vorhanden."
+        return "\(recordedCount) von \(HomePatternPreviewData.minimumEpisodeCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden."
     }
 
     private var title: String {
@@ -571,7 +574,7 @@ private struct HomePatternEmptyState: View {
 
 struct InsightsView: View {
     let appContainer: AppContainer
-    @State private var data = HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
+    @State private var data = InsightResult(totalQualifiedEpisodeCount: 0, insights: [])
 
     var body: some View {
         ScrollView {
@@ -591,15 +594,15 @@ struct InsightsView: View {
     }
 
     private func reload() async {
-        data = (try? await LoadHomePatternPreviewUseCase(repository: appContainer.episodeRepository).execute()) ?? HomePatternPreviewData(
-            totalPainEpisodeCount: 0,
-            cards: []
-        )
+        data = (try? await LoadInsightResultUseCase(
+            repository: appContainer.episodeRepository,
+            insightEngine: appContainer.insightEngine
+        ).execute()) ?? InsightResult(totalQualifiedEpisodeCount: 0, insights: [])
     }
 }
 
 private struct HomeInsightsContent: View {
-    let data: HomePatternPreviewData
+    let data: InsightResult
 
     var body: some View {
         VStack(alignment: .leading, spacing: SymiSpacing.xxl) {
@@ -608,16 +611,105 @@ private struct HomeInsightsContent: View {
                 .foregroundStyle(AppTheme.symiTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            if data.hasEnoughData, !data.cards.isEmpty {
+            if data.hasEnoughData, let heroInsight = data.heroInsight {
                 VStack(alignment: .leading, spacing: SymiSpacing.md) {
-                    ForEach(data.cards) { card in
-                        HomePatternCard(card: card)
+                    InsightHeroCard(insight: heroInsight)
+
+                    ForEach(data.insights.dropFirst()) { insight in
+                        HomePatternCard(card: HomePatternPreviewCard(insight: insight))
                     }
                 }
             } else {
-                HomePatternEmptyState(recordedCount: data.totalPainEpisodeCount)
+                HomePatternEmptyState(recordedCount: data.totalQualifiedEpisodeCount)
+            }
+
+            InsightMethodSummary()
+        }
+    }
+}
+
+private struct InsightHeroCard: View {
+    let insight: Insight
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.md) {
+            HStack(alignment: .center, spacing: SymiSpacing.md) {
+                Image(systemName: insight.systemImage ?? insight.category.fallbackSystemImage)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(AppTheme.symiOnAccent)
+                    .frame(width: 44, height: 44)
+                    .background(AppTheme.petrol(for: colorScheme), in: Circle())
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+                    Text("Wichtigster Hinweis")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
+                        .textCase(.uppercase)
+
+                    Text(insight.title)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Text(insight.description)
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: SymiSpacing.sm) {
+                InsightScorePill(label: "Confidence", value: insight.confidence)
+                InsightScorePill(label: "Importance", value: insight.importance)
             }
         }
+        .padding(SymiSpacing.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .homeSurface()
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("insights-hero")
+    }
+}
+
+private struct InsightScorePill: View {
+    let label: String
+    let value: Double
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Text("\(label) \(percentageText)")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(AppTheme.petrol(for: colorScheme))
+            .padding(.horizontal, SymiSpacing.sm)
+            .padding(.vertical, SymiSpacing.compact)
+            .background(AppTheme.sage(for: colorScheme).opacity(SymiOpacity.faintSurface), in: Capsule())
+    }
+
+    private var percentageText: String {
+        "\(Int((value * 100).rounded())) %"
+    }
+}
+
+private struct InsightMethodSummary: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
+            Label("So entstehen die Hinweise", systemImage: "function")
+                .font(.headline)
+                .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
+
+            Text("Symi wertet nur Migräne- und Kopfschmerz-Einträge aus. Ab \(InsightEngine.minimumQualifiedEpisodeCount) Einträgen entstehen Kandidaten für Wochentag, Trigger, Durchschnitt und Trend. Confidence kombiniert Musterstärke und Datenmenge; Importance kombiniert Relevanz und Intensität. Angezeigt wird erst ab 50 % Confidence und 40 % Importance, sortiert nach dem kombinierten Score.")
+                .font(.footnote)
+                .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(SymiSpacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .homeSurface()
+        .accessibilityIdentifier("insights-method-summary")
     }
 }
 

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -232,7 +232,10 @@ struct CoreArchitectureTests {
             makeEpisode(id: UUID(), startedAt: .now.addingTimeInterval(-172_800), intensity: 4, type: .headache)
         ]
 
-        let result = try await LoadHomePatternPreviewUseCase(repository: repository).execute()
+        let result = try await LoadHomePatternPreviewUseCase(
+            repository: repository,
+            insightEngine: InsightEngine()
+        ).execute()
 
         #expect(result.totalPainEpisodeCount == 2)
         #expect(result.hasEnoughData == false)
@@ -240,33 +243,120 @@ struct CoreArchitectureTests {
     }
 
     @Test
-    func homePatternPreviewBuildsCautiousCardsFromPainEpisodes() async throws {
-        let repository = EpisodeRepositoryMock()
-        let monday = Date(timeIntervalSince1970: 1_711_929_600)
-        let tuesday = monday.addingTimeInterval(86_400)
-        let weather = WeatherRecord(
-            recordedAt: monday,
-            condition: "Regen",
-            temperature: 12,
-            humidity: 80,
-            pressure: 1_004,
-            precipitation: 1.2,
-            weatherCode: 61,
-            source: "Apple Weather"
-        )
-        repository.recentRecords = [
-            makeEpisode(id: UUID(), startedAt: monday, intensity: 6, type: .migraine, symptoms: ["Übelkeit"], menstruationStatus: .active, weather: weather),
-            makeEpisode(id: UUID(), startedAt: monday.addingTimeInterval(3_600), intensity: 5, type: .headache, symptoms: ["Übelkeit"], menstruationStatus: .expected, weather: weather),
-            makeEpisode(id: UUID(), startedAt: tuesday, intensity: 4, type: .migraine, symptoms: ["Lichtempfindlichkeit"], weather: weather)
+    func insightEngineIgnoresUnclearEpisodesForAverageAndMinimumCount() {
+        let engine = InsightEngine()
+        let start = fixedDate()
+        let episodes = [
+            makeEpisode(id: UUID(), startedAt: start, intensity: 6, type: .migraine),
+            makeEpisode(id: UUID(), startedAt: start, intensity: 6, type: .headache),
+            makeEpisode(id: UUID(), startedAt: start, intensity: 6, type: .migraine),
+            makeEpisode(id: UUID(), startedAt: start, intensity: 6, type: .headache),
+            makeEpisode(id: UUID(), startedAt: start, intensity: 6, type: .migraine),
+            makeEpisode(id: UUID(), startedAt: start, intensity: 10, type: .unclear),
+            makeEpisode(id: UUID(), startedAt: start, intensity: 10, type: .unclear)
         ]
 
-        let result = try await LoadHomePatternPreviewUseCase(repository: repository).execute()
+        let result = engine.evaluate(episodes: episodes, calendar: fixedCalendar())
+        let average = result.insights.first { $0.category == .averageIntensity }
 
-        #expect(result.hasEnoughData)
-        #expect(result.cards.map(\.kind) == [.frequentDay, .weatherSymptoms, .menstruationCycle])
-        #expect(result.cards.first?.title == "Häufigster Tag")
-        #expect(result.cards.contains { $0.title == "Wetter & Symptome" })
-        #expect(result.cards.contains { $0.isWide })
+        #expect(result.totalQualifiedEpisodeCount == 5)
+        #expect(average?.title == "Durchschnitt 6/10")
+    }
+
+    @Test
+    func insightEngineReturnsNoArtificialInsightForEmptyData() {
+        let result = InsightEngine().evaluate(episodes: [], calendar: fixedCalendar())
+
+        #expect(result.totalQualifiedEpisodeCount == 0)
+        #expect(result.heroInsight == nil)
+        #expect(result.insights.isEmpty)
+    }
+
+    @Test
+    func insightEngineBuildsAverageIntensityInsight() {
+        let engine = InsightEngine()
+        let start = fixedDate()
+        let intensities = [4, 6, 8, 5, 7]
+        let episodes = intensities.enumerated().map { offset, intensity in
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(Double(offset) * 86_400), intensity: intensity)
+        }
+
+        let result = engine.evaluate(episodes: episodes, calendar: fixedCalendar())
+        let average = result.insights.first { $0.category == .averageIntensity }
+
+        #expect(average?.title == "Durchschnitt 6/10")
+        #expect(average?.description.contains("6 von 10") == true)
+        #expect(average?.confidence ?? 0 >= InsightScorer.confidenceThreshold)
+        #expect(abs((average?.importance ?? 0) - 0.6) < 0.001)
+    }
+
+    @Test
+    func insightEngineAppliesWeekdayAndTriggerThresholds() {
+        let engine = InsightEngine()
+        let start = fixedDate()
+        let weakEpisodes = (0 ..< 5).map { offset in
+            makeEpisode(
+                id: UUID(),
+                startedAt: start.addingTimeInterval(Double(offset) * 86_400),
+                intensity: 4,
+                triggers: offset < 2 ? ["Stress"] : []
+            )
+        }
+
+        let weakResult = engine.evaluate(episodes: weakEpisodes, calendar: fixedCalendar())
+
+        #expect(!weakResult.insights.contains { $0.category == .weekdayPattern })
+        #expect(!weakResult.insights.contains { $0.category == .triggerCorrelation })
+
+        let strongEpisodes = [
+            makeEpisode(id: UUID(), startedAt: start, intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(7 * 86_400), intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(14 * 86_400), intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(21 * 86_400), intensity: 8),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(86_400), intensity: 7)
+        ]
+
+        let strongResult = engine.evaluate(episodes: strongEpisodes, calendar: fixedCalendar())
+
+        #expect(strongResult.insights.contains { $0.category == .weekdayPattern })
+        #expect(strongResult.insights.contains { $0.category == .triggerCorrelation })
+    }
+
+    @Test
+    func insightEngineDetectsRisingAndFallingTrends() {
+        let engine = InsightEngine()
+        let start = fixedDate()
+        let rising = [2, 2, 3, 7, 8, 8].enumerated().map { offset, intensity in
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(Double(offset) * 86_400), intensity: intensity)
+        }
+        let falling = [8, 8, 7, 3, 2, 2].enumerated().map { offset, intensity in
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(Double(offset) * 86_400), intensity: intensity)
+        }
+
+        let risingTrend = engine.evaluate(episodes: rising, calendar: fixedCalendar()).insights.first { $0.category == .trend }
+        let fallingTrend = engine.evaluate(episodes: falling, calendar: fixedCalendar()).insights.first { $0.category == .trend }
+
+        #expect(risingTrend?.title == "Intensität steigt")
+        #expect(fallingTrend?.title == "Intensität fällt")
+    }
+
+    @Test
+    func insightEngineSortsByCombinedScoreAndExposesHeroInsight() {
+        let engine = InsightEngine()
+        let start = fixedDate()
+        let episodes = [
+            makeEpisode(id: UUID(), startedAt: start, intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(7 * 86_400), intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(14 * 86_400), intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(21 * 86_400), intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(28 * 86_400), intensity: 8, triggers: ["Stress"])
+        ]
+
+        let result = engine.evaluate(episodes: episodes, calendar: fixedCalendar())
+
+        #expect(Array(result.insights.map(\.category).prefix(2)) == [.weekdayPattern, .triggerCorrelation])
+        #expect(result.heroInsight == result.insights.first)
+        #expect(result.heroInsight?.category == .weekdayPattern)
     }
 
     @Test
@@ -414,6 +504,7 @@ private func makeEpisode(
     deletedAt: Date? = nil,
     type: EpisodeType = .migraine,
     symptoms: [String] = [],
+    triggers: [String] = [],
     menstruationStatus: MenstruationStatus = .unknown,
     weather: WeatherRecord? = nil
 ) -> EpisodeRecord {
@@ -429,7 +520,7 @@ private func makeEpisode(
         painCharacter: "",
         notes: "",
         symptoms: symptoms,
-        triggers: [],
+        triggers: triggers,
         functionalImpact: "",
         menstruationStatus: menstruationStatus,
         medications: [],
@@ -437,6 +528,17 @@ private func makeEpisode(
         weather: weather,
         healthContext: nil
     )
+}
+
+private func fixedDate() -> Date {
+    Date(timeIntervalSince1970: 1_704_067_200)
+}
+
+private func fixedCalendar() -> Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    calendar.firstWeekday = 2
+    return calendar
 }
 
 private func sampleEnvelope() -> SyncDocumentEnvelope {

--- a/docs/Insight-Engine.md
+++ b/docs/Insight-Engine.md
@@ -1,0 +1,88 @@
+# Insight Engine
+
+Die Insight Engine berechnet lokale Hinweise aus echten Tagebuchdaten. Sie erzeugt keine Demo-Werte und keine Fallback-Insights. Wenn die Datenlage zu dünn oder ein Muster zu schwach ist, bleibt die Liste leer.
+
+## Eingabedaten
+
+Ausgewertet werden nur aktive Einträge mit dem Typ `Migräne` oder `Kopfschmerz`. Einträge mit `Unklar`, gelöschte Einträge und zukünftige Nicht-Schmerz-Typen zählen nicht als normale Messwerte. Dadurch werden auch keine „Keine Schmerzen“-Datenpunkte in Durchschnitt, Trend oder Muster eingerechnet.
+
+Die Mindestmenge liegt bei `5` qualifizierten Einträgen. Unterhalb dieser Grenze liefert `InsightEngine` nur `totalQualifiedEpisodeCount` und keine Insights.
+
+## Aggregation
+
+`DataAggregator` bereitet die Daten für alle Detektoren vor:
+
+- qualifizierte Einträge, nach Startzeit sortiert
+- durchschnittliche Intensität über alle qualifizierten Einträge
+- Anzahl und durchschnittliche Intensität pro Wochentag
+- Anzahl normalisierter Trigger pro Eintrag
+- Fingerprint für den Cache
+
+Trigger werden pro Eintrag dedupliziert, getrimmt und alphabetisch sortiert. Leere Trigger werden ignoriert.
+
+## Detektoren
+
+`PatternDetector` erzeugt maximal einen Kandidaten pro Kategorie:
+
+- `weekdayPattern`: häufigster Wochentag, sobald dieser mindestens zwei qualifizierte Einträge enthält
+- `triggerCorrelation`: häufigster dokumentierter Trigger, sobald dieser mindestens zwei qualifizierte Einträge enthält
+- `averageIntensity`: Durchschnitt über alle qualifizierten Einträge
+- `trend`: Vergleich der älteren und neueren Hälfte; ein Trend entsteht erst ab mindestens `1,0` Punkt Unterschied
+
+Trigger-Kandidaten beschreiben nur eine Häufung in dokumentierten Einträgen. Sie behaupten keine Ursache und keine medizinische Korrelation.
+
+## Scoring
+
+Jeder Kandidat bekommt `confidence` und `importance`.
+
+`confidence`:
+
+```text
+sampleCoverage = min(1, supportCount / 8)
+confidence = 0.6 * patternStrength + 0.4 * sampleCoverage
+```
+
+`patternStrength` hängt von der Kategorie ab:
+
+- Wochentag: Abstand zur gleichmäßigen 1/7-Verteilung
+- Trigger: Anteil qualifizierter Einträge mit diesem Trigger
+- Durchschnitt: durchschnittliche Intensität / 10
+- Trend: absoluter Unterschied der Hälften / 3, begrenzt auf 1
+
+`importance`:
+
+```text
+averageIntensity: importance = durchschnittliche Intensität / 10
+andere Kategorien: importance = 0.55 * patternStrength + 0.45 * relevante Intensität / 10
+```
+
+Ein Insight wird nur angezeigt, wenn `confidence >= 0.50` und `importance >= 0.40`.
+
+## Sortierung und Hero Insight
+
+Alle sichtbaren Insights werden nach kombiniertem Score sortiert:
+
+```text
+sortScore = 0.6 * importance + 0.4 * confidence
+```
+
+Bei gleichem Score entscheidet zuerst die höhere `confidence`, danach der Titel alphabetisch. `heroInsight` ist immer der erste Insight dieser sortierten Liste.
+
+## Cache
+
+`InsightEngine` cached das letzte Ergebnis im Speicher. Der Cache-Fingerprint enthält:
+
+- Kalenderkennung, Zeitzone und ersten Wochentag
+- qualifizierte Eintrags-IDs
+- `startedAt`
+- `updatedAt`
+- Typ
+- Intensität
+- normalisierte Trigger
+- Wetterstatus
+
+Neue oder bearbeitete Einträge ändern `updatedAt` oder die ausgewerteten Felder und erzwingen dadurch eine Neuberechnung. Der Cache ist bewusst nur lokal im laufenden Prozess; er ersetzt keine persistierte Statistik.
+
+## Texte
+
+`InsightFormatter` formuliert alle Hinweise nicht-diagnostisch. Die Texte sprechen von bisherigen Einträgen, Häufungen und Verläufen. Sie enthalten keine Therapieempfehlung, keine Vorhersage und keine Aussage, dass ein Trigger Beschwerden verursacht.

--- a/docs/Teststrategie-und-Release-Checkliste.md
+++ b/docs/Teststrategie-und-Release-Checkliste.md
@@ -34,6 +34,7 @@ Die automatisierten Tests decken aktuell folgende Kernlogik ab:
 
 - Wetter-Snapshots für echte API-Daten und Zukunftsvalidierung
 - Export-Metriken für Durchschnittsintensität und Medikamentenliste
+- Insight Engine für Mindestdaten, Ausschlüsse, Durchschnitt, Trigger-/Wochentag-Thresholds, Trend und Hero-Sortierung
 
 Damit sind die fehleranfälligen, nicht-visuellen Regeln des MVP reproduzierbar abgesichert, ohne das iPhone-UI unnötig kompliziert zu machen.
 


### PR DESCRIPTION
## Summary
- Implementiert eine lokale `InsightEngine` mit Aggregation, Mustererkennung, Scoring, Formatierung und Fingerprint-Cache.
- Ersetzt die bisherigen Home-/Insights-Platzhalter durch echte Engine-Ergebnisse inklusive Hero-Insight und kompakter In-App-Erklärung.
- Ergänzt die genaue Dokumentation in `docs/Insight-Engine.md`, verlinkt sie im README und erweitert die Teststrategie-Doku.
- Nimmt die zusätzlichen AppShell-Icon- und String-Catalog-Änderungen mit.

Closes #171

## Validation
- `xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16'`