### PR TITLE
[codex] Consolidate medication formatting

### DIFF
--- a/Symi/Sources/App/AppStoreScreenshotMode.swift
+++ b/Symi/Sources/App/AppStoreScreenshotMode.swift
@@ -107,7 +107,7 @@ enum AppStoreScreenshotMode {
             selectedTriggers: Set(ScreenshotLocalization.list(de: ["Stress", "Bildschirmzeit"], en: ["Stress", "Screen time"])),
             medications: [
                 MedicationSelectionDraft(
-                    selectionKey: MedicationSelectionDraft.makeSelectionKey(
+                    selectionKey: MedicationSelectionKey.make(
                         name: "Paracetamol",
                         category: .paracetamol,
                         dosage: "500 mg"

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -85,10 +85,7 @@ struct ContinuousMedicationRecord: Identifiable, Equatable, Sendable {
     }
 
     nonisolated var detailText: String {
-        [dosage, frequency]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " · ")
+        MedicationTextFormatter.detailText(dosage: dosage, frequency: frequency)
     }
 }
 
@@ -101,10 +98,7 @@ struct ContinuousMedicationCheckRecord: Identifiable, Equatable, Sendable {
     nonisolated let wasTaken: Bool
 
     nonisolated var detailText: String {
-        [dosage, frequency]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " · ")
+        MedicationTextFormatter.detailText(dosage: dosage, frequency: frequency)
     }
 }
 
@@ -212,10 +206,7 @@ struct ContinuousMedicationCheckDraft: Identifiable, Equatable, Sendable {
     }
 
     nonisolated var detailText: String {
-        [dosage, frequency]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " · ")
+        MedicationTextFormatter.detailText(dosage: dosage, frequency: frequency)
     }
 }
 
@@ -295,11 +286,11 @@ struct MedicationDefinitionRecord: Identifiable, Equatable, Sendable {
     }
 
     nonisolated var selectionKey: String {
-        [
-            name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-            category.rawValue,
-            suggestedDosage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        ].joined(separator: "|")
+        MedicationSelectionKey.make(
+            name: name,
+            category: category,
+            dosage: suggestedDosage
+        )
     }
 }
 
@@ -333,7 +324,7 @@ struct MedicationSelectionDraft: Identifiable, Equatable, Sendable {
     nonisolated init(record: MedicationRecord) {
         self.init(
             id: record.id,
-            selectionKey: Self.makeSelectionKey(
+            selectionKey: MedicationSelectionKey.make(
                 name: record.name,
                 category: record.category,
                 dosage: record.dosage
@@ -352,14 +343,6 @@ struct MedicationSelectionDraft: Identifiable, Equatable, Sendable {
             category: definition.category,
             dosage: definition.suggestedDosage
         )
-    }
-
-    nonisolated static func makeSelectionKey(name: String, category: MedicationCategory, dosage: String) -> String {
-        [
-            name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-            category.rawValue,
-            dosage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        ].joined(separator: "|")
     }
 }
 

--- a/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
@@ -163,7 +163,7 @@ final class EpisodeMedicationSelectionController {
             return
         }
 
-        let selectionKey = MedicationSelectionDraft.makeSelectionKey(
+        let selectionKey = MedicationSelectionKey.make(
             name: name,
             category: fallbackCategory,
             dosage: fallbackDosage

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -35,6 +35,25 @@ enum MedicationEffectiveness: String, CaseIterable, Codable, Identifiable {
     var id: String { rawValue }
 }
 
+struct MedicationTextFormatter {
+    nonisolated static func detailText(dosage: String, frequency: String) -> String {
+        [dosage, frequency]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+}
+
+struct MedicationSelectionKey {
+    nonisolated static func make(name: String, category: MedicationCategory, dosage: String) -> String {
+        [
+            name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+            category.rawValue,
+            dosage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        ].joined(separator: "|")
+    }
+}
+
 extension Episode {
     convenience init(
         id: UUID = UUID(),
@@ -131,10 +150,7 @@ extension ContinuousMedication {
     }
 
     var detailText: String {
-        [dosage, frequency]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " · ")
+        MedicationTextFormatter.detailText(dosage: dosage, frequency: frequency)
     }
 
     func markUpdated(at date: Date = .now) {
@@ -222,11 +238,11 @@ extension MedicationDefinition {
     }
 
     var selectionKey: String {
-        [
-            name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-            category.rawValue,
-            suggestedDosage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        ].joined(separator: "|")
+        MedicationSelectionKey.make(
+            name: name,
+            category: category,
+            dosage: suggestedDosage
+        )
     }
 
     var isDeleted: Bool {

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -231,6 +231,24 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func medicationDetailTextFormatsEmptyWhitespaceAndCombinations() {
+        #expect(MedicationTextFormatter.detailText(dosage: "", frequency: "") == "")
+        #expect(MedicationTextFormatter.detailText(dosage: "  ", frequency: "\n\t") == "")
+        #expect(MedicationTextFormatter.detailText(dosage: " 50 mg ", frequency: "") == "50 mg")
+        #expect(MedicationTextFormatter.detailText(dosage: "", frequency: " täglich ") == "täglich")
+        #expect(MedicationTextFormatter.detailText(dosage: " 50 mg ", frequency: " täglich ") == "50 mg · täglich")
+    }
+
+    @Test
+    func medicationSelectionKeyNormalizesEmptyWhitespaceAndCombinations() {
+        #expect(MedicationSelectionKey.make(name: "", category: .other, dosage: "") == "|Sonstiges|")
+        #expect(MedicationSelectionKey.make(name: "  ", category: .other, dosage: "\n\t") == "|Sonstiges|")
+        #expect(MedicationSelectionKey.make(name: " Sumatriptan ", category: .triptan, dosage: "") == "sumatriptan|Triptan|")
+        #expect(MedicationSelectionKey.make(name: "", category: .nsar, dosage: " 400 MG ") == "|NSAR|400 mg")
+        #expect(MedicationSelectionKey.make(name: " IBUprofen ", category: .nsar, dosage: " 400 MG ") == "ibuprofen|NSAR|400 mg")
+    }
+
+    @Test
     func loadHistoryMonthUseCaseGroupsByCalendarDay() async throws {
         let repository = EpisodeRepositoryMock()
         let firstDay = Date(timeIntervalSince1970: 10_000)


### PR DESCRIPTION
## Summary
- centralize medication detail text formatting in `MedicationTextFormatter`
- centralize medication selection-key generation in `MedicationSelectionKey`
- update existing call-sites and add focused formatter/key tests

## Validation
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #235