### PR TITLE
[codex] Implement Liquid Glass UI refresh

### DIFF
--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -60,6 +60,61 @@ enum EntryStartedAtPreset: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
+enum EntryDayPartPreset: String, CaseIterable, Identifiable, Sendable {
+    case morgens
+    case mittags
+    case abends
+    case nacht
+
+    var id: String { rawValue }
+
+    var dayPart: EpisodeDayPart {
+        switch self {
+        case .morgens:
+            .morgens
+        case .mittags:
+            .mittags
+        case .abends:
+            .abends
+        case .nacht:
+            .nacht
+        }
+    }
+
+    var title: String {
+        dayPart.label
+    }
+
+    var symbolName: String {
+        switch self {
+        case .morgens:
+            "sunrise.fill"
+        case .mittags:
+            "sun.max.fill"
+        case .abends:
+            "sunset.fill"
+        case .nacht:
+            "moon.stars.fill"
+        }
+    }
+
+    func date(on referenceDate: Date = .now, calendar: Calendar = .current) -> Date {
+        let hour: Int
+        switch self {
+        case .morgens:
+            hour = 8
+        case .mittags:
+            hour = 13
+        case .abends:
+            hour = 19
+        case .nacht:
+            hour = 23
+        }
+
+        return calendar.date(bySettingHour: hour, minute: 0, second: 0, of: referenceDate) ?? referenceDate
+    }
+}
+
 @MainActor
 @Observable
 final class EntryContinuousMedicationController {
@@ -222,6 +277,11 @@ final class EntryFlowCoordinator {
 
     func selectStartedAtPreset(_ preset: EntryStartedAtPreset, calendar: Calendar = .current) {
         draft.startedAt = preset.date(relativeTo: .now, calendar: calendar)
+        weatherLoadState = .idle
+    }
+
+    func selectDayPartPreset(_ preset: EntryDayPartPreset, referenceDate: Date = .now, calendar: Calendar = .current) {
+        draft.startedAt = preset.date(on: referenceDate, calendar: calendar)
         weatherLoadState = .idle
     }
 

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -141,7 +141,7 @@ private struct EntryHeadacheStepView: View {
     let onBack: () -> Void
     let onCancel: () -> Void
 
-    @State private var selectedStartedAtPreset: EntryStartedAtPreset = .now
+    @State private var selectedDayPartPreset: EntryDayPartPreset = EntryDayPartPreset(dayPart: EpisodeDayPart(date: .now))
     private let visiblePainLocations: [EntryPainLocationOption] = [
         .init(title: "Stirn", imageName: "PainLocationForehead"),
         .init(title: "Schläfen", imageName: "PainLocationTemples"),
@@ -176,32 +176,20 @@ private struct EntryHeadacheStepView: View {
                 }
             }
 
-            InputFlowFieldGroup(title: "Wann tritt es auf?") {
-                HeadachePresetGrid {
-                    ForEach(EntryStartedAtPreset.allCases) { preset in
-                        PillOption(
+            InputFlowFieldGroup(title: "Tagesbereich") {
+                HeadacheDayPartGrid {
+                    ForEach(EntryDayPartPreset.allCases) { preset in
+                        InputFlowSelectionTile(
                             title: preset.title,
-                            isSelected: selectedStartedAtPreset == preset,
+                            systemImage: preset.symbolName,
+                            isSelected: selectedDayPartPreset == preset,
                             theme: .pain,
-                            accessibilityIdentifier: "entry-started-at-\(preset.rawValue)"
+                            accessibilityIdentifier: "entry-daypart-\(preset.rawValue)"
                         ) {
-                            selectedStartedAtPreset = preset
-                            if preset != .custom {
-                                coordinator.selectStartedAtPreset(preset)
-                            }
+                            selectedDayPartPreset = preset
+                            coordinator.selectDayPartPreset(preset)
                         }
                     }
-                }
-
-                if selectedStartedAtPreset == .custom {
-                    DatePicker(
-                        "Beginn",
-                        selection: $coordinator.draft.startedAt,
-                        in: ...Date.now,
-                        displayedComponents: [.date, .hourAndMinute]
-                    )
-                    .datePickerStyle(.compact)
-                    .accessibilityIdentifier("entry-started-at-custom-picker")
                 }
             }
         } footer: {
@@ -219,6 +207,7 @@ private struct EntryHeadacheStepView: View {
         .onAppear {
             coordinator.draft.type = .headache
             coordinator.draft.intensity = coordinator.draft.normalizedIntensity
+            selectedDayPartPreset = EntryDayPartPreset(dayPart: EpisodeDayPart(date: coordinator.draft.startedAt))
             seedDefaultPainLocationIfNeeded(coordinator: coordinator)
         }
     }
@@ -242,6 +231,21 @@ private struct EntryHeadacheStepView: View {
             selection.remove(option)
         } else {
             selection.insert(option)
+        }
+    }
+}
+
+private extension EntryDayPartPreset {
+    init(dayPart: EpisodeDayPart) {
+        switch dayPart {
+        case .morgens:
+            self = .morgens
+        case .mittags:
+            self = .mittags
+        case .abends:
+            self = .abends
+        case .nacht:
+            self = .nacht
         }
     }
 }
@@ -345,7 +349,7 @@ private struct HeadacheLocationGrid<Content: View>: View {
     }
 }
 
-private struct HeadachePresetGrid<Content: View>: View {
+private struct HeadacheDayPartGrid<Content: View>: View {
     let content: Content
 
     init(@ViewBuilder content: () -> Content) {

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -44,6 +44,14 @@ struct HomeView: View {
                 HomeHeaderView()
                     .padding(.bottom, SymiSpacing.lg)
 
+                HomePainScaleCard(episode: latestTodayEpisode)
+                    .padding(.bottom, SymiSpacing.lg)
+
+                PrimaryEntryButton {
+                    isPresentingEpisodeEditor = true
+                }
+                .padding(.bottom, SymiSpacing.lg)
+
                 HomeMonthCalendarView(
                     month: displayedMonth,
                     episodesByDay: calendarMonthData.episodesByDay,
@@ -51,11 +59,6 @@ struct HomeView: View {
                     onNext: showNextMonth
                 )
                 .padding(.bottom, SymiSpacing.lg)
-
-                PrimaryEntryButton {
-                    isPresentingEpisodeEditor = true
-                }
-                .padding(.bottom, SymiSpacing.md)
 
                 HomeAllEntriesLink(appContainer: appContainer)
                     .padding(.bottom, SymiSpacing.xxxl)
@@ -77,6 +80,14 @@ struct HomeView: View {
                 HomeHeaderView()
                     .padding(.bottom, SymiSpacing.lg)
 
+                HomePainScaleCard(episode: latestTodayEpisode)
+                    .padding(.bottom, SymiSpacing.lg)
+
+                PrimaryEntryButton {
+                    isPresentingEpisodeEditor = true
+                }
+                .padding(.bottom, SymiSpacing.lg)
+
                 HomeMonthCalendarView(
                     month: displayedMonth,
                     episodesByDay: calendarMonthData.episodesByDay,
@@ -84,11 +95,6 @@ struct HomeView: View {
                     onNext: showNextMonth
                 )
                 .padding(.bottom, SymiSpacing.lg)
-
-                PrimaryEntryButton {
-                    isPresentingEpisodeEditor = true
-                }
-                .padding(.bottom, SymiSpacing.md)
 
                 HomeAllEntriesLink(appContainer: appContainer)
                     .padding(.bottom, SymiSpacing.xxxl)
@@ -139,6 +145,11 @@ struct HomeView: View {
         }
 
         displayedMonth = newMonth
+    }
+
+    private var latestTodayEpisode: EpisodeRecord? {
+        let today = Calendar.current.startOfDay(for: .now)
+        return calendarMonthData.episodesByDay[today]?.max { $0.startedAt < $1.startedAt }
     }
 }
 
@@ -282,11 +293,11 @@ private struct HomeCalendarDayCell: View {
     private func dotColor(for entry: EpisodeRecord) -> Color {
         switch entry.intensity {
         case 8 ... 10:
-            AppTheme.coral(for: colorScheme).opacity(0.72)
+            AppTheme.coral(for: colorScheme).opacity(SymiOpacity.calendarHighIntensityDot)
         case 5 ... 7:
-            AppTheme.sage(for: colorScheme).opacity(0.72)
+            AppTheme.sage(for: colorScheme).opacity(SymiOpacity.calendarMediumIntensityDot)
         default:
-            AppTheme.petrol(for: colorScheme).opacity(0.62)
+            AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.calendarLowIntensityDot)
         }
     }
 
@@ -295,7 +306,7 @@ private struct HomeCalendarDayCell: View {
             return AppTheme.symiOnAccent
         }
 
-        return AppTheme.textPrimary(for: colorScheme).opacity(0.6)
+        return AppTheme.textPrimary(for: colorScheme).opacity(SymiOpacity.calendarInactiveDayText)
     }
 
     private var dayNumberFont: Font {
@@ -337,7 +348,7 @@ private struct HomeHeaderView: View {
         Image("HomeBrandLogo")
             .resizable()
             .scaledToFit()
-            .frame(width: 140, height: 68, alignment: .leading)
+            .frame(width: SymiSize.homeBrandLogoWidth, height: SymiSize.homeBrandLogoHeight, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityLabel(ProductBranding.displayName)
             .accessibilityAddTraits(.isHeader)
@@ -354,12 +365,12 @@ private struct PrimaryEntryButton: View {
                 Image(systemName: "plus")
                     .font(.title2.weight(.semibold))
                     .foregroundStyle(AppTheme.symiOnAccent)
-                    .frame(width: 48, height: 48)
+                    .frame(width: SymiSize.homeQuickEntryIcon, height: SymiSize.homeQuickEntryIcon)
                     .background(AppTheme.coral(for: colorScheme), in: Circle())
                     .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
-                    Text("Eintrag erstellen")
+                    Text("Neuer Eintrag")
                         .font(.headline.weight(.semibold))
                         .foregroundStyle(AppTheme.symiOnAccent)
                         .lineLimit(1)
@@ -375,15 +386,131 @@ private struct PrimaryEntryButton: View {
                 Spacer(minLength: SymiSpacing.xs)
             }
             .padding(.horizontal, SymiSpacing.lg)
-            .frame(maxWidth: .infinity, minHeight: 68, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: SymiSize.homeQuickEntryButtonMinHeight, alignment: .leading)
         }
         .buttonStyle(HomePrimaryActionButtonStyle(colorScheme: colorScheme))
         .keyboardShortcut("n", modifiers: .command)
         .hoverEffect(.highlight)
         .accessibilityIdentifier("home-quick-entry")
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Eintrag erstellen")
+        .accessibilityLabel("Neuer Eintrag")
         .accessibilityHint("Startet einen neuen Eintrag.")
+    }
+}
+
+private struct HomePainScaleCard: View {
+    let episode: EpisodeRecord?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        GlassCard(level: .prominent) {
+            VStack(alignment: .leading, spacing: SymiSpacing.lg) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Schmerzskala")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
+                        .accessibilityAddTraits(.isHeader)
+
+                    Spacer(minLength: SymiSpacing.sm)
+
+                    Text(dayPartText)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(AppTheme.petrol(for: colorScheme))
+                        .padding(.horizontal, SymiSpacing.md)
+                        .padding(.vertical, SymiSpacing.compact)
+                        .background(AppTheme.sage(for: colorScheme).opacity(SymiOpacity.secondaryFill), in: Capsule())
+                }
+
+                HStack(alignment: .lastTextBaseline, spacing: SymiSpacing.sm) {
+                    Text(scoreText)
+                        .font(SymiTypography.homePainScaleMetric)
+                        .monospacedDigit()
+                        .foregroundStyle(AppTheme.petrol(for: colorScheme))
+                        .minimumScaleFactor(SymiTypography.gaugeScaleFactor)
+
+                    Text("/10")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
+
+                    Spacer(minLength: SymiSpacing.xs)
+                }
+
+                HomeScaleBar(value: episode?.intensity)
+
+                Text(detailText)
+                    .font(.subheadline)
+                    .foregroundStyle(AppTheme.textSecondary(for: colorScheme))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier("home-pain-scale-card")
+    }
+
+    private var scoreText: String {
+        guard let episode else {
+            return "-"
+        }
+
+        return "\(min(max(episode.intensity, 1), 10))"
+    }
+
+    private var dayPartText: String {
+        episode?.dayPart.label ?? EpisodeDayPart(date: .now).label
+    }
+
+    private var detailText: String {
+        guard let episode else {
+            return "Starte mit der Skala und erfasse nur Tage, an denen du Schmerzen festhalten möchtest."
+        }
+
+        let location = episode.painLocation.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !location.isEmpty else {
+            return "Letzter Eintrag heute, \(episode.startedAt.formatted(date: .omitted, time: .shortened))."
+        }
+
+        return "\(location) · letzter Eintrag heute, \(episode.startedAt.formatted(date: .omitted, time: .shortened))."
+    }
+
+    private var accessibilityLabel: String {
+        guard let episode else {
+            return "Schmerzskala, noch kein Eintrag heute."
+        }
+
+        return "Schmerzskala, letzter Eintrag heute \(episode.intensity) von 10, \(dayPartText)."
+    }
+}
+
+private struct HomeScaleBar: View {
+    let value: Int?
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: SymiSpacing.compact) {
+            ForEach(1 ... 10, id: \.self) { step in
+                Capsule()
+                    .fill(fill(for: step))
+                    .frame(maxWidth: .infinity)
+                    .frame(height: step == value ? SymiSize.homePainScaleSelectedSegmentHeight : SymiSize.homePainScaleSegmentHeight)
+            }
+        }
+        .frame(height: SymiSize.homePainScaleBarHeight)
+        .accessibilityHidden(true)
+    }
+
+    private func fill(for step: Int) -> Color {
+        guard let value else {
+            return AppTheme.sage(for: colorScheme).opacity(SymiOpacity.faintSurface)
+        }
+
+        if step <= min(max(value, 1), 10) {
+            return step >= 7 ? AppTheme.coral(for: colorScheme) : AppTheme.petrol(for: colorScheme)
+        }
+
+        return AppTheme.sage(for: colorScheme).opacity(SymiOpacity.softFill)
     }
 }
 
@@ -630,7 +757,7 @@ private struct HomeInsightsContent: View {
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 22) {
+        VStack(alignment: .leading, spacing: SymiSpacing.insightsContentSpacing) {
             InsightsHeader()
 
             InsightsPeriodFilter(selectedPeriod: $selectedPeriod)
@@ -707,7 +834,7 @@ private struct InsightsHeader: View {
     var body: some View {
         VStack(alignment: .leading, spacing: SymiSpacing.xs) {
             Text("Insights")
-                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .font(SymiTypography.largeRoundedTitle)
                 .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
                 .accessibilityAddTraits(.isHeader)
 
@@ -763,7 +890,7 @@ private struct InsightHeroCard: View {
                 Image(systemName: insight.systemImage ?? insight.category.fallbackSystemImage)
                     .font(.body.weight(.semibold))
                     .foregroundStyle(AppTheme.petrol(for: colorScheme))
-                    .frame(width: 42, height: 42)
+                    .frame(width: SymiSize.insightHeroIcon, height: SymiSize.insightHeroIcon)
                     .background(AppTheme.sage(for: colorScheme).opacity(SymiOpacity.secondaryFill), in: Circle())
                     .accessibilityHidden(true)
 
@@ -774,7 +901,7 @@ private struct InsightHeroCard: View {
                         .textCase(.uppercase)
 
                     Text(insight.title)
-                        .font(.system(size: 23, weight: .bold, design: .rounded))
+                        .font(SymiTypography.insightHeroTitle)
                         .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -787,11 +914,11 @@ private struct InsightHeroCard: View {
 
             if trendPoints.count >= 2 {
                 InsightTrendStrip(points: trendPoints)
-                    .frame(height: 142)
+                    .frame(height: SymiSize.insightTrendStripHeight)
                     .accessibilityLabel("Ruhiger Verlauf der dokumentierten Stärke")
             } else {
                 InsightDotPattern(entryCount: entryCount)
-                    .frame(height: 78)
+                    .frame(height: SymiSize.insightDotPatternHeight)
                     .accessibilityLabel("\(entryCount) Einträge im gewählten Zeitraum")
             }
         }
@@ -813,7 +940,7 @@ private struct AverageIntensityInsightCard: View {
             InsightCardHeader(title: "Durchschnittliche Stärke", systemImage: "gauge.medium", tint: AppTheme.sage(for: colorScheme))
 
             Text("\(formattedAverage) / 10")
-                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .font(SymiTypography.insightMetric)
                 .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
 
             Text(intensityDescription)
@@ -830,7 +957,7 @@ private struct AverageIntensityInsightCard: View {
                         .frame(width: geometry.size.width * min(max(averageIntensity / 10, 0), 1))
                 }
             }
-            .frame(height: 7)
+            .frame(height: SymiSize.insightAverageTrackHeight)
             .accessibilityHidden(true)
         }
         .padding(SymiSpacing.xl)
@@ -911,7 +1038,7 @@ private struct InsightCardHeader: View {
             Image(systemName: systemImage)
                 .font(.caption.weight(.bold))
                 .foregroundStyle(tint)
-                .frame(width: 28, height: 28)
+                .frame(width: SymiSize.insightCardHeaderIcon, height: SymiSize.insightCardHeaderIcon)
                 .background(tint.opacity(SymiOpacity.clearAccent), in: Circle())
                 .accessibilityHidden(true)
 
@@ -952,7 +1079,7 @@ private struct InsightFrequencyRow: View {
                             .frame(width: geometry.size.width * min(max(summary.share, 0), 1))
                     }
             }
-            .frame(height: 6)
+            .frame(height: SymiSize.insightShareTrackHeight)
             .accessibilityHidden(true)
         }
     }
@@ -971,7 +1098,7 @@ private struct InsightTrendStrip: View {
                 TrendLineShape(values: points.map(\.averageIntensity))
                     .stroke(
                         AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.heroPrimaryWave),
-                        style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round)
+                        style: StrokeStyle(lineWidth: SymiStroke.trendLine, lineCap: .round, lineJoin: .round)
                     )
                     .padding(.horizontal, SymiSpacing.md)
                     .padding(.vertical, SymiSpacing.xl)
@@ -979,7 +1106,7 @@ private struct InsightTrendStrip: View {
                 ForEach(Array(points.enumerated()), id: \.element.day) { index, point in
                     Circle()
                         .fill(AppTheme.coral(for: colorScheme).opacity(SymiOpacity.heroAccentWave))
-                        .frame(width: 7, height: 7)
+                        .frame(width: SymiSize.insightTrendPoint, height: SymiSize.insightTrendPoint)
                         .position(dotPosition(for: index, value: point.averageIntensity, in: geometry.size))
                 }
             }
@@ -1035,7 +1162,7 @@ private struct InsightDotPattern: View {
             ForEach(0 ..< visibleDotCount, id: \.self) { index in
                 Circle()
                     .fill(index.isMultiple(of: 2) ? AppTheme.sage(for: colorScheme).opacity(SymiOpacity.secondaryFill) : AppTheme.coral(for: colorScheme).opacity(SymiOpacity.faintSurface))
-                    .frame(width: 9, height: 9)
+                    .frame(width: SymiSize.insightPatternDot, height: SymiSize.insightPatternDot)
             }
         }
         .frame(maxWidth: .infinity)
@@ -1071,19 +1198,21 @@ struct AdaptiveDashboardCard<Content: View>: View {
 }
 
 private struct HomePrimaryActionButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     let colorScheme: ColorScheme
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .background(buttonBackground, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
-            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+            .background(buttonBackground, in: RoundedRectangle(cornerRadius: SymiRadius.homeActionButton, style: .continuous))
+            .scaleEffect(reduceMotion ? 1 : (configuration.isPressed ? 0.97 : 1))
             .shadow(
-                color: AppTheme.petrol(for: colorScheme).opacity(colorScheme == .dark ? 0.05 : 0.10),
+                color: AppTheme.petrol(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.homeActionShadowDark : SymiOpacity.homeActionShadowLight),
                 radius: 16,
                 x: SymiShadow.cardXOffset,
                 y: 5
             )
-            .animation(.spring(response: 0.22, dampingFraction: 0.82), value: configuration.isPressed)
+            .animation(reduceMotion ? nil : .spring(response: 0.22, dampingFraction: 0.82), value: configuration.isPressed)
     }
 
     private var buttonBackground: LinearGradient {
@@ -1105,44 +1234,27 @@ private struct HomeScreenModifier: ViewModifier {
         content
             .tint(AppTheme.petrol(for: colorScheme))
             .scrollContentBackground(.hidden)
-            .background(AppTheme.warmBackground(for: colorScheme).ignoresSafeArea())
+            .background {
+                ZStack {
+                    AppTheme.appBackground(for: colorScheme)
+                    AppTheme.sage(for: colorScheme)
+                        .opacity(colorScheme == .dark ? SymiOpacity.homeBackgroundPrimaryDark : SymiOpacity.homeBackgroundPrimaryLight)
+                        .blur(radius: SymiSize.homeLiquidBackgroundPrimaryBlur)
+                        .offset(x: SymiSpacing.homeLiquidBackgroundPrimaryOffsetX, y: SymiSpacing.homeLiquidBackgroundPrimaryOffsetY)
+                    AppTheme.coral(for: colorScheme)
+                        .opacity(colorScheme == .dark ? SymiOpacity.homeBackgroundSecondaryDark : SymiOpacity.homeBackgroundSecondaryLight)
+                        .blur(radius: SymiSize.homeLiquidBackgroundSecondaryBlur)
+                        .offset(x: SymiSpacing.homeLiquidBackgroundSecondaryOffsetX, y: SymiSpacing.homeLiquidBackgroundSecondaryOffsetY)
+                }
+                .ignoresSafeArea()
+            }
     }
 }
 
 private struct HomeSurfaceModifier: ViewModifier {
-    @Environment(\.colorScheme) private var colorScheme
-
     func body(content: Content) -> some View {
         content
-            .background(cardBackground, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
-            .shadow(
-                color: AppTheme.petrol(for: colorScheme).opacity(colorScheme == .dark ? 0.02 : 0.05),
-                radius: colorScheme == .dark ? 3 : 10,
-                x: SymiShadow.cardXOffset,
-                y: colorScheme == .dark ? 1 : 4
-            )
-    }
-
-    private var cardBackground: LinearGradient {
-        if colorScheme == .dark {
-            return LinearGradient(
-                colors: [
-                    AppTheme.cardBackground(for: colorScheme),
-                    AppTheme.sage(for: colorScheme).opacity(SymiOpacity.hairline),
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-        }
-
-        return LinearGradient(
-            colors: [
-                Color.white,
-                AppTheme.sage(for: colorScheme).opacity(0.03),
-            ],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-        )
+            .symiGlass(.regular, cornerRadius: SymiRadius.homeActionButton)
     }
 }
 

--- a/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
@@ -8,7 +8,7 @@ struct PainGaugeView: View {
 
     init(
         value: Binding<Int>,
-        range: ClosedRange<Int> = 0 ... 10,
+        range: ClosedRange<Int> = 1 ... 10,
         theme: InputFlowStepTheme = .pain
     ) {
         _value = value
@@ -108,8 +108,6 @@ private struct PainGaugeCard: View {
 
     private var intensityLabel: String {
         switch normalizedValue {
-        case ...0:
-            "Kein"
         case 1 ... 3:
             "Leicht"
         case 4 ... 6:
@@ -123,6 +121,7 @@ private struct PainGaugeCard: View {
 }
 
 private struct PainGaugeSlider: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
 
     @Binding var value: Int
@@ -163,7 +162,7 @@ private struct PainGaugeSlider: View {
                         updateValue(for: gesture.location.x, width: proxy.size.width)
                     }
             )
-            .animation(.snappy, value: value)
+            .animation(reduceMotion ? nil : .snappy, value: value)
         }
         .frame(height: SymiSize.painSliderTouchHeight)
         .accessibilityAdjustableAction { direction in

--- a/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
@@ -14,6 +14,7 @@ nonisolated enum SymiSpacing {
     static let screenTopInset: CGFloat = 12
     static let groupedHorizontalInset: CGFloat = 20
     static let dashboardSpacing: CGFloat = 20
+    static let insightsContentSpacing: CGFloat = 22
     static let wideContentMaxWidth: CGFloat = 1180
     static let readableContentMaxWidth: CGFloat = 760
     static let flowHorizontalPadding: CGFloat = 20
@@ -40,13 +41,19 @@ nonisolated enum SymiSpacing {
     static let heroWaveSecondaryOffsetY: CGFloat = 24
     static let heroWaveAccentOffsetX: CGFloat = -8
     static let heroWaveAccentOffsetY: CGFloat = 28
+    static let homeLiquidBackgroundPrimaryOffsetX: CGFloat = -160
+    static let homeLiquidBackgroundPrimaryOffsetY: CGFloat = -260
+    static let homeLiquidBackgroundSecondaryOffsetX: CGFloat = 170
+    static let homeLiquidBackgroundSecondaryOffsetY: CGFloat = 260
 }
 
 nonisolated enum SymiRadius {
     static let card: CGFloat = 20
     static let button: CGFloat = 18
     static let chip: CGFloat = 12
+    static let homeActionButton: CGFloat = 22
     static let heroCard: CGFloat = 24
+    static let glassSheetPanel: CGFloat = 32
     static let flowCard: CGFloat = 18
     static let flowTile: CGFloat = 14
     static let flowPill: CGFloat = 12
@@ -75,6 +82,8 @@ enum SymiShadow {
 nonisolated enum SymiSize {
     static let accessibilityMarker: CGFloat = 1
     static let minInteractiveHeight: CGFloat = 44
+    static let homeBrandLogoWidth: CGFloat = 140
+    static let homeBrandLogoHeight: CGFloat = 68
     static let flowHeaderControlHeight: CGFloat = 34
     static let primaryButtonHeight: CGFloat = 48
     static let progressIndicator: CGFloat = 22
@@ -118,6 +127,11 @@ nonisolated enum SymiSize {
     static let homeCalendarAccessibilityGrowth: CGFloat = 10
     static let homeCalendarDayAccessibilityGrowth: CGFloat = 14
     static let quickEntryIcon: CGFloat = 58
+    static let homeQuickEntryIcon: CGFloat = 48
+    static let homeQuickEntryButtonMinHeight: CGFloat = 68
+    static let homePainScaleSelectedSegmentHeight: CGFloat = 12
+    static let homePainScaleSegmentHeight: CGFloat = 8
+    static let homePainScaleBarHeight: CGFloat = 16
     static let quickEntryMinHeight: CGFloat = 108
     static let homePatternIcon: CGFloat = 34
     static let homePatternWideMinHeight: CGFloat = 138
@@ -125,6 +139,14 @@ nonisolated enum SymiSize {
     static let homePatternAccessibilityHeightGrowth: CGFloat = 54
     static let homePatternEmptyIcon: CGFloat = 38
     static let trendChartHeight: CGFloat = 88
+    static let insightHeroIcon: CGFloat = 42
+    static let insightTrendStripHeight: CGFloat = 142
+    static let insightDotPatternHeight: CGFloat = 78
+    static let insightAverageTrackHeight: CGFloat = 7
+    static let insightCardHeaderIcon: CGFloat = 28
+    static let insightShareTrackHeight: CGFloat = 6
+    static let insightTrendPoint: CGFloat = 7
+    static let insightPatternDot: CGFloat = 9
     static let reviewStepIcon: CGFloat = 44
     static let reviewSummaryIcon: CGFloat = 42
     static let productInfoIconWidth: CGFloat = 28
@@ -136,6 +158,8 @@ nonisolated enum SymiSize {
     static let heroWaveAccentHeight: CGFloat = 34
     static let painGaugeWidth: CGFloat = 218
     static let painGaugeHeight: CGFloat = 148
+    static let homeLiquidBackgroundPrimaryBlur: CGFloat = 70
+    static let homeLiquidBackgroundSecondaryBlur: CGFloat = 86
     static let emptyStateMinHeight: CGFloat = 360
     static let defaultWindowWidth: CGFloat = 1280
     static let defaultWindowHeight: CGFloat = 800
@@ -196,4 +220,19 @@ nonisolated enum SymiOpacity {
     static let footerBackground: Double = 0.96
     static let opaque: Double = 1
     static let elevatedShadow: Double = 1.2
+    static let calendarHighIntensityDot: Double = 0.72
+    static let calendarMediumIntensityDot: Double = 0.72
+    static let calendarLowIntensityDot: Double = 0.62
+    static let calendarInactiveDayText: Double = 0.60
+    static let glassBorderDarkMultiplier: Double = 0.22
+    static let glassProminentShadow: Double = 0.08
+    static let glassRegularShadow: Double = 0.045
+    static let glassTintDark: Double = 0.18
+    static let glassTintLight: Double = 0.26
+    static let homeActionShadowLight: Double = 0.10
+    static let homeActionShadowDark: Double = 0.05
+    static let homeBackgroundPrimaryLight: Double = 0.16
+    static let homeBackgroundPrimaryDark: Double = 0.08
+    static let homeBackgroundSecondaryLight: Double = 0.10
+    static let homeBackgroundSecondaryDark: Double = 0.05
 }

--- a/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiTypography.swift
@@ -11,6 +11,10 @@ enum SymiTypography {
     static let button = Font.headline.weight(.semibold)
     static let caption = Font.caption
     static let largeMetric = Font.system(size: 58, weight: .bold, design: .rounded)
+    static let largeRoundedTitle = Font.system(size: 34, weight: .bold, design: .rounded)
+    static let homePainScaleMetric = Font.system(size: 58, weight: .bold, design: .rounded)
+    static let insightHeroTitle = Font.system(size: 23, weight: .bold, design: .rounded)
+    static let insightMetric = Font.system(size: 30, weight: .bold, design: .rounded)
     static let painGaugeMetric = Font.system(size: 52, weight: .bold, design: .rounded)
     static let painGaugeUnit = Font.footnote.weight(.medium)
     static let painGaugeLabel = Font.title3.weight(.semibold)

--- a/Symi/Sources/Shared/LiquidGlassStyle.swift
+++ b/Symi/Sources/Shared/LiquidGlassStyle.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+
+enum SymiGlassLevel: Sendable {
+    case subtle
+    case regular
+    case prominent
+
+    var cornerRadius: CGFloat {
+        switch self {
+        case .subtle:
+            18
+        case .regular:
+            20
+        case .prominent:
+            24
+        }
+    }
+
+    var fillOpacity: Double {
+        switch self {
+        case .subtle:
+            0.70
+        case .regular:
+            0.80
+        case .prominent:
+            0.90
+        }
+    }
+
+    var borderOpacity: Double {
+        switch self {
+        case .subtle:
+            0.24
+        case .regular:
+            0.32
+        case .prominent:
+            0.42
+        }
+    }
+
+    var shadowRadius: CGFloat {
+        switch self {
+        case .prominent:
+            22
+        case .regular:
+            14
+        case .subtle:
+            9
+        }
+    }
+
+    var shadowY: CGFloat {
+        switch self {
+        case .prominent:
+            9
+        case .regular:
+            6
+        case .subtle:
+            3
+        }
+    }
+}
+
+struct GlassCard<Content: View>: View {
+    let level: SymiGlassLevel
+    let content: Content
+
+    init(level: SymiGlassLevel = .regular, @ViewBuilder content: () -> Content) {
+        self.level = level
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(SymiSpacing.cardPadding)
+            .symiGlass(level)
+    }
+}
+
+struct GlassSheetPanel<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(.horizontal, SymiSpacing.xxl)
+            .padding(.top, SymiSpacing.md)
+            .padding(.bottom, SymiSpacing.xxl)
+            .symiGlass(.prominent, cornerRadius: SymiRadius.glassSheetPanel)
+    }
+}
+
+private struct SymiGlassSurfaceModifier: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+
+    let level: SymiGlassLevel
+    let cornerRadius: CGFloat?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        let radius = cornerRadius ?? level.cornerRadius
+        let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
+
+        if reduceTransparency {
+            content
+                .background {
+                    shape.fill(SymiColors.cardBackground(for: colorScheme))
+                }
+                .overlay {
+                    shape.stroke(borderColor, lineWidth: SymiStroke.hairline)
+                }
+                .clipShape(shape)
+                .shadow(
+                    color: shadowColor,
+                    radius: level.shadowRadius,
+                    x: SymiShadow.cardXOffset,
+                    y: level.shadowY
+                )
+        } else if #available(iOS 26.0, *) {
+            content
+                .background {
+                    shape.fill(SymiColors.cardBackground(for: colorScheme).opacity(level.fillOpacity))
+                }
+                .glassEffect(.regular.tint(glassTint), in: .rect(cornerRadius: radius))
+                .overlay {
+                    shape.stroke(borderColor, lineWidth: SymiStroke.hairline)
+                }
+                .clipShape(shape)
+                .shadow(
+                    color: shadowColor,
+                    radius: level.shadowRadius,
+                    x: SymiShadow.cardXOffset,
+                    y: level.shadowY
+                )
+        } else {
+            content
+                .background {
+                    shape
+                        .fill(.thinMaterial)
+                        .background {
+                            shape.fill(SymiColors.cardBackground(for: colorScheme).opacity(level.fillOpacity))
+                        }
+                }
+                .overlay {
+                    shape.stroke(borderColor, lineWidth: SymiStroke.hairline)
+                }
+                .clipShape(shape)
+                .shadow(
+                    color: shadowColor,
+                    radius: level.shadowRadius,
+                    x: SymiShadow.cardXOffset,
+                    y: level.shadowY
+                )
+        }
+    }
+
+    private var borderColor: Color {
+        if reduceTransparency {
+            return SymiColors.subtleSeparator(for: colorScheme).opacity(SymiOpacity.strongSurface)
+        }
+
+        return Color.white.opacity(colorScheme == .dark ? level.borderOpacity * SymiOpacity.glassBorderDarkMultiplier : level.borderOpacity)
+    }
+
+    private var shadowColor: Color {
+        guard colorScheme != .dark else {
+            return Color.clear
+        }
+
+        return AppTheme.symiPetrol.opacity(level == .prominent ? SymiOpacity.glassProminentShadow : SymiOpacity.glassRegularShadow)
+    }
+
+    private var glassTint: Color {
+        SymiColors.cardBackground(for: colorScheme).opacity(colorScheme == .dark ? SymiOpacity.glassTintDark : SymiOpacity.glassTintLight)
+    }
+}
+
+extension View {
+    func symiGlass(_ level: SymiGlassLevel = .regular, cornerRadius: CGFloat? = nil) -> some View {
+        modifier(SymiGlassSurfaceModifier(level: level, cornerRadius: cornerRadius))
+    }
+}

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -151,11 +151,11 @@ struct EntryFlowCoordinatorTests {
         let coordinator = makeCoordinator()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 26, hour: 15, minute: 30))!
 
-        coordinator.selectStartedAtPreset(.todayMorning, calendar: calendar)
-        let morningHour = calendar.component(.hour, from: coordinator.draft.startedAt)
+        coordinator.selectDayPartPreset(.abends, referenceDate: referenceDate, calendar: calendar)
+        let selectedHour = calendar.component(.hour, from: coordinator.draft.startedAt)
 
-        #expect(EntryStartedAtPreset.todayMorning.dayPart == .morgens)
-        #expect(morningHour == 8)
+        #expect(EntryDayPartPreset.abends.dayPart == .abends)
+        #expect(selectedHour == 19)
         #expect(EntryStartedAtPreset.oneHourAgo.date(relativeTo: referenceDate, calendar: calendar) == referenceDate.addingTimeInterval(-3_600))
     }
 

--- a/SymiUITests/EntryFlowUITests.swift
+++ b/SymiUITests/EntryFlowUITests.swift
@@ -144,10 +144,16 @@ final class EntryFlowUITests: XCTestCase {
         XCTAssertVisibleText("Wie stark ist es gerade?", in: app)
         XCTAssertVisibleText("Mittel", in: app)
         XCTAssertVisibleText("Wo spürst du den Schmerz?", in: app)
-        XCTAssertVisibleText("Wann tritt es auf?", in: app)
+        XCTAssertVisibleText("Tagesbereich", in: app)
         XCTAssertTrue(app.buttons["entry-location-Schläfen"].exists)
         XCTAssertEqual(app.buttons["entry-location-Schläfen"].value as? String, "Ausgewählt")
-        XCTAssertTrue(app.buttons["entry-started-at-now"].exists)
+        let dayPartButtons = [
+            app.buttons["entry-daypart-morgens"],
+            app.buttons["entry-daypart-mittags"],
+            app.buttons["entry-daypart-abends"],
+            app.buttons["entry-daypart-nacht"],
+        ]
+        XCTAssertTrue(dayPartButtons.contains { $0.exists })
         XCTAssertTrue(app.buttons["entry-flow-next"].exists)
         XCTAssertTrue(app.buttons["entry-flow-save-headache-only"].exists)
         XCTAssertVisibleText("von 5", in: app)

--- a/SymiUITests/HomeRedesignUITests.swift
+++ b/SymiUITests/HomeRedesignUITests.swift
@@ -16,6 +16,7 @@ final class HomeRedesignUITests: XCTestCase {
 
         let calendar = app.descendants(matching: .any)["home-calendar"]
         XCTAssertTrue(calendar.waitForExistence(timeout: 6))
+        XCTAssertTrue(app.descendants(matching: .any)["home-pain-scale-card"].exists)
         XCTAssertTrue(accessibilityElement(containing: "Monatskalender", in: app).exists)
         XCTAssertTrue(accessibilityElement(containing: "heute", in: app).exists)
         XCTAssertFalse(accessibilityElement(containing: "ausgewählt", in: app).exists)
@@ -26,7 +27,7 @@ final class HomeRedesignUITests: XCTestCase {
         scrollUntilVisible(quickEntry, in: app)
         XCTAssertTrue(quickEntry.exists)
         XCTAssertMinimumTouchTarget(quickEntry)
-        XCTAssertTrue(accessibilityElement(containing: "Eintrag erstellen", in: app).exists)
+        XCTAssertTrue(accessibilityElement(containing: "Neuer Eintrag", in: app).exists)
         XCTAssertFalse(app.sliders["home-feeling-slider"].exists)
 
         let allEntries = app.descendants(matching: .any)["home-all-entries"]


### PR DESCRIPTION
## Zusammenfassung

- Fügt ein zentrales Liquid-Glass-Styling mit iOS-26-`glassEffect`, Material-Fallback und Reduce-Transparency-Unterstützung hinzu.
- Richtet Home auf den neuen Flow aus: Schmerzskala zuerst, danach `Neuer Eintrag`, Kalender und Insights.
- Ersetzt im neuen Eintrag die präzise Zeit-Preset-Auswahl durch Tagesbereich-Chips für morgens, mittags, abends und nacht.
- Entfernt die speicherbare 0/`Kein`-Skala aus dem neuen Flow und ergänzt Design-Tokens, damit SwiftLint sauber bleibt.

## Validierung

- `swiftlint`
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath build/CodexDerivedData`
- `xcodebuild build-for-testing -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath build/CodexDerivedData`

Closes #137