### PR TITLE
Tageszeit-Logik vereinheitlichen

### DIFF
--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -254,6 +254,19 @@ enum EpisodeDayPart: String, CaseIterable, Codable, Identifiable, Sendable {
             "Nacht"
         }
     }
+
+    nonisolated var contextualLabel: String {
+        switch self {
+        case .morgens:
+            "Am Morgen"
+        case .mittags:
+            "Am Nachmittag"
+        case .abends:
+            "Am Abend"
+        case .nacht:
+            "In der Nacht"
+        }
+    }
 }
 
 struct MedicationDefinitionRecord: Identifiable, Equatable, Sendable {

--- a/Symi/Sources/Features/History/JournalEntryContext.swift
+++ b/Symi/Sources/Features/History/JournalEntryContext.swift
@@ -36,18 +36,7 @@ enum JournalEntryContext {
     }
 
     static func timeOfDay(for date: Date, calendar: Calendar = .current) -> String {
-        let hour = calendar.component(.hour, from: date)
-
-        return switch hour {
-        case 5 ..< 11:
-            "Am Morgen"
-        case 11 ..< 17:
-            "Am Nachmittag"
-        case 17 ..< 22:
-            "Am Abend"
-        default:
-            "In der Nacht"
-        }
+        EpisodeDayPart(date: date, calendar: calendar).contextualLabel
     }
 
     static func medicationSummary(for episode: EpisodeRecord) -> String? {

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -106,6 +106,31 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func episodeDayPartProvidesCentralClassificationAndDisplayText() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let expectations: [(Int, EpisodeDayPart, String)] = [
+            (4, .nacht, "In der Nacht"),
+            (5, .morgens, "Am Morgen"),
+            (10, .morgens, "Am Morgen"),
+            (11, .mittags, "Am Nachmittag"),
+            (16, .mittags, "Am Nachmittag"),
+            (17, .abends, "Am Abend"),
+            (21, .abends, "Am Abend"),
+            (22, .nacht, "In der Nacht")
+        ]
+
+        for expectation in expectations {
+            let date = calendar.date(from: DateComponents(year: 2026, month: 4, day: 28, hour: expectation.0))!
+            let dayPart = EpisodeDayPart(date: date, calendar: calendar)
+
+            #expect(dayPart == expectation.1)
+            #expect(dayPart.contextualLabel == expectation.2)
+            #expect(JournalEntryContext.timeOfDay(for: date, calendar: calendar) == expectation.2)
+        }
+    }
+
+    @Test
     func healthTypePreferencesSeparateSelectionFromAuthorizationRequest() {
         let suiteName = "HealthTypePreferencesTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Änderungen
- zentralen Kontext-Anzeigetext an `EpisodeDayPart` ergänzt
- `JournalEntryContext.timeOfDay` auf `EpisodeDayPart` umgestellt
- Grenzzeiten und Anzeige über einen Core-Test abgesichert

## Tests
- `xcodebuild test -scheme SymiTests -project Symi.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #238