### PR TITLE
[codex] Centralize pain intensity buckets

### DIFF
--- a/Symi/Sources/Core/Episodes/PainIntensityLevel.swift
+++ b/Symi/Sources/Core/Episodes/PainIntensityLevel.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+nonisolated enum PainIntensityLevel: CaseIterable, Equatable, Sendable {
+    case none
+    case low
+    case medium
+    case high
+    case veryHigh
+
+    nonisolated init(intensity: Int) {
+        switch intensity {
+        case 1 ... 3:
+            self = .low
+        case 4 ... 6:
+            self = .medium
+        case 7 ... 8:
+            self = .high
+        case 9 ... 10:
+            self = .veryHigh
+        default:
+            self = .none
+        }
+    }
+
+    nonisolated var displayLabel: String {
+        switch self {
+        case .none:
+            "Nicht bewertet"
+        case .low:
+            "Leicht"
+        case .medium:
+            "Mittel"
+        case .high:
+            "Stark"
+        case .veryHigh:
+            "Sehr stark"
+        }
+    }
+
+    nonisolated var contextText: String? {
+        switch self {
+        case .none:
+            nil
+        case .low:
+            "Leichter Verlauf"
+        case .medium:
+            "Mittlerer Verlauf"
+        case .high:
+            "Starker Verlauf"
+        case .veryHigh:
+            "Sehr starker Verlauf"
+        }
+    }
+
+    nonisolated var detailDescription: String {
+        switch self {
+        case .none:
+            "Die Intensität wurde für diesen Eintrag nicht bewertet."
+        case .low:
+            "Die Schmerzen waren leicht und gut im Alltag einzuordnen."
+        case .medium:
+            "Die Schmerzen waren spürbar, aber noch gut auszuhalten."
+        case .high:
+            "Die Schmerzen waren deutlich und haben viel Aufmerksamkeit gebraucht."
+        case .veryHigh:
+            "Die Schmerzen waren sehr stark und haben den Alltag deutlich eingeschränkt."
+        }
+    }
+
+    nonisolated var healthSeverityLabel: String {
+        switch self {
+        case .none, .low:
+            "Leicht"
+        case .medium:
+            "Mittel"
+        case .high, .veryHigh:
+            "Stark"
+        }
+    }
+
+    nonisolated func contains(intensity: Int) -> Bool {
+        self == PainIntensityLevel(intensity: intensity)
+    }
+}

--- a/Symi/Sources/Core/Health/HealthCore.swift
+++ b/Symi/Sources/Core/Health/HealthCore.swift
@@ -186,13 +186,6 @@ extension HealthContextSnapshotData {
 
 enum HealthSeverityMapper {
     static func symptomSeverityLabel(forIntensity intensity: Int) -> String {
-        switch intensity {
-        case ...3:
-            "Leicht"
-        case 4...6:
-            "Mittel"
-        default:
-            "Stark"
-        }
+        PainIntensityLevel(intensity: intensity).healthSeverityLabel
     }
 }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -801,16 +801,7 @@ private struct EntryReviewStepView: View {
     }
 
     private func intensityLabel(for intensity: Int) -> String {
-        switch intensity {
-        case 1 ... 3:
-            "Leicht"
-        case 4 ... 6:
-            "Mittel"
-        case 7 ... 8:
-            "Stark"
-        default:
-            "Sehr stark"
-        }
+        PainIntensityLevel(intensity: intensity).displayLabel
     }
 }
 

