### PR TITLE
[codex] Implement cautious insight empty states

### DIFF
--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -527,6 +527,7 @@ struct HomeOverviewData: Equatable {
 
 struct HomePatternPreviewData: Equatable {
     let totalPainEpisodeCount: Int
+    let emptyState: InsightEmptyState?
     let cards: [HomePatternPreviewCard]
 
     var hasEnoughData: Bool {
@@ -535,13 +536,15 @@ struct HomePatternPreviewData: Equatable {
 
     static let minimumEpisodeCount = InsightEngine.minimumQualifiedEpisodeCount
 
-    init(totalPainEpisodeCount: Int, cards: [HomePatternPreviewCard]) {
+    init(totalPainEpisodeCount: Int, emptyState: InsightEmptyState? = nil, cards: [HomePatternPreviewCard]) {
         self.totalPainEpisodeCount = totalPainEpisodeCount
+        self.emptyState = emptyState
         self.cards = cards
     }
 
     init(result: InsightResult) {
         totalPainEpisodeCount = result.totalQualifiedEpisodeCount
+        emptyState = result.emptyState
         cards = result.insights.map(HomePatternPreviewCard.init)
     }
 }

--- a/Symi/Sources/Core/Insights/InsightCore.swift
+++ b/Symi/Sources/Core/Insights/InsightCore.swift
@@ -199,16 +199,16 @@ extension InsightEmptyState {
         if qualifiedEpisodeCount == 0 {
             self = InsightEmptyState(
                 reason: .noQualifiedEntries,
-                title: "Noch keine auswertbaren Einträge",
-                message: "Für diesen Zeitraum liegen keine Migräne- oder Kopfschmerz-Einträge vor.",
+                title: "Noch nicht genug Einträge für Muster",
+                message: "Wenn du einige Schmerz- oder Migräneeinträge erfasst hast, zeigt Symi hier vorsichtige Hinweise.",
                 requiredEntryCount: minimumCount,
                 availableEntryCount: qualifiedEpisodeCount
             )
         } else {
             self = InsightEmptyState(
                 reason: .notEnoughQualifiedEntries(required: minimumCount, available: qualifiedEpisodeCount),
-                title: "Noch nicht genug Einträge",
-                message: "\(qualifiedEpisodeCount) von \(minimumCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden.",
+                title: "Noch nicht genug Einträge für Muster",
+                message: "\(qualifiedEpisodeCount) von \(minimumCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden. Sobald mehr Daten da sind, sucht Symi nach vorsichtigen Mustern.",
                 requiredEntryCount: minimumCount,
                 availableEntryCount: qualifiedEpisodeCount
             )
@@ -218,8 +218,8 @@ extension InsightEmptyState {
     static func noVisibleInsights(qualifiedEpisodeCount: Int, minimumCount: Int) -> InsightEmptyState {
         InsightEmptyState(
             reason: .noVisibleInsights,
-            title: "Noch kein stabiler Hinweis",
-            message: "Es gibt genug Einträge, aber noch kein Muster mit ausreichender Confidence und Importance.",
+            title: "Noch kein vorsichtiges Muster sichtbar",
+            message: "Es gibt genug Einträge, aber noch nichts, das in deinen Einträgen auffällig genug ist.",
             requiredEntryCount: minimumCount,
             availableEntryCount: qualifiedEpisodeCount
         )
@@ -840,26 +840,26 @@ enum InsightFormatter {
     private static func title(for candidate: InsightCandidate) -> String {
         switch candidate.payload {
         case .weekday(let weekday, _, _):
-            "Auffälliger \(weekdayName(for: weekday))"
+            "Muster erkannt: \(weekdayName(for: weekday))"
         case .trigger(let name, _, _):
-            "\(name) fällt öfter auf"
+            "\(name) häufiger zusammen mit Einträgen"
         case .averageIntensity(let value, _):
-            "Durchschnitt \(formattedIntensity(value))/10"
+            "Muster erkannt: Durchschnitt \(formattedIntensity(value))/10"
         case .trend(let direction, _, _, _):
-            direction == .rising ? "Intensität steigt" : "Intensität fällt"
+            direction == .rising ? "Muster erkannt: häufiger höhere Intensität" : "Muster erkannt: häufiger niedrigere Intensität"
         }
     }
 
     private static func description(for candidate: InsightCandidate, totalCount: Int) -> String {
         switch candidate.payload {
         case .weekday(let weekday, let count, _):
-            "\(entryCountText(count)) von \(entryCountText(totalCount)) liegen auf \(weekdayName(for: weekday)). Das ist ein Muster in deinen bisherigen Einträgen, keine Vorhersage."
+            "\(entryCountText(count)) von \(entryCountText(totalCount)) liegen auf \(weekdayName(for: weekday)). Das ist in deinen Einträgen auffällig, aber keine Vorhersage."
         case .trigger(let name, let count, _):
-            "\(name) wurde bei \(entryCountText(count)) von \(entryCountText(totalCount)) notiert. Symi wertet das als Häufung, nicht als Ursache."
-        case .averageIntensity(let value, let count):
-            "Die durchschnittliche Intensität deiner \(entryCountText(count)) liegt bei \(formattedIntensity(value)) von 10."
+            "\(name) wurde bei \(entryCountText(count)) von \(entryCountText(totalCount)) notiert. Symi beschreibt nur, was häufiger zusammen mit dokumentierten Einträgen vorkommt."
+        case .averageIntensity(let value, _):
+            "In deinen Einträgen auffällig: Die dokumentierte Intensität liegt im Durchschnitt bei \(formattedIntensity(value)) von 10."
         case .trend(_, let olderAverage, let newerAverage, _):
-            "Neuere Einträge liegen im Durchschnitt bei \(formattedIntensity(newerAverage))/10, ältere bei \(formattedIntensity(olderAverage))/10. Das beschreibt nur den Verlauf deiner dokumentierten Einträge."
+            "Muster erkannt: Neuere Einträge liegen im Durchschnitt bei \(formattedIntensity(newerAverage))/10, ältere bei \(formattedIntensity(olderAverage))/10. Das beschreibt nur den dokumentierten Verlauf."
         }
     }
 

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -461,7 +461,7 @@ private struct HomePatternPreviewSection<Destination: View>: View {
                     }
                 }
             } else {
-                HomePatternEmptyState(recordedCount: data.totalPainEpisodeCount)
+                HomePatternEmptyState(recordedCount: data.totalPainEpisodeCount, emptyState: data.emptyState)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -522,6 +522,7 @@ private struct HomePatternCard: View {
 
 private struct HomePatternEmptyState: View {
     let recordedCount: Int
+    let emptyState: InsightEmptyState?
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -552,19 +553,27 @@ private struct HomePatternEmptyState: View {
     }
 
     private var emptyStateText: String {
+        if let emptyState {
+            return emptyState.message
+        }
+
         if recordedCount >= HomePatternPreviewData.minimumEpisodeCount {
-            return "Es gibt schon genug Einträge, aber noch keinen wiederkehrenden Hinweis, den wir ruhig anzeigen würden."
+            return "Es gibt schon genug Einträge, aber noch nichts, das in deinen Einträgen auffällig genug ist."
         }
 
         if recordedCount == 0 {
-            return "Wenn du ein paar Schmerz- oder Migräneeinträge erfasst hast, zeigen wir hier vorsichtige Hinweise."
+            return "Wenn du einige Schmerz- oder Migräneeinträge erfasst hast, zeigt Symi hier vorsichtige Hinweise."
         }
 
-        return "\(recordedCount) von \(HomePatternPreviewData.minimumEpisodeCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden."
+        return "\(recordedCount) von \(HomePatternPreviewData.minimumEpisodeCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden. Sobald mehr Daten da sind, sucht Symi nach vorsichtigen Mustern."
     }
 
     private var title: String {
-        recordedCount >= HomePatternPreviewData.minimumEpisodeCount ? "Noch kein ruhiger Hinweis" : "Noch nicht genug Einträge"
+        if let emptyState {
+            return emptyState.title
+        }
+
+        return recordedCount >= HomePatternPreviewData.minimumEpisodeCount ? "Noch kein vorsichtiges Muster sichtbar" : "Noch nicht genug Einträge für Muster"
     }
 
     private var emptyIconSize: CGFloat {
@@ -642,7 +651,7 @@ private struct HomeInsightsContent: View {
                     }
                 }
             } else {
-                HomePatternEmptyState(recordedCount: data.totalQualifiedEpisodeCount)
+                HomePatternEmptyState(recordedCount: data.totalQualifiedEpisodeCount, emptyState: data.emptyState)
             }
 
             InsightMethodSummary()
@@ -804,10 +813,10 @@ private struct HomeSurfaceModifier: ViewModifier {
         content
             .background(cardBackground, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
             .shadow(
-                color: AppTheme.petrol(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.clearAccent : 0.05),
-                radius: 10,
+                color: AppTheme.petrol(for: colorScheme).opacity(colorScheme == .dark ? 0.02 : 0.05),
+                radius: colorScheme == .dark ? 3 : 10,
                 x: SymiShadow.cardXOffset,
-                y: 4
+                y: colorScheme == .dark ? 1 : 4
             )
     }
 
@@ -816,7 +825,7 @@ private struct HomeSurfaceModifier: ViewModifier {
             return LinearGradient(
                 colors: [
                     AppTheme.cardBackground(for: colorScheme),
-                    AppTheme.sage(for: colorScheme).opacity(SymiOpacity.clearAccent),
+                    AppTheme.sage(for: colorScheme).opacity(SymiOpacity.hairline),
                 ],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -260,7 +260,7 @@ struct CoreArchitectureTests {
         let average = result.insights.first { $0.category == .averageIntensity }
 
         #expect(result.totalQualifiedEpisodeCount == 5)
-        #expect(average?.title == "Durchschnitt 6/10")
+        #expect(average?.title == "Muster erkannt: Durchschnitt 6/10")
     }
 
     @Test
@@ -284,7 +284,7 @@ struct CoreArchitectureTests {
         let result = engine.evaluate(episodes: episodes, calendar: fixedCalendar())
         let average = result.insights.first { $0.category == .averageIntensity }
 
-        #expect(average?.title == "Durchschnitt 6/10")
+        #expect(average?.title == "Muster erkannt: Durchschnitt 6/10")
         #expect(average?.description.contains("6 von 10") == true)
         #expect(average?.confidence ?? 0 >= InsightScorer.confidenceThreshold)
         #expect(abs((average?.importance ?? 0) - 0.6) < 0.001)
@@ -336,8 +336,33 @@ struct CoreArchitectureTests {
         let risingTrend = engine.evaluate(episodes: rising, calendar: fixedCalendar()).insights.first { $0.category == .trend }
         let fallingTrend = engine.evaluate(episodes: falling, calendar: fixedCalendar()).insights.first { $0.category == .trend }
 
-        #expect(risingTrend?.title == "Intensität steigt")
-        #expect(fallingTrend?.title == "Intensität fällt")
+        #expect(risingTrend?.title == "Muster erkannt: häufiger höhere Intensität")
+        #expect(fallingTrend?.title == "Muster erkannt: häufiger niedrigere Intensität")
+    }
+
+    @Test
+    func insightEngineUsesCautiousNonDiagnosticLanguage() {
+        let engine = InsightEngine()
+        let start = fixedDate()
+        let episodes = [
+            makeEpisode(id: UUID(), startedAt: start, intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(7 * 86_400), intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(14 * 86_400), intensity: 8, triggers: ["Stress"]),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(21 * 86_400), intensity: 8),
+            makeEpisode(id: UUID(), startedAt: start.addingTimeInterval(86_400), intensity: 7)
+        ]
+
+        let result = engine.evaluate(episodes: episodes, calendar: fixedCalendar())
+        let combinedInsightText = result.insights
+            .flatMap { [$0.title, $0.description] }
+            .joined(separator: " ")
+
+        #expect(combinedInsightText.contains("Muster erkannt"))
+        #expect(combinedInsightText.contains("häufiger zusammen mit") || combinedInsightText.contains("in deinen Einträgen auffällig"))
+        #expect(combinedInsightText.localizedCaseInsensitiveContains("Diagnose") == false)
+        #expect(combinedInsightText.localizedCaseInsensitiveContains("Ursache") == false)
+        #expect(combinedInsightText.localizedCaseInsensitiveContains("Risiko") == false)
+        #expect(combinedInsightText.localizedCaseInsensitiveContains("du solltest") == false)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- updates insight copy to use cautious, non-diagnostic wording
- carries structured empty states into Home and Insights instead of local fallback-only text
- softens Home/Insights surfaces in dark mode
- adds test coverage for the insight wording rules

## Validation
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'