### PR TITLE
[codex] Headache option grid zusammenführen

### DIFF
--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -162,7 +162,7 @@ private struct EntryHeadacheStepView: View {
             PainGaugeView(value: $coordinator.draft.intensity)
 
             InputFlowFieldGroup(title: "Wo spürst du den Schmerz?") {
-                HeadacheOptionGrid {
+                InputFlowHeadacheOptionGrid {
                     ForEach(visiblePainLocations) { location in
                         PainLocationSelectionTile(
                             option: location,
@@ -177,7 +177,7 @@ private struct EntryHeadacheStepView: View {
             }
 
             InputFlowFieldGroup(title: "Tagesbereich") {
-                HeadacheOptionGrid {
+                InputFlowHeadacheOptionGrid {
                     ForEach(EntryDayPartPreset.allCases) { preset in
                         InputFlowSelectionTile(
                             title: preset.title,
@@ -314,22 +314,6 @@ private struct PainLocationSelectionTile: View {
         }
 
         return SymiColors.subtleSeparator(for: colorScheme).opacity(SymiOpacity.strongSurface)
-    }
-}
-private struct HeadacheOptionGrid<Content: View>: View {
-    let content: Content
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
-    var body: some View {
-        InputFlowFixedTileGrid(
-            minimumColumnWidth: SymiSize.headacheOptionGridMinWidth,
-            columnCount: SymiSize.headacheOptionGridColumnCount
-        ) {
-            content
-        }
     }
 }
 

--- a/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
+++ b/Symi/Sources/Features/InputFlow/Components/InputFlowLayout.swift
@@ -78,6 +78,23 @@ struct InputFlowFixedTileGrid<Content: View>: View {
     }
 }
 
+struct InputFlowHeadacheOptionGrid<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    var body: some View {
+        InputFlowFixedTileGrid(
+            minimumColumnWidth: SymiSize.headacheOptionGridMinWidth,
+            columnCount: SymiSize.headacheOptionGridColumnCount
+        ) {
+            content
+        }
+    }
+}
+
 struct InputFlowPillGrid<Content: View>: View {
     let minimumColumnWidth: CGFloat
     let content: Content


### PR DESCRIPTION
## Änderungen
- Gemeinsame `InputFlowHeadacheOptionGrid` in die InputFlow-Komponenten verschoben.
- Location- und Tagesbereich-Auswahl verwenden dieselbe zentrale Grid-Komponente.
- Capture-spezifische `HeadacheOptionGrid`-Hülle entfernt.

## Validierung
- `xcodebuild test -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #241
