### PR TITLE
[codex] Move pain classification into domain layer

### DIFF
--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -177,12 +177,8 @@ private enum EntryDetailSurface {
 private struct EntryDetailHeroCard: View {
     let episode: EpisodeRecord
 
-    private var painLevel: PainIntensityLevel {
-        PainIntensityLevel(intensity: episode.intensity)
-    }
-
     private var painToken: PainToken {
-        ColorToken.Pain.token(for: painLevel)
+        ColorToken.Pain.token(forIntensity: episode.intensity)
     }
 
     var body: some View {
@@ -208,7 +204,7 @@ private struct EntryDetailHeroCard: View {
 
                 Spacer(minLength: SymiSpacing.md)
 
-                EntryDetailFaceBadge(painLevel: painLevel, painToken: painToken)
+                EntryDetailFaceBadge(painLevel: painToken.level, painToken: painToken)
             }
 
             EntryDetailProgressBar(value: Double(episode.intensity) / 10, painToken: painToken)

--- a/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiColors.swift
@@ -154,6 +154,10 @@ enum ColorToken {
     }
 
     enum Pain {
+        static func token(forIntensity intensity: Int) -> PainToken {
+            PainToken(level: PainIntensityLevel(intensity: intensity))
+        }
+
         static func token(for level: PainIntensityLevel) -> PainToken {
             PainToken(level: level)
         }

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -106,6 +106,15 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func painTokenMapsRawIntensityThroughDomainLevel() {
+        for intensity in 0 ... 11 {
+            let token = ColorToken.Pain.token(forIntensity: intensity)
+
+            #expect(token.level == PainIntensityLevel(intensity: intensity))
+        }
+    }
+
+    @Test
     func healthTypePreferencesSeparateSelectionFromAuthorizationRequest() {
         let suiteName = "HealthTypePreferencesTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
## Änderung

- führt einen `ColorToken.Pain.token(forIntensity:)` Einstieg ein, der Rohwerte über `PainIntensityLevel` im Core/Domain-Layer klassifiziert
- lässt die Detailansicht Pain-Styling über diesen Styling-Token beziehen, statt dort selbst aus `Int` zu klassifizieren
- ergänzt einen Architekturtest, der die Delegation vom Styling-Token zur Domain-Klassifikation absichert

## Validierung

- `swiftlint lint --config .swiftlint.yml`
- `xcodebuild test -project Symi.xcodeproj -scheme Symi -destination 'platform=iOS Simulator,id=E2A46197-7D15-4D8F-807C-25798416BDB6'`

Closes #240