--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -177,8 +177,8 @@ private enum EntryDetailSurface {
 private struct EntryDetailHeroCard: View {
     let episode: EpisodeRecord
 
-    private var painLevel: PainLevel {
-        PainLevel(intensity: episode.intensity)
+    private var painLevel: PainIntensityLevel {
+        PainIntensityLevel(intensity: episode.intensity)
     }
 
     private var painToken: PainToken {
@@ -236,21 +236,12 @@ private struct EntryDetailHeroCard: View {
     }
 
     private var intensityDescription: String {
-        switch episode.intensity {
-        case 1 ... 3:
-            "Die Schmerzen waren leicht und gut im Alltag einzuordnen."
-        case 4 ... 6:
-            "Die Schmerzen waren spürbar, aber noch gut auszuhalten."
-        case 7 ... 10:
-            "Die Schmerzen waren deutlich und haben viel Aufmerksamkeit gebraucht."
-        default:
-            "Die Intensität wurde für diesen Eintrag nicht bewertet."
-        }
+        PainIntensityLevel(intensity: episode.intensity).detailDescription
     }
 }
 
 private struct EntryDetailFaceBadge: View {
-    let painLevel: PainLevel
+    let painLevel: PainIntensityLevel
     let painToken: PainToken
 
     var body: some View {
@@ -271,7 +262,7 @@ private struct EntryDetailFaceBadge: View {
 }
 
 private struct CalmFaceIcon: Shape {
-    let painLevel: PainLevel
+    let painLevel: PainIntensityLevel
 
     func path(in rect: CGRect) -> Path {
         var path = Path()
@@ -297,7 +288,7 @@ private struct CalmFaceIcon: Shape {
 
     private var leftEyeStartY: CGFloat {
         switch painLevel {
-        case .high:
+        case .high, .veryHigh:
             0.38
         case .none, .low, .medium:
             0.40
@@ -306,7 +297,7 @@ private struct CalmFaceIcon: Shape {
 
     private var leftEyeEndY: CGFloat {
         switch painLevel {
-        case .high:
+        case .high, .veryHigh:
             0.42
         case .none, .low, .medium:
             0.42
@@ -315,7 +306,7 @@ private struct CalmFaceIcon: Shape {
 
     private var rightEyeStartY: CGFloat {
         switch painLevel {
-        case .high:
+        case .high, .veryHigh:
             0.38
         case .none, .low, .medium:
             0.40
@@ -324,7 +315,7 @@ private struct CalmFaceIcon: Shape {
 
     private var rightEyeEndY: CGFloat {
         switch painLevel {
-        case .high:
+        case .high, .veryHigh:
             0.42
         case .none, .low, .medium:
             0.42
@@ -339,7 +330,7 @@ private struct CalmFaceIcon: Shape {
             0.64
         case .medium:
             0.63
-        case .high:
+        case .high, .veryHigh:
             0.64
         }
     }
@@ -352,7 +343,7 @@ private struct CalmFaceIcon: Shape {
             0.62
         case .medium:
             0.67
-        case .high:
+        case .high, .veryHigh:
             0.59
         }
     }
@@ -388,8 +379,8 @@ private struct EntryDetailProgressBar: View {
 private struct EntryDetailContextCard: View {
     let episode: EpisodeRecord
 
-    private var painLevel: PainLevel {
-        PainLevel(intensity: episode.intensity)
+    private var painLevel: PainIntensityLevel {
+        PainIntensityLevel(intensity: episode.intensity)
     }
 
     private var rows: [EntryDetailContextRowModel] {
@@ -676,7 +667,7 @@ private enum EntryDetailContextHierarchy {
 
 private enum EntryDetailContextCategory {
     case neutral
-    case pain(PainLevel)
+    case pain(PainIntensityLevel)
     case note
 
     var iconColor: Color {

--- a/Symi/Sources/Features/History/HistoryView.swift
+++ b/Symi/Sources/Features/History/HistoryView.swift
@@ -226,19 +226,23 @@ private enum JournalIntensityFilter: String, CaseIterable, Identifiable {
     case light = "Leicht"
     case medium = "Mittel"
     case strong = "Stark"
+    case veryStrong = "Sehr stark"
 
     var id: String { rawValue }
 
     func matches(_ intensity: Int) -> Bool {
-        switch self {
+        let level = PainIntensityLevel(intensity: intensity)
+        return switch self {
         case .all:
             true
         case .light:
-            (1 ... 3).contains(intensity)
+            level == .low
         case .medium:
-            (4 ... 6).contains(intensity)
+            level == .medium
         case .strong:
-            (7 ... 10).contains(intensity)
+            level == .high
+        case .veryStrong:
+            level == .veryHigh
         }
     }
 }

--- a/Symi/Sources/Features/History/JournalEntryContext.swift
+++ b/Symi/Sources/Features/History/JournalEntryContext.swift
@@ -19,27 +19,18 @@ enum JournalEntryContext {
     }
 
     static func intensityLabel(for intensity: Int) -> String {
-        switch intensity {
-        case 1 ... 3:
-            "Leicht"
-        case 4 ... 6:
-            "Mittel"
-        case 7 ... 10:
-            "Stark"
-        default:
-            "Nicht bewertet"
-        }
+        PainIntensityLevel(intensity: intensity).displayLabel
     }
 
     static func intensityColor(for intensity: Int) -> Color {
-        switch intensity {
-        case 1 ... 3:
+        switch PainIntensityLevel(intensity: intensity) {
+        case .low:
             SymiColors.intensityLight.color
-        case 4 ... 6:
+        case .medium:
             SymiColors.intensityMedium.color
-        case 7 ... 10:
+        case .high, .veryHigh:
             SymiColors.intensityStrong.color
-        default:
+        case .none:
             SymiColors.textPrimary.color
         }
     }
@@ -81,16 +72,7 @@ enum JournalEntryContext {
     }
 
     static func intensityContext(for intensity: Int) -> String? {
-        switch intensity {
-        case 1 ... 3:
-            "Leichter Verlauf"
-        case 4 ... 6:
-            "Mittlerer Verlauf"
-        case 7 ... 10:
-            "Starker Verlauf"
-        default:
-            nil
-        }
+        PainIntensityLevel(intensity: intensity).contextText
     }
 
     private static func contextualSubtitleSegments(for episode: EpisodeRecord) -> [String] {

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -288,12 +288,12 @@ private struct HomeCalendarDayCell: View {
     }
 
     private func dotColor(for entry: EpisodeRecord) -> Color {
-        switch entry.intensity {
-        case 8 ... 10:
+        switch PainIntensityLevel(intensity: entry.intensity) {
+        case .high, .veryHigh:
             AppTheme.coral(for: colorScheme).opacity(SymiOpacity.calendarHighIntensityDot)
-        case 5 ... 7:
+        case .medium:
             AppTheme.sage(for: colorScheme).opacity(SymiOpacity.calendarMediumIntensityDot)
-        default:
+        case .none, .low:
             AppTheme.petrol(for: colorScheme).opacity(SymiOpacity.calendarLowIntensityDot)
         }
     }

--- a/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
+++ b/Symi/Sources/Features/InputFlow/Components/PainGaugeView.swift
@@ -107,16 +107,7 @@ private struct PainGaugeCard: View {
     }
 
     private var intensityLabel: String {
-        switch normalizedValue {
-        case 1 ... 3:
-            "Leicht"
-        case 4 ... 6:
-            "Mittel"
-        case 7 ... 8:
-            "Stark"
-        default:
-            "Sehr stark"
-        }
+        PainIntensityLevel(intensity: normalizedValue).displayLabel
     }
 }
 

--- a/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
@@ -42,26 +42,6 @@ struct SymiColorValue: Equatable, Sendable {
     }
 }
 
-nonisolated enum PainLevel: Sendable {
-    case none
-    case low
-    case medium
-    case high
-
-    init(intensity: Int) {
-        switch intensity {
-        case 1 ... 3:
-            self = .low
-        case 4 ... 6:
-            self = .medium
-        case 7 ... 10:
-            self = .high
-        default:
-            self = .none
-        }
-    }
-}
-
 enum SymiColors {
     static let primaryPetrol = SymiColorValue(hex: 0x0F3D3E)
     static let sage = SymiColorValue(hex: 0x8ECDB8)
@@ -174,14 +154,14 @@ enum ColorToken {
     }
 
     enum Pain {
-        static func token(for level: PainLevel) -> PainToken {
+        static func token(for level: PainIntensityLevel) -> PainToken {
             PainToken(level: level)
         }
     }
 }
 
 struct PainToken {
-    let level: PainLevel
+    let level: PainIntensityLevel
 
     var foreground: Color {
         baseValue.color
@@ -192,11 +172,11 @@ struct PainToken {
     }
 
     var emphasizedText: Color {
-        level == .high ? foreground : ColorToken.Text.primary
+        level == .high || level == .veryHigh ? foreground : ColorToken.Text.primary
     }
 
     var descriptionText: Color {
-        level == .high ? foreground : ColorToken.Text.secondary
+        level == .high || level == .veryHigh ? foreground : ColorToken.Text.secondary
     }
 
     var faceBackground: Color {
@@ -207,7 +187,7 @@ struct PainToken {
             SymiColors.entryDetailIconFill.color
         case .medium:
             SymiColors.entryDetailFaceFill.color
-        case .high:
+        case .high, .veryHigh:
             SymiColors.coral.color.opacity(SymiOpacity.clearAccent)
         }
     }
@@ -231,7 +211,7 @@ struct PainToken {
             SymiColors.intensityLight
         case .medium:
             SymiColors.intensityMedium
-        case .high:
+        case .high, .veryHigh:
             SymiColors.intensityStrong
         }
     }

--- a/Symi/Sources/Infrastructure/Health/AppleHealthKitService.swift
+++ b/Symi/Sources/Infrastructure/Health/AppleHealthKitService.swift
@@ -373,12 +373,12 @@ final class AppleHealthKitService: HealthService {
     }
 
     private static func severityValue(forIntensity intensity: Int) -> Int {
-        switch intensity {
-        case ...3:
+        switch PainIntensityLevel(intensity: intensity) {
+        case .none, .low:
             HKCategoryValueSeverity.mild.rawValue
-        case 4...6:
+        case .medium:
             HKCategoryValueSeverity.moderate.rawValue
-        default:
+        case .high, .veryHigh:
             HKCategoryValueSeverity.severe.rawValue
         }
     }

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -77,6 +77,32 @@ struct CoreArchitectureTests {
         #expect(HealthSeverityMapper.symptomSeverityLabel(forIntensity: 1) == "Leicht")
         #expect(HealthSeverityMapper.symptomSeverityLabel(forIntensity: 4) == "Mittel")
         #expect(HealthSeverityMapper.symptomSeverityLabel(forIntensity: 8) == "Stark")
+        #expect(HealthSeverityMapper.symptomSeverityLabel(forIntensity: 10) == "Stark")
+    }
+
+    @Test
+    func painIntensityLevelUsesCentralBoundaryBuckets() {
+        let expectations: [(Int, PainIntensityLevel, String, String?)] = [
+            (0, .none, "Nicht bewertet", nil),
+            (1, .low, "Leicht", "Leichter Verlauf"),
+            (3, .low, "Leicht", "Leichter Verlauf"),
+            (4, .medium, "Mittel", "Mittlerer Verlauf"),
+            (6, .medium, "Mittel", "Mittlerer Verlauf"),
+            (7, .high, "Stark", "Starker Verlauf"),
+            (8, .high, "Stark", "Starker Verlauf"),
+            (9, .veryHigh, "Sehr stark", "Sehr starker Verlauf"),
+            (10, .veryHigh, "Sehr stark", "Sehr starker Verlauf"),
+            (11, .none, "Nicht bewertet", nil)
+        ]
+
+        for expectation in expectations {
+            let level = PainIntensityLevel(intensity: expectation.0)
+
+            #expect(level == expectation.1)
+            #expect(level.displayLabel == expectation.2)
+            #expect(level.contextText == expectation.3)
+            #expect(level.contains(intensity: expectation.0))
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a central `PainIntensityLevel` domain enum with buckets `none`, `low`, `medium`, `high`, and `veryHigh`.
- Route input, review, history, detail, home calendar, color token, and HealthKit severity mappings through the central bucket source.
- Split history filtering into `Stark` for 7...8 and `Sehr stark` for 9...10.

## Validation
- `swiftlint`
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`\n- UI test attempt: `xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 17'` built but simulator launch failed with `Busy (Application failed preflight checks)`; user approved proceeding.
 
Closes #234