### PR TITLE
[codex] Centralize String trimmed helper

### DIFF
--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -687,9 +687,3 @@ private extension EpisodeRecord {
         triggers.contains { !$0.trimmed.isEmpty }
     }
 }
-
-private extension String {
-    var trimmed: String {
-        trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-}

--- a/Symi/Sources/Features/History/HistoryView.swift
+++ b/Symi/Sources/Features/History/HistoryView.swift
@@ -746,12 +746,6 @@ private extension View {
     }
 }
 
-private extension String {
-    var trimmed: String {
-        trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-}
-
 extension Calendar {
     nonisolated func startOfMonth(for inputDate: Date) -> Date {
         self.date(from: dateComponents([.year, .month], from: inputDate)) ?? inputDate

--- a/Symi/Sources/Features/History/JournalEntryContext.swift
+++ b/Symi/Sources/Features/History/JournalEntryContext.swift
@@ -110,9 +110,3 @@ enum JournalEntryContext {
             .filter { !$0.isEmpty }
     }
 }
-
-private extension String {
-    var trimmed: String {
-        trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-}

--- a/Symi/Sources/Shared/String+Trimmed.swift
+++ b/Symi/Sources/Shared/String+Trimmed.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Änderungen
- Zentrale `String.trimmed`-Extension in `Sources/Shared` ergänzt.
- Lokale Duplikate aus den History-Feature-Dateien entfernt.

## Validierung
- `rg "var trimmed|extension String" -n Symi/Sources`
- `xcodebuild -project Symi.xcodeproj -scheme Symi -destination 'generic/platform=iOS Simulator' build`

Closes #236
