### PR TITLE
[codex] Insights aggregation for extended entry data

### DIFF
--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -639,13 +639,13 @@ struct LoadInsightResultUseCase {
     let repository: EpisodeRepository
     let insightEngine: InsightEngine
 
-    func execute() async throws -> InsightResult {
+    func execute(period: InsightPeriod = .thirtyDays) async throws -> InsightResult {
         let repository = repository
         let episodes = try await Task.detached(priority: .userInitiated) {
             try repository.fetchRecent()
         }.value
 
-        return insightEngine.evaluate(episodes: episodes)
+        return insightEngine.evaluate(episodes: episodes, period: period)
     }
 }
 

--- a/Symi/Sources/Core/Insights/InsightCore.swift
+++ b/Symi/Sources/Core/Insights/InsightCore.swift
@@ -44,8 +44,28 @@ enum InsightCategory: String, CaseIterable, Equatable, Sendable {
 }
 
 struct InsightResult: Equatable, Sendable {
+    let period: InsightPeriod
+    let dateRange: DateInterval?
     let totalQualifiedEpisodeCount: Int
+    let metrics: InsightMetrics
+    let emptyState: InsightEmptyState?
     let insights: [Insight]
+
+    init(
+        period: InsightPeriod = .thirtyDays,
+        dateRange: DateInterval? = nil,
+        totalQualifiedEpisodeCount: Int,
+        metrics: InsightMetrics = .empty,
+        emptyState: InsightEmptyState? = nil,
+        insights: [Insight]
+    ) {
+        self.period = period
+        self.dateRange = dateRange
+        self.totalQualifiedEpisodeCount = totalQualifiedEpisodeCount
+        self.metrics = metrics
+        self.emptyState = emptyState
+        self.insights = insights
+    }
 
     var heroInsight: Insight? {
         insights.first
@@ -56,6 +76,191 @@ struct InsightResult: Equatable, Sendable {
     }
 }
 
+enum InsightPeriod: String, CaseIterable, Identifiable, Equatable, Sendable {
+    case sevenDays
+    case thirtyDays
+    case threeMonths
+
+    var id: String { rawValue }
+
+    var displayTitle: String {
+        switch self {
+        case .sevenDays:
+            "7 Tage"
+        case .thirtyDays:
+            "30 Tage"
+        case .threeMonths:
+            "3 Monate"
+        }
+    }
+
+    func startDate(endingAt referenceDate: Date, calendar: Calendar) -> Date {
+        let value: Int
+        let component: Calendar.Component
+
+        switch self {
+        case .sevenDays:
+            value = -7
+            component = .day
+        case .thirtyDays:
+            value = -30
+            component = .day
+        case .threeMonths:
+            value = -3
+            component = .month
+        }
+
+        return calendar.date(byAdding: component, value: value, to: referenceDate) ?? referenceDate
+    }
+}
+
+struct InsightEmptyState: Equatable, Sendable {
+    enum Reason: Equatable, Sendable {
+        case noQualifiedEntries
+        case notEnoughQualifiedEntries(required: Int, available: Int)
+        case noVisibleInsights
+    }
+
+    let reason: Reason
+    let title: String
+    let message: String
+    let requiredEntryCount: Int
+    let availableEntryCount: Int
+}
+
+struct InsightMetrics: Equatable, Sendable {
+    let dayPartSummaries: [InsightDayPartSummary]
+    let triggerSummaries: [InsightFrequencySummary]
+    let acuteMedicationSummaries: [InsightFrequencySummary]
+    let continuousMedicationSummaries: [InsightContinuousMedicationSummary]
+    let weatherSummary: InsightWeatherSummary
+    let dailyIntensityTrend: [InsightDailyIntensityPoint]
+
+    static let empty = InsightMetrics(
+        dayPartSummaries: [],
+        triggerSummaries: [],
+        acuteMedicationSummaries: [],
+        continuousMedicationSummaries: [],
+        weatherSummary: .empty,
+        dailyIntensityTrend: []
+    )
+}
+
+struct InsightDayPartSummary: Equatable, Sendable {
+    let dayPart: EpisodeDayPart
+    let count: Int
+    let share: Double
+    let averageIntensity: Double
+}
+
+struct InsightFrequencySummary: Equatable, Sendable {
+    let name: String
+    let count: Int
+    let share: Double
+}
+
+struct InsightContinuousMedicationSummary: Equatable, Sendable {
+    let name: String
+    let takenCount: Int
+    let missedCount: Int
+    let totalCheckCount: Int
+    let takenShare: Double
+}
+
+struct InsightWeatherSummary: Equatable, Sendable {
+    let entryCountWithWeather: Int
+    let extendedContextCount: Int
+    let conditionSummaries: [InsightFrequencySummary]
+    let averageTemperature: Double?
+    let averageHumidity: Double?
+    let averagePressure: Double?
+    let averagePrecipitation: Double?
+
+    static let empty = InsightWeatherSummary(
+        entryCountWithWeather: 0,
+        extendedContextCount: 0,
+        conditionSummaries: [],
+        averageTemperature: nil,
+        averageHumidity: nil,
+        averagePressure: nil,
+        averagePrecipitation: nil
+    )
+}
+
+struct InsightDailyIntensityPoint: Equatable, Sendable {
+    let day: Date
+    let entryCount: Int
+    let averageIntensity: Double
+    let highestIntensity: Int
+}
+
+extension InsightEmptyState {
+    init(qualifiedEpisodeCount: Int, minimumCount: Int) {
+        if qualifiedEpisodeCount == 0 {
+            self = InsightEmptyState(
+                reason: .noQualifiedEntries,
+                title: "Noch keine auswertbaren Einträge",
+                message: "Für diesen Zeitraum liegen keine Migräne- oder Kopfschmerz-Einträge vor.",
+                requiredEntryCount: minimumCount,
+                availableEntryCount: qualifiedEpisodeCount
+            )
+        } else {
+            self = InsightEmptyState(
+                reason: .notEnoughQualifiedEntries(required: minimumCount, available: qualifiedEpisodeCount),
+                title: "Noch nicht genug Einträge",
+                message: "\(qualifiedEpisodeCount) von \(minimumCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden.",
+                requiredEntryCount: minimumCount,
+                availableEntryCount: qualifiedEpisodeCount
+            )
+        }
+    }
+
+    static func noVisibleInsights(qualifiedEpisodeCount: Int, minimumCount: Int) -> InsightEmptyState {
+        InsightEmptyState(
+            reason: .noVisibleInsights,
+            title: "Noch kein stabiler Hinweis",
+            message: "Es gibt genug Einträge, aber noch kein Muster mit ausreichender Confidence und Importance.",
+            requiredEntryCount: minimumCount,
+            availableEntryCount: qualifiedEpisodeCount
+        )
+    }
+}
+
+extension InsightMetrics {
+    init(aggregate: InsightAggregate) {
+        let totalCount = aggregate.qualifiedEpisodes.count
+        dayPartSummaries = EpisodeDayPart.allCases.compactMap { dayPart in
+            guard let count = aggregate.dayPartCounts[dayPart], count > 0 else {
+                return nil
+            }
+
+            return InsightDayPartSummary(
+                dayPart: dayPart,
+                count: count,
+                share: totalCount == 0 ? 0 : Double(count) / Double(totalCount),
+                averageIntensity: aggregate.dayPartAverageIntensities[dayPart] ?? 0
+            )
+        }
+        triggerSummaries = DataAggregator.frequencySummaries(
+            from: aggregate.triggerCounts,
+            denominator: totalCount
+        )
+        acuteMedicationSummaries = DataAggregator.frequencySummaries(
+            from: aggregate.acuteMedicationCounts,
+            denominator: totalCount
+        )
+        continuousMedicationSummaries = aggregate.continuousMedicationUsage.values.sorted { lhs, rhs in
+            if lhs.totalCheckCount != rhs.totalCheckCount {
+                return lhs.totalCheckCount > rhs.totalCheckCount
+            }
+
+            return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+        }
+        weatherSummary = aggregate.weatherSummary
+        dailyIntensityTrend = aggregate.dailyIntensityTrend
+    }
+}
+
 final class InsightEngine: @unchecked Sendable {
     static let minimumQualifiedEpisodeCount = 5
 
@@ -63,8 +268,18 @@ final class InsightEngine: @unchecked Sendable {
     private var cachedResult: InsightResult?
     private let cacheLock = NSLock()
 
-    func evaluate(episodes: [EpisodeRecord], calendar: Calendar = .current) -> InsightResult {
-        let fingerprint = DataAggregator.fingerprint(for: episodes, calendar: calendar)
+    func evaluate(
+        episodes: [EpisodeRecord],
+        period: InsightPeriod = .thirtyDays,
+        referenceDate: Date? = nil,
+        calendar: Calendar = .current
+    ) -> InsightResult {
+        let fingerprint = DataAggregator.fingerprint(
+            for: episodes,
+            period: period,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
 
         cacheLock.lock()
         if fingerprint == cachedFingerprint, let cachedResult {
@@ -73,11 +288,27 @@ final class InsightEngine: @unchecked Sendable {
         }
         cacheLock.unlock()
 
-        let aggregate = DataAggregator.aggregate(episodes: episodes, calendar: calendar)
+        let aggregate = DataAggregator.aggregate(
+            episodes: episodes,
+            period: period,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
         let result: InsightResult
+        let metrics = InsightMetrics(aggregate: aggregate)
 
         if aggregate.qualifiedEpisodes.count < Self.minimumQualifiedEpisodeCount {
-            result = InsightResult(totalQualifiedEpisodeCount: aggregate.qualifiedEpisodes.count, insights: [])
+            result = InsightResult(
+                period: aggregate.period,
+                dateRange: aggregate.dateRange,
+                totalQualifiedEpisodeCount: aggregate.qualifiedEpisodes.count,
+                metrics: metrics,
+                emptyState: InsightEmptyState(
+                    qualifiedEpisodeCount: aggregate.qualifiedEpisodes.count,
+                    minimumCount: Self.minimumQualifiedEpisodeCount
+                ),
+                insights: []
+            )
         } else {
             let insights = PatternDetector.detect(in: aggregate)
                 .compactMap { InsightScorer.score($0, aggregate: aggregate) }
@@ -95,7 +326,17 @@ final class InsightEngine: @unchecked Sendable {
                 }
                 .map(\.insight)
 
-            result = InsightResult(totalQualifiedEpisodeCount: aggregate.qualifiedEpisodes.count, insights: insights)
+            result = InsightResult(
+                period: aggregate.period,
+                dateRange: aggregate.dateRange,
+                totalQualifiedEpisodeCount: aggregate.qualifiedEpisodes.count,
+                metrics: metrics,
+                emptyState: insights.isEmpty ? InsightEmptyState.noVisibleInsights(
+                    qualifiedEpisodeCount: aggregate.qualifiedEpisodes.count,
+                    minimumCount: Self.minimumQualifiedEpisodeCount
+                ) : nil,
+                insights: insights
+            )
         }
 
         cacheLock.lock()
@@ -108,8 +349,19 @@ final class InsightEngine: @unchecked Sendable {
 }
 
 enum DataAggregator {
-    static func aggregate(episodes: [EpisodeRecord], calendar: Calendar) -> InsightAggregate {
-        let qualifiedEpisodes = qualifiedEpisodes(from: episodes).sorted { lhs, rhs in
+    static func aggregate(
+        episodes: [EpisodeRecord],
+        period: InsightPeriod,
+        referenceDate: Date?,
+        calendar: Calendar
+    ) -> InsightAggregate {
+        let allQualifiedEpisodes = qualifiedEpisodes(from: episodes)
+        let effectiveReferenceDate = referenceDate ?? allQualifiedEpisodes.map(\.startedAt).max() ?? Date()
+        let periodStart = period.startDate(endingAt: effectiveReferenceDate, calendar: calendar)
+        let dateRange = DateInterval(start: periodStart, end: effectiveReferenceDate)
+        let qualifiedEpisodes = allQualifiedEpisodes.filter { episode in
+            episode.startedAt >= periodStart && episode.startedAt <= effectiveReferenceDate
+        }.sorted { lhs, rhs in
             if lhs.startedAt != rhs.startedAt {
                 return lhs.startedAt < rhs.startedAt
             }
@@ -132,21 +384,49 @@ enum DataAggregator {
                 counts[trigger, default: 0] += 1
             }
         }
+        let dayPartGroups = Dictionary(grouping: qualifiedEpisodes) { episode in
+            EpisodeDayPart(date: episode.startedAt, calendar: calendar)
+        }
+        let acuteMedicationCounts = qualifiedEpisodes.reduce(into: [String: Int]()) { counts, episode in
+            for medication in normalizedMedicationNames(from: episode.medications) {
+                counts[medication, default: 0] += 1
+            }
+        }
+        let continuousMedicationUsage = continuousMedicationUsage(from: qualifiedEpisodes)
+        let weatherSummary = weatherSummary(from: qualifiedEpisodes)
+        let dailyIntensityTrend = dailyIntensityTrend(from: qualifiedEpisodes, calendar: calendar)
 
         return InsightAggregate(
+            period: period,
+            dateRange: dateRange,
             qualifiedEpisodes: qualifiedEpisodes,
             averageIntensity: averageIntensity,
             weekdayCounts: weekdayCounts,
             weekdayAverageIntensities: weekdayAverageIntensities,
-            triggerCounts: triggerCounts
+            triggerCounts: triggerCounts,
+            dayPartCounts: dayPartGroups.mapValues(\.count),
+            dayPartAverageIntensities: dayPartGroups.mapValues { episodes in
+                average(episodes.map { Double($0.intensity) })
+            },
+            acuteMedicationCounts: acuteMedicationCounts,
+            continuousMedicationUsage: continuousMedicationUsage,
+            weatherSummary: weatherSummary,
+            dailyIntensityTrend: dailyIntensityTrend
         )
     }
 
-    static func fingerprint(for episodes: [EpisodeRecord], calendar: Calendar) -> String {
+    static func fingerprint(
+        for episodes: [EpisodeRecord],
+        period: InsightPeriod,
+        referenceDate: Date?,
+        calendar: Calendar
+    ) -> String {
         let calendarPart = [
             "\(calendar.identifier)",
             calendar.timeZone.identifier,
-            "\(calendar.firstWeekday)"
+            "\(calendar.firstWeekday)",
+            period.rawValue,
+            referenceDate.map { "\($0.timeIntervalSinceReferenceDate)" } ?? "auto-reference"
         ].joined(separator: "|")
 
         let episodeParts = qualifiedEpisodes(from: episodes)
@@ -159,7 +439,9 @@ enum DataAggregator {
                     episode.type.rawValue,
                     "\(episode.intensity)",
                     normalizedTriggers(from: episode).joined(separator: ","),
-                    episode.weather == nil ? "no-weather" : "weather"
+                    normalizedMedicationNames(from: episode.medications).joined(separator: ","),
+                    episode.continuousMedicationChecks.map(checkFingerprint).sorted().joined(separator: ","),
+                    weatherFingerprint(from: episode.weather)
                 ].joined(separator: "|")
             }
 
@@ -176,6 +458,10 @@ enum DataAggregator {
         Array(Set(episode.triggers.map(normalizeLabel).filter { !$0.isEmpty })).sorted()
     }
 
+    static func normalizedMedicationNames(from medications: [MedicationRecord]) -> [String] {
+        Array(Set(medications.map { normalizeLabel($0.name) }.filter { !$0.isEmpty })).sorted()
+    }
+
     static func normalizeLabel(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -187,14 +473,164 @@ enum DataAggregator {
 
         return values.reduce(0, +) / Double(values.count)
     }
+
+    private static func continuousMedicationUsage(
+        from episodes: [EpisodeRecord]
+    ) -> [String: InsightContinuousMedicationSummary] {
+        var buckets: [String: (name: String, taken: Int, missed: Int)] = [:]
+
+        for episode in episodes {
+            for check in episode.continuousMedicationChecks {
+                let name = normalizeLabel(check.name)
+                guard !name.isEmpty else {
+                    continue
+                }
+
+                var bucket = buckets[name] ?? (name: name, taken: 0, missed: 0)
+                if check.wasTaken {
+                    bucket.taken += 1
+                } else {
+                    bucket.missed += 1
+                }
+                buckets[name] = bucket
+            }
+        }
+
+        return buckets.mapValues { bucket in
+            let total = bucket.taken + bucket.missed
+            return InsightContinuousMedicationSummary(
+                name: bucket.name,
+                takenCount: bucket.taken,
+                missedCount: bucket.missed,
+                totalCheckCount: total,
+                takenShare: total == 0 ? 0 : Double(bucket.taken) / Double(total)
+            )
+        }
+    }
+
+    private static func weatherSummary(from episodes: [EpisodeRecord]) -> InsightWeatherSummary {
+        let snapshots = episodes.compactMap(\.weather)
+        guard !snapshots.isEmpty else {
+            return .empty
+        }
+
+        let conditionCounts = snapshots.reduce(into: [String: Int]()) { counts, weather in
+            let condition = normalizeLabel(weather.condition)
+            guard !condition.isEmpty else {
+                return
+            }
+
+            counts[condition, default: 0] += 1
+        }
+        let conditionSummaries = frequencySummaries(from: conditionCounts, denominator: snapshots.count)
+
+        return InsightWeatherSummary(
+            entryCountWithWeather: snapshots.count,
+            extendedContextCount: snapshots.filter(\.hasExtendedContext).count,
+            conditionSummaries: conditionSummaries,
+            averageTemperature: averageOptional(snapshots.compactMap(\.temperature)),
+            averageHumidity: averageOptional(snapshots.compactMap(\.humidity)),
+            averagePressure: averageOptional(snapshots.compactMap(\.pressure)),
+            averagePrecipitation: averageOptional(snapshots.compactMap(\.precipitation))
+        )
+    }
+
+    private static func dailyIntensityTrend(
+        from episodes: [EpisodeRecord],
+        calendar: Calendar
+    ) -> [InsightDailyIntensityPoint] {
+        Dictionary(grouping: episodes) { episode in
+            calendar.startOfDay(for: episode.startedAt)
+        }
+        .map { day, episodes in
+            InsightDailyIntensityPoint(
+                day: day,
+                entryCount: episodes.count,
+                averageIntensity: average(episodes.map { Double($0.intensity) }),
+                highestIntensity: episodes.map(\.intensity).max() ?? 0
+            )
+        }
+        .sorted { $0.day < $1.day }
+    }
+
+    static func frequencySummaries(from counts: [String: Int], denominator: Int) -> [InsightFrequencySummary] {
+        guard denominator > 0 else {
+            return []
+        }
+
+        return counts
+            .map { name, count in
+                InsightFrequencySummary(name: name, count: count, share: Double(count) / Double(denominator))
+            }
+            .sorted { lhs, rhs in
+                if lhs.count != rhs.count {
+                    return lhs.count > rhs.count
+                }
+
+                return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+            }
+    }
+
+    private static func averageOptional(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else {
+            return nil
+        }
+
+        return average(values)
+    }
+
+    private static func checkFingerprint(_ check: ContinuousMedicationCheckRecord) -> String {
+        [
+            check.id.uuidString,
+            check.continuousMedicationID.uuidString,
+            normalizeLabel(check.name),
+            normalizeLabel(check.dosage),
+            normalizeLabel(check.frequency),
+            "\(check.wasTaken)"
+        ].joined(separator: ":")
+    }
+
+    private static func weatherFingerprint(from weather: WeatherRecord?) -> String {
+        guard let weather else {
+            return "no-weather"
+        }
+
+        let temperature = weather.temperature.map { String($0) } ?? ""
+        let humidity = weather.humidity.map { String($0) } ?? ""
+        let pressure = weather.pressure.map { String($0) } ?? ""
+        let precipitation = weather.precipitation.map { String($0) } ?? ""
+        let weatherCode = weather.weatherCode.map { String($0) } ?? ""
+        let hasExtendedContext = String(weather.hasExtendedContext)
+        let parts: [String] = [
+            "weather",
+            String(weather.recordedAt.timeIntervalSinceReferenceDate),
+            normalizeLabel(weather.condition),
+            temperature,
+            humidity,
+            pressure,
+            precipitation,
+            weatherCode,
+            hasExtendedContext
+        ]
+
+        return parts.joined(separator: ":")
+    }
 }
 
 struct InsightAggregate: Equatable, Sendable {
+    let period: InsightPeriod
+    let dateRange: DateInterval
     let qualifiedEpisodes: [EpisodeRecord]
     let averageIntensity: Double
     let weekdayCounts: [Int: Int]
     let weekdayAverageIntensities: [Int: Double]
     let triggerCounts: [String: Int]
+    let dayPartCounts: [EpisodeDayPart: Int]
+    let dayPartAverageIntensities: [EpisodeDayPart: Double]
+    let acuteMedicationCounts: [String: Int]
+    let continuousMedicationUsage: [String: InsightContinuousMedicationSummary]
+    let weatherSummary: InsightWeatherSummary
+    let dailyIntensityTrend: [InsightDailyIntensityPoint]
 }
 
 enum PatternDetector {

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -575,10 +575,14 @@ private struct HomePatternEmptyState: View {
 struct InsightsView: View {
     let appContainer: AppContainer
     @State private var data = InsightResult(totalQualifiedEpisodeCount: 0, insights: [])
+    @State private var selectedPeriod: InsightPeriod = .thirtyDays
 
     var body: some View {
         ScrollView {
-            HomeInsightsContent(data: data)
+            HomeInsightsContent(
+                data: data,
+                selectedPeriod: $selectedPeriod
+            )
             .padding(.horizontal, SymiSpacing.xxl)
             .padding(.vertical, SymiSpacing.xl)
             .wideContent(maxWidth: AppTheme.readableContentMaxWidth)
@@ -587,6 +591,11 @@ struct InsightsView: View {
         .navigationTitle("Insights")
         .task {
             await reload()
+        }
+        .onChange(of: selectedPeriod) { _, _ in
+            Task {
+                await reload()
+            }
         }
         .refreshable {
             await reload()
@@ -597,15 +606,28 @@ struct InsightsView: View {
         data = (try? await LoadInsightResultUseCase(
             repository: appContainer.episodeRepository,
             insightEngine: appContainer.insightEngine
-        ).execute()) ?? InsightResult(totalQualifiedEpisodeCount: 0, insights: [])
+        ).execute(period: selectedPeriod)) ?? InsightResult(
+            period: selectedPeriod,
+            totalQualifiedEpisodeCount: 0,
+            insights: []
+        )
     }
 }
 
 private struct HomeInsightsContent: View {
     let data: InsightResult
+    @Binding var selectedPeriod: InsightPeriod
 
     var body: some View {
         VStack(alignment: .leading, spacing: SymiSpacing.xxl) {
+            Picker("Zeitraum", selection: $selectedPeriod) {
+                ForEach(InsightPeriod.allCases) { period in
+                    Text(period.displayTitle).tag(period)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityIdentifier("insights-period-picker")
+
             Text("Diese Hinweise basieren nur auf deinen bisherigen Schmerz- und Migräneeinträgen. Sie ersetzen keine medizinische Einschätzung.")
                 .font(.subheadline)
                 .foregroundStyle(AppTheme.symiTextSecondary)

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -360,6 +360,123 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func insightAggregationFiltersSupportedPeriods() {
+        let calendar = fixedCalendar()
+        let referenceDate = fixedDate().addingTimeInterval(40 * 86_400)
+        let episodes = [
+            makeEpisode(id: UUID(), startedAt: referenceDate.addingTimeInterval(-2 * 86_400), intensity: 5),
+            makeEpisode(id: UUID(), startedAt: referenceDate.addingTimeInterval(-6 * 86_400), intensity: 6),
+            makeEpisode(id: UUID(), startedAt: referenceDate.addingTimeInterval(-20 * 86_400), intensity: 7),
+            makeEpisode(id: UUID(), startedAt: referenceDate.addingTimeInterval(-70 * 86_400), intensity: 8)
+        ]
+
+        let sevenDays = InsightEngine().evaluate(
+            episodes: episodes,
+            period: .sevenDays,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+        let thirtyDays = InsightEngine().evaluate(
+            episodes: episodes,
+            period: .thirtyDays,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+        let threeMonths = InsightEngine().evaluate(
+            episodes: episodes,
+            period: .threeMonths,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        #expect(sevenDays.totalQualifiedEpisodeCount == 2)
+        #expect(thirtyDays.totalQualifiedEpisodeCount == 3)
+        #expect(threeMonths.totalQualifiedEpisodeCount == 4)
+    }
+
+    @Test
+    func insightAggregationExposesSharedMetricsForTriggersMedicationWeatherAndTrend() {
+        let calendar = fixedCalendar()
+        let start = fixedDate()
+        let medication = MedicationRecord(
+            id: UUID(),
+            name: "Sumatriptan",
+            category: .triptan,
+            dosage: "50 mg",
+            quantity: 1,
+            takenAt: start,
+            effectiveness: .good,
+            reliefStartedAt: nil,
+            isRepeatDose: false
+        )
+        let check = ContinuousMedicationCheckRecord(
+            id: UUID(),
+            continuousMedicationID: UUID(),
+            name: "Metoprolol",
+            dosage: "50 mg",
+            frequency: "täglich",
+            wasTaken: true
+        )
+        let weather = WeatherRecord(
+            recordedAt: start,
+            condition: "Regen",
+            temperature: 12,
+            humidity: 80,
+            pressure: 1_004,
+            precipitation: 2,
+            weatherCode: 63,
+            source: "Test",
+            contextRangeStart: start.addingTimeInterval(-3_600),
+            contextRangeEnd: start
+        )
+        let episodes = (0 ..< 5).map { offset in
+            makeEpisode(
+                id: UUID(),
+                startedAt: start.addingTimeInterval(Double(offset) * 86_400),
+                intensity: 4 + offset,
+                triggers: offset < 3 ? ["Stress"] : [],
+                medications: offset < 2 ? [medication] : [],
+                continuousMedicationChecks: offset < 4 ? [check] : [],
+                weather: offset < 2 ? weather : nil
+            )
+        }
+
+        let result = InsightEngine().evaluate(
+            episodes: episodes,
+            period: .thirtyDays,
+            referenceDate: start.addingTimeInterval(5 * 86_400),
+            calendar: calendar
+        )
+
+        #expect(result.metrics.triggerSummaries.first?.name == "Stress")
+        #expect(result.metrics.triggerSummaries.first?.count == 3)
+        #expect(abs((result.metrics.triggerSummaries.first?.share ?? 0) - 0.6) < 0.001)
+        #expect(result.metrics.acuteMedicationSummaries.first?.name == "Sumatriptan")
+        #expect(result.metrics.acuteMedicationSummaries.first?.count == 2)
+        #expect(result.metrics.continuousMedicationSummaries.first?.name == "Metoprolol")
+        #expect(result.metrics.continuousMedicationSummaries.first?.takenCount == 4)
+        #expect(result.metrics.weatherSummary.entryCountWithWeather == 2)
+        #expect(result.metrics.weatherSummary.extendedContextCount == 2)
+        #expect(result.metrics.dailyIntensityTrend.count == 5)
+        #expect(result.metrics.dailyIntensityTrend.last?.highestIntensity == 8)
+    }
+
+    @Test
+    func insightAggregationReturnsStructuredEmptyStateInsteadOfFallbackValues() {
+        let result = InsightEngine().evaluate(
+            episodes: [],
+            period: .sevenDays,
+            referenceDate: fixedDate(),
+            calendar: fixedCalendar()
+        )
+
+        #expect(result.emptyState?.reason == .noQualifiedEntries)
+        #expect(result.emptyState?.availableEntryCount == 0)
+        #expect(result.metrics == .empty)
+        #expect(result.insights.isEmpty)
+    }
+
+    @Test
     func loadSettingsUseCaseCountsActiveTrashAndConflicts() async throws {
         let episodeRepository = EpisodeRepositoryMock()
         let medicationRepository = MedicationCatalogRepositoryMock()
@@ -506,6 +623,8 @@ private func makeEpisode(
     symptoms: [String] = [],
     triggers: [String] = [],
     menstruationStatus: MenstruationStatus = .unknown,
+    medications: [MedicationRecord] = [],
+    continuousMedicationChecks: [ContinuousMedicationCheckRecord] = [],
     weather: WeatherRecord? = nil
 ) -> EpisodeRecord {
     EpisodeRecord(
@@ -523,8 +642,8 @@ private func makeEpisode(
         triggers: triggers,
         functionalImpact: "",
         menstruationStatus: menstruationStatus,
-        medications: [],
-        continuousMedicationChecks: [],
+        medications: medications,
+        continuousMedicationChecks: continuousMedicationChecks,
         weather: weather,
         healthContext: nil
     )

--- a/docs/Insight-Engine.md
+++ b/docs/Insight-Engine.md
@@ -6,19 +6,24 @@ Die Insight Engine berechnet lokale Hinweise aus echten Tagebuchdaten. Sie erzeu
 
 Ausgewertet werden nur aktive Einträge mit dem Typ `Migräne` oder `Kopfschmerz`. Einträge mit `Unklar`, gelöschte Einträge und zukünftige Nicht-Schmerz-Typen zählen nicht als normale Messwerte. Dadurch werden auch keine „Keine Schmerzen“-Datenpunkte in Durchschnitt, Trend oder Muster eingerechnet.
 
-Die Mindestmenge liegt bei `5` qualifizierten Einträgen. Unterhalb dieser Grenze liefert `InsightEngine` nur `totalQualifiedEpisodeCount` und keine Insights.
+Die Mindestmenge liegt bei `5` qualifizierten Einträgen. Unterhalb dieser Grenze liefert `InsightEngine` strukturierte Empty-State-Daten und keine Insights.
 
 ## Aggregation
 
-`DataAggregator` bereitet die Daten für alle Detektoren vor:
+`DataAggregator` bereitet die Daten für alle Detektoren, Kennzahlen und Charts aus derselben gefilterten Datenbasis vor. Unterstützte Zeiträume sind `7 Tage`, `30 Tage` und `3 Monate`.
 
-- qualifizierte Einträge, nach Startzeit sortiert
+- qualifizierte Einträge im ausgewählten Zeitraum, nach Startzeit sortiert
 - durchschnittliche Intensität über alle qualifizierten Einträge
 - Anzahl und durchschnittliche Intensität pro Wochentag
-- Anzahl normalisierter Trigger pro Eintrag
+- Anzahl und durchschnittliche Intensität pro Tagesbereich
+- Anzahl normalisierter Trigger pro Eintrag inklusive relativer Häufigkeit
+- Akutmedikation und Dauermedikations-Checks pro Zeitraum
+- Wetterkontext inklusive Bedingungen, Mittelwerten und erweiterten Kontextwerten
+- Tagesverlauf mit echten Intensitätswerten
 - Fingerprint für den Cache
 
 Trigger werden pro Eintrag dedupliziert, getrimmt und alphabetisch sortiert. Leere Trigger werden ignoriert.
+Akutmedikamente werden pro Eintrag über den normalisierten Namen dedupliziert. Dauermedikation nutzt die beim Eintrag gespeicherten Checks und trennt eingenommen/nicht eingenommen.
 
 ## Detektoren
 
@@ -79,7 +84,9 @@ Bei gleichem Score entscheidet zuerst die höhere `confidence`, danach der Titel
 - Typ
 - Intensität
 - normalisierte Trigger
-- Wetterstatus
+- normalisierte Akutmedikation
+- Dauermedikations-Checks
+- Wetterstatus und Wetterkontext
 
 Neue oder bearbeitete Einträge ändern `updatedAt` oder die ausgewerteten Felder und erzwingen dadurch eine Neuberechnung. Der Cache ist bewusst nur lokal im laufenden Prozess; er ersetzt keine persistierte Statistik.
 


### PR DESCRIPTION
## What changed

- Added period-aware insight aggregation for 7 days, 30 days, and 3 months.
- Added shared metrics for trigger shares, day parts, medication usage, weather context, and daily intensity trend data.
- Added structured empty-state data instead of fallback insight values when data is missing or weak.
- Added an Insights period picker and updated the Insight Engine documentation.

## Why

Implements #172 so Insights, charts, and key figures can be derived from the same real filtered entry data without demo or placeholder values.

## Validation

- `xcodebuild test -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 16'`\n- `git diff --check`