### PR TITLE
[codex] Multi-Select Toggle-Logik und Grid-Komponenten konsolidieren

### DIFF
--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -162,7 +162,7 @@ private struct EntryHeadacheStepView: View {
             PainGaugeView(value: $coordinator.draft.intensity)
 
             InputFlowFieldGroup(title: "Wo spürst du den Schmerz?") {
-                HeadacheLocationGrid {
+                HeadacheOptionGrid {
                     ForEach(visiblePainLocations) { location in
                         PainLocationSelectionTile(
                             option: location,
@@ -170,14 +170,14 @@ private struct EntryHeadacheStepView: View {
                             theme: .pain,
                             accessibilityIdentifier: "entry-location-\(location.title)"
                         ) {
-                            toggle(location.title, in: &coordinator.draft.selectedPainLocations)
+                            coordinator.draft.selectedPainLocations.toggleMembership(location.title)
                         }
                     }
                 }
             }
 
             InputFlowFieldGroup(title: "Tagesbereich") {
-                HeadacheDayPartGrid {
+                HeadacheOptionGrid {
                     ForEach(EntryDayPartPreset.allCases) { preset in
                         InputFlowSelectionTile(
                             title: preset.title,
@@ -224,14 +224,6 @@ private struct EntryHeadacheStepView: View {
         }
 
         coordinator.draft.selectedPainLocations = ["Schläfen"]
-    }
-
-    private func toggle(_ option: String, in selection: inout Set<String>) {
-        if selection.contains(option) {
-            selection.remove(option)
-        } else {
-            selection.insert(option)
-        }
     }
 }
 
@@ -324,7 +316,7 @@ private struct PainLocationSelectionTile: View {
         return SymiColors.subtleSeparator(for: colorScheme).opacity(SymiOpacity.strongSurface)
     }
 }
-private struct HeadacheLocationGrid<Content: View>: View {
+private struct HeadacheOptionGrid<Content: View>: View {
     let content: Content
 
     init(@ViewBuilder content: () -> Content) {
@@ -332,42 +324,9 @@ private struct HeadacheLocationGrid<Content: View>: View {
     }
 
     var body: some View {
-        LazyVGrid(
-            columns: Array(
-                repeating: GridItem(
-                    .flexible(minimum: SymiSize.headacheOptionGridMinWidth),
-                    spacing: SymiSpacing.xs,
-                    alignment: .top
-                ),
-                count: SymiSize.headacheOptionGridColumnCount
-            ),
-            alignment: .leading,
-            spacing: SymiSpacing.xs
-        ) {
-            content
-        }
-    }
-}
-
-private struct HeadacheDayPartGrid<Content: View>: View {
-    let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
-    var body: some View {
-        LazyVGrid(
-            columns: Array(
-                repeating: GridItem(
-                    .flexible(minimum: SymiSize.headacheOptionGridMinWidth),
-                    spacing: SymiSpacing.xs,
-                    alignment: .top
-                ),
-                count: SymiSize.headacheOptionGridColumnCount
-            ),
-            alignment: .leading,
-            spacing: SymiSpacing.xs
+        InputFlowFixedTileGrid(
+            minimumColumnWidth: SymiSize.headacheOptionGridMinWidth,
+            columnCount: SymiSize.headacheOptionGridColumnCount
         ) {
             content
         }
@@ -569,7 +528,7 @@ private struct EntryTriggersStepView: View {
                             theme: .trigger,
                             accessibilityIdentifier: "entry-trigger-\(option.title)"
                         ) {
-                            toggle(option.title, in: &coordinator.draft.selectedTriggers)
+                            coordinator.draft.selectedTriggers.toggleMembership(option.title)
                         }
                     }
                 }
@@ -587,14 +546,6 @@ private struct EntryTriggersStepView: View {
                 onPrimary: coordinator.continueToNextStep,
                 onSecondary: coordinator.skipCurrentStep
             )
-        }
-    }
-
-    private func toggle(_ option: String, in selection: inout Set<String>) {
-        if selection.contains(option) {
-            selection.remove(option)
-        } else {
-            selection.insert(option)
         }
     }
 }

--- a/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
+++ b/Symi/Sources/Features/Capture/NewEntryDesignSystem.swift
@@ -126,20 +126,12 @@ struct MultiSelectGrid: View {
                     isSelected: isSelected,
                     colorToken: colorToken
                 ) {
-                    toggle(option)
+                    selection.toggleMembership(option)
                 }
                 .accessibilityLabel("\(accessibilityPrefix): \(option)")
                 .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
                 .accessibilityHint(isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus.")
             }
-        }
-    }
-
-    private func toggle(_ option: String) {
-        if selection.contains(option) {
-            selection.remove(option)
-        } else {
-            selection.insert(option)
         }
     }
 }

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
@@ -42,6 +42,42 @@ struct InputFlowTileGrid<Content: View>: View {
     }
 }
 
+struct InputFlowFixedTileGrid<Content: View>: View {
+    let minimumColumnWidth: CGFloat
+    let columnCount: Int
+    let spacing: CGFloat
+    let content: Content
+
+    init(
+        minimumColumnWidth: CGFloat,
+        columnCount: Int,
+        spacing: CGFloat = SymiSpacing.xs,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.minimumColumnWidth = minimumColumnWidth
+        self.columnCount = columnCount
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: Array(
+                repeating: GridItem(
+                    .flexible(minimum: minimumColumnWidth),
+                    spacing: spacing,
+                    alignment: .top
+                ),
+                count: columnCount
+            ),
+            alignment: .leading,
+            spacing: spacing
+        ) {
+            content
+        }
+    }
+}
+
 struct InputFlowPillGrid<Content: View>: View {
     let minimumColumnWidth: CGFloat
     let content: Content

--- a/Symi/Sources/Shared/SetToggleMembership.swift
+++ b/Symi/Sources/Shared/SetToggleMembership.swift
@@ -1,0 +1,9 @@
+extension Set {
+    mutating func toggleMembership(_ member: Element) {
+        if contains(member) {
+            remove(member)
+        } else {
+            insert(member)
+        }
+    }
+}

--- a/SymiTests/NewEntryDesignSystemTests.swift
+++ b/SymiTests/NewEntryDesignSystemTests.swift
@@ -96,4 +96,15 @@ struct NewEntryDesignSystemTests {
             #expect(token.lightColorValue.hexString == expected[token, default: ""])
         }
     }
+
+    @Test
+    func setToggleMembershipAddsAndRemovesMembers() {
+        var selection: Set<String> = ["Stress"]
+
+        selection.toggleMembership("Wetter")
+        #expect(selection == ["Stress", "Wetter"])
+
+        selection.toggleMembership("Stress")
+        #expect(selection == ["Wetter"])
+    }
 }


### PR DESCRIPTION
## Änderung

- Fügt `Set.toggleMembership(_:)` als gemeinsamen Helper für Multi-Select-Auswahlen hinzu.
- Konsolidiert die identischen Headache-Grid-Komponenten über `InputFlowFixedTileGrid`.
- Nutzt den Helper in Schmerzort-, Trigger- und `MultiSelectGrid`-Auswahlen.

## Validierung
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #237
