### PR TITLE
Fix App Store badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Symi ist ein lokal-first Migräne Tagebuch für mehr gute Tage. Die App kombiniert einen schnellen, ruhigen Eintrag mit persönlichem Tagebuch, Wetterkontext, Medikamentendokumentation und Export.
 
-[![Im App Store laden](https://tools.applemediaservices.com/api/badges/download-on-the-app-store/white/de-de)](https://apps.apple.com/app/id6761906025)
+[![Im App Store laden](https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/white/de-de)](https://apps.apple.com/app/id6761906025)
 
 [![App Store Release](https://github.com/mpwg/Symi/actions/workflows/ios-app-store.yml/badge.svg)](https://github.com/mpwg/Symi/actions/workflows/ios-app-store.yml)
 [![TestFlight Release](https://github.com/mpwg/Symi/actions/workflows/ios-testflight.yml/badge.svg)](https://github.com/mpwg/Symi/actions/workflows/ios-testflight.yml)


### PR DESCRIPTION
Updated App Store badge link to the new marketing tools URL.