### PR TITLE
[codex] Sync coverage for health context and continuous meds

### DIFF
--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -98,13 +98,19 @@ enum ScreenshotBootstrap {
 
         let seed = try ScreenshotSeedFactory.populate(seedName: seedName, in: container)
         let appLogStore = AppLogStore()
-        let syncCoordinator = SyncCoordinator(modelContainer: container, appLogStore: appLogStore)
+        let healthContextStore = HealthContextStore()
+        let syncCoordinator = SyncCoordinator(
+            modelContainer: container,
+            appLogStore: appLogStore,
+            healthContextStore: healthContextStore
+        )
         let appContainer = AppContainer(
             modelContainer: container,
             syncCoordinator: syncCoordinator,
             appLogStore: appLogStore,
             weatherService: ScreenshotWeatherService(),
-            locationService: ScreenshotLocationService()
+            locationService: ScreenshotLocationService(),
+            healthContextStore: healthContextStore
         )
 
         return (container, appContainer, appLogStore, syncCoordinator, seed)

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -77,15 +77,18 @@ struct SymiApp: App {
 
         let container = try makeContainer(schema: schema, configuration: configuration)
         let appLogStore = AppLogStore()
+        let healthContextStore = HealthContextStore()
         let syncCoordinator = SyncCoordinator(
             modelContainer: container,
             appLogStore: appLogStore,
+            healthContextStore: healthContextStore,
             autostart: !launchConfiguration.isRunningTests
         )
         let appContainer = AppContainer(
             modelContainer: container,
             syncCoordinator: syncCoordinator,
-            appLogStore: appLogStore
+            appLogStore: appLogStore,
+            healthContextStore: healthContextStore
         )
 
         return AppRuntimeEnvironment(

--- a/Symi/Sources/Core/Health/HealthCore.swift
+++ b/Symi/Sources/Core/Health/HealthCore.swift
@@ -4,10 +4,10 @@ enum HealthDataDirection: String, Codable, CaseIterable, Identifiable, Sendable 
     case read = "Lesen"
     case write = "Schreiben"
 
-    var id: String { rawValue }
+    public var id: String { rawValue }
 }
 
-enum HealthDataTypeID: String, Codable, CaseIterable, Identifiable, Sendable {
+public enum HealthDataTypeID: String, Codable, CaseIterable, Identifiable, Sendable {
     case sleep
     case steps
     case heartRate
@@ -19,7 +19,7 @@ enum HealthDataTypeID: String, Codable, CaseIterable, Identifiable, Sendable {
     case dizziness
     case fatigue
 
-    var id: String { rawValue }
+    public var id: String { rawValue }
 
     nonisolated var displayName: String {
         switch self {
@@ -70,24 +70,68 @@ enum HealthDataCatalog {
     }
 }
 
-struct HealthSymptomSampleData: @preconcurrency Codable, Equatable, Sendable {
-    let type: HealthDataTypeID
-    let severity: String
-    let startDate: Date
-    let endDate: Date
-    let source: String
+public struct HealthSymptomSampleData: @preconcurrency Codable, Equatable, Sendable {
+    public let type: HealthDataTypeID
+    public let severity: String
+    public let startDate: Date
+    public let endDate: Date
+    public let source: String
+
+    public nonisolated init(
+        type: HealthDataTypeID,
+        severity: String,
+        startDate: Date,
+        endDate: Date,
+        source: String
+    ) {
+        self.type = type
+        self.severity = severity
+        self.startDate = startDate
+        self.endDate = endDate
+        self.source = source
+    }
+
+    public nonisolated static func == (lhs: HealthSymptomSampleData, rhs: HealthSymptomSampleData) -> Bool {
+        lhs.type == rhs.type &&
+            lhs.severity == rhs.severity &&
+            lhs.startDate == rhs.startDate &&
+            lhs.endDate == rhs.endDate &&
+            lhs.source == rhs.source
+    }
 }
 
-struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sendable {
-    let recordedAt: Date
-    let source: String
-    let sleepMinutes: Double?
-    let stepCount: Int?
-    let averageHeartRate: Double?
-    let restingHeartRate: Double?
-    let heartRateVariability: Double?
-    let menstrualFlow: String?
-    let symptoms: [HealthSymptomSampleData]
+public struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sendable {
+    public let recordedAt: Date
+    public let source: String
+    public let sleepMinutes: Double?
+    public let stepCount: Int?
+    public let averageHeartRate: Double?
+    public let restingHeartRate: Double?
+    public let heartRateVariability: Double?
+    public let menstrualFlow: String?
+    public let symptoms: [HealthSymptomSampleData]
+
+    public nonisolated init(
+        recordedAt: Date,
+        source: String,
+        sleepMinutes: Double?,
+        stepCount: Int?,
+        averageHeartRate: Double?,
+        restingHeartRate: Double?,
+        heartRateVariability: Double?,
+        menstrualFlow: String?,
+        symptoms: [HealthSymptomSampleData]
+    ) {
+        self.recordedAt = recordedAt
+        self.source = source
+        self.sleepMinutes = sleepMinutes
+        self.stepCount = stepCount
+        self.averageHeartRate = averageHeartRate
+        self.restingHeartRate = restingHeartRate
+        self.heartRateVariability = heartRateVariability
+        self.menstrualFlow = menstrualFlow
+        self.symptoms = symptoms
+    }
 
     var hasVisibleData: Bool {
         sleepMinutes != nil ||
@@ -96,7 +140,19 @@ struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sendable {
         restingHeartRate != nil ||
         heartRateVariability != nil ||
         menstrualFlow != nil ||
-        !symptoms.isEmpty
+            !symptoms.isEmpty
+    }
+
+    public nonisolated static func == (lhs: HealthContextSnapshotData, rhs: HealthContextSnapshotData) -> Bool {
+        lhs.recordedAt == rhs.recordedAt &&
+            lhs.source == rhs.source &&
+            lhs.sleepMinutes == rhs.sleepMinutes &&
+            lhs.stepCount == rhs.stepCount &&
+            lhs.averageHeartRate == rhs.averageHeartRate &&
+            lhs.restingHeartRate == rhs.restingHeartRate &&
+            lhs.heartRateVariability == rhs.heartRateVariability &&
+            lhs.menstrualFlow == rhs.menstrualFlow &&
+            lhs.symptoms == rhs.symptoms
     }
 }
 

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -756,6 +756,8 @@ private struct ManageCloudDataView: View {
             "Episode"
         case .medicationDefinition:
             "Medikamentenvorlage"
+        case .continuousMedication:
+            "Dauermedikation"
         }
     }
 

--- a/Symi/Sources/Features/Sync/SyncCoordinator.swift
+++ b/Symi/Sources/Features/Sync/SyncCoordinator.swift
@@ -21,6 +21,7 @@ final class SyncCoordinator {
     init(
         modelContainer: ModelContainer,
         appLogStore: AppLogStore,
+        healthContextStore: HealthContextStore = HealthContextStore(),
         stateStore: SyncStateStore = SyncStateStore(),
         deviceID: String? = nil,
         autostart: Bool = true
@@ -28,7 +29,7 @@ final class SyncCoordinator {
         self.modelContainer = modelContainer
         self.stateStore = stateStore
         self.appLogStore = appLogStore
-        self.repository = LocalSyncRepository(modelContainer: modelContainer)
+        self.repository = LocalSyncRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
         self.deviceID = deviceID ?? Self.persistedDeviceID()
 
         guard autostart else {
@@ -558,6 +559,10 @@ final class SyncCoordinator {
             values["isCustom"] = "\(payload.isCustom)"
             values["category"] = payload.category
             values["sortOrder"] = "\(payload.sortOrder)"
+        case .continuousMedication(let payload):
+            values["hasEndDate"] = "\(payload.endDate != nil)"
+            values["hasDosage"] = "\(!payload.dosage.isEmpty)"
+            values["hasFrequency"] = "\(!payload.frequency.isEmpty)"
         }
 
         return values

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -4,15 +4,23 @@ import SwiftData
 @MainActor
 struct LocalSyncRepository {
     let modelContainer: ModelContainer
+    let healthContextStore: HealthContextStore
+
+    init(modelContainer: ModelContainer, healthContextStore: HealthContextStore = HealthContextStore()) {
+        self.modelContainer = modelContainer
+        self.healthContextStore = healthContextStore
+    }
 
     func allEnvelopes(deviceID: String) throws -> [SyncDocumentEnvelope] {
         let context = ModelContext(modelContainer)
         let episodes = try context.fetch(FetchDescriptor<Episode>())
         let customDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
             .filter(\.isCustom)
+        let continuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
 
-        return episodes.map { $0.syncEnvelope(deviceID: deviceID) } +
-            customDefinitions.map { $0.syncEnvelope(deviceID: deviceID) }
+        return episodes.map { $0.syncEnvelope(deviceID: deviceID, healthContextStore: healthContextStore) } +
+            customDefinitions.map { $0.syncEnvelope(deviceID: deviceID) } +
+            continuousMedications.map { $0.syncEnvelope(deviceID: deviceID) }
     }
 
     func envelope(documentID: String, deviceID: String) throws -> SyncDocumentEnvelope? {
@@ -28,6 +36,8 @@ struct LocalSyncRepository {
             try applyEpisodePayload(payload, from: envelope, in: context)
         case .medicationDefinition(let payload):
             try applyMedicationDefinitionPayload(payload, from: envelope, in: context)
+        case .continuousMedication(let payload):
+            try applyContinuousMedicationPayload(payload, from: envelope, in: context)
         }
 
         try context.save()
@@ -68,6 +78,10 @@ struct LocalSyncRepository {
             context.delete(medication)
         }
 
+        for check in target.continuousMedicationChecks {
+            context.delete(check)
+        }
+
         if let weatherSnapshot = target.weatherSnapshot {
             context.delete(weatherSnapshot)
             target.weatherSnapshot = nil
@@ -84,6 +98,17 @@ struct LocalSyncRepository {
                 effectiveness: MedicationEffectiveness(rawValue: medication.effectiveness) ?? .partial,
                 reliefStartedAt: medication.reliefStartedAt,
                 isRepeatDose: medication.isRepeatDose,
+                episode: target
+            )
+        }
+        target.continuousMedicationChecks = payload.continuousMedicationChecks.map { check in
+            ContinuousMedicationCheck(
+                id: UUID(uuidString: check.id) ?? UUID(),
+                continuousMedicationID: UUID(uuidString: check.continuousMedicationID) ?? UUID(),
+                name: check.name,
+                dosage: check.dosage,
+                frequency: check.frequency,
+                wasTaken: check.wasTaken,
                 episode: target
             )
         }
@@ -109,6 +134,10 @@ struct LocalSyncRepository {
 
         if existing == nil {
             context.insert(target)
+        }
+
+        if payload.includesHealthContext {
+            try healthContextStore.save(payload.healthContext, for: episodeID)
         }
     }
 
@@ -149,11 +178,44 @@ struct LocalSyncRepository {
             context.insert(target)
         }
     }
+
+    private func applyContinuousMedicationPayload(
+        _ payload: SyncContinuousMedicationPayload,
+        from envelope: SyncDocumentEnvelope,
+        in context: ModelContext
+    ) throws {
+        let medicationID = UUID(uuidString: payload.id) ?? UUID()
+        let existing = try context.fetch(FetchDescriptor<ContinuousMedication>()).first { $0.id == medicationID }
+        let target = existing ?? ContinuousMedication(
+            id: medicationID,
+            name: payload.name,
+            dosage: payload.dosage,
+            frequency: payload.frequency,
+            startDate: payload.startDate,
+            endDate: payload.endDate,
+            createdAt: payload.createdAt,
+            updatedAt: envelope.modifiedAt
+        )
+
+        target.name = payload.name
+        target.dosage = payload.dosage
+        target.frequency = payload.frequency
+        target.startDate = payload.startDate
+        target.endDate = payload.endDate
+        target.createdAt = payload.createdAt
+        target.updatedAt = envelope.modifiedAt
+
+        if existing == nil {
+            context.insert(target)
+        }
+    }
 }
 
 extension Episode {
-    func syncEnvelope(deviceID: String) -> SyncDocumentEnvelope {
-        SyncDocumentEnvelope(
+    func syncEnvelope(deviceID: String, healthContextStore: HealthContextStore) -> SyncDocumentEnvelope {
+        let healthContext = healthContextStore.load(for: id).map(HealthContextSnapshotData.init)
+
+        return SyncDocumentEnvelope(
             documentID: "episode:\(id.uuidString)",
             entityType: .episode,
             modifiedAt: updatedAt,
@@ -186,6 +248,16 @@ extension Episode {
                             isRepeatDose: $0.isRepeatDose
                         )
                     },
+                    continuousMedicationChecks: continuousMedicationChecks.map {
+                        SyncContinuousMedicationCheckPayload(
+                            id: $0.id.uuidString,
+                            continuousMedicationID: $0.continuousMedicationID.uuidString,
+                            name: $0.name,
+                            dosage: $0.dosage,
+                            frequency: $0.frequency,
+                            wasTaken: $0.wasTaken
+                        )
+                    },
                     weatherSnapshot: weatherSnapshot.map {
                         SyncWeatherSnapshotPayload(
                             id: $0.id.uuidString,
@@ -203,7 +275,30 @@ extension Episode {
                             contextRangeEnd: $0.contextRangeEnd,
                             contextPoints: $0.contextPoints
                         )
-                    }
+                    },
+                    healthContext: healthContext
+                )
+            )
+        )
+    }
+}
+
+extension ContinuousMedication {
+    func syncEnvelope(deviceID: String) -> SyncDocumentEnvelope {
+        SyncDocumentEnvelope(
+            documentID: "continuousMedication:\(id.uuidString)",
+            entityType: .continuousMedication,
+            modifiedAt: updatedAt,
+            authorDeviceID: deviceID,
+            payload: .continuousMedication(
+                SyncContinuousMedicationPayload(
+                    id: id.uuidString,
+                    name: name,
+                    dosage: dosage,
+                    frequency: frequency,
+                    startDate: startDate,
+                    endDate: endDate,
+                    createdAt: createdAt
                 )
             )
         )

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -32,6 +32,7 @@ public enum SyncServiceState: String, Codable, CaseIterable, Sendable {
 public enum SyncEntityType: String, Codable, CaseIterable, Sendable {
     case episode
     case medicationDefinition
+    case continuousMedication
 }
 
 public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
@@ -92,10 +93,12 @@ public struct SyncDocumentEnvelope: Codable, Equatable, Sendable {
     public enum Payload: Codable, Equatable, Sendable {
         case episode(SyncEpisodePayload)
         case medicationDefinition(SyncMedicationDefinitionPayload)
+        case continuousMedication(SyncContinuousMedicationPayload)
 
         private enum CodingKeys: String, CodingKey {
             case episode
             case medicationDefinition
+            case continuousMedication
         }
 
         public nonisolated init(from decoder: any Decoder) throws {
@@ -107,6 +110,11 @@ public struct SyncDocumentEnvelope: Codable, Equatable, Sendable {
 
             if let definition = try container.decodeIfPresent(SyncMedicationDefinitionPayload.self, forKey: .medicationDefinition) {
                 self = .medicationDefinition(definition)
+                return
+            }
+
+            if let medication = try container.decodeIfPresent(SyncContinuousMedicationPayload.self, forKey: .continuousMedication) {
+                self = .continuousMedication(medication)
                 return
             }
 
@@ -125,6 +133,8 @@ public struct SyncDocumentEnvelope: Codable, Equatable, Sendable {
                 try container.encode(payload, forKey: .episode)
             case .medicationDefinition(let payload):
                 try container.encode(payload, forKey: .medicationDefinition)
+            case .continuousMedication(let payload):
+                try container.encode(payload, forKey: .continuousMedication)
             }
         }
     }
@@ -144,7 +154,29 @@ public struct SyncEpisodePayload: Codable, Equatable, Sendable {
     public nonisolated var functionalImpact: String
     public nonisolated var menstruationStatus: String
     public nonisolated var medications: [SyncMedicationEntryPayload]
+    public nonisolated var continuousMedicationChecks: [SyncContinuousMedicationCheckPayload]
     public nonisolated var weatherSnapshot: SyncWeatherSnapshotPayload?
+    public nonisolated var healthContext: HealthContextSnapshotData?
+    public nonisolated var includesHealthContext: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case startedAt
+        case endedAt
+        case type
+        case intensity
+        case painLocation
+        case painCharacter
+        case notes
+        case symptoms
+        case triggers
+        case functionalImpact
+        case menstruationStatus
+        case medications
+        case continuousMedicationChecks
+        case weatherSnapshot
+        case healthContext
+    }
 
     public nonisolated init(
         id: String,
@@ -160,7 +192,10 @@ public struct SyncEpisodePayload: Codable, Equatable, Sendable {
         functionalImpact: String,
         menstruationStatus: String,
         medications: [SyncMedicationEntryPayload],
-        weatherSnapshot: SyncWeatherSnapshotPayload?
+        continuousMedicationChecks: [SyncContinuousMedicationCheckPayload] = [],
+        weatherSnapshot: SyncWeatherSnapshotPayload?,
+        healthContext: HealthContextSnapshotData? = nil,
+        includesHealthContext: Bool = true
     ) {
         self.id = id
         self.startedAt = startedAt
@@ -175,7 +210,61 @@ public struct SyncEpisodePayload: Codable, Equatable, Sendable {
         self.functionalImpact = functionalImpact
         self.menstruationStatus = menstruationStatus
         self.medications = medications
+        self.continuousMedicationChecks = continuousMedicationChecks
         self.weatherSnapshot = weatherSnapshot
+        self.healthContext = healthContext
+        self.includesHealthContext = includesHealthContext
+    }
+
+    public nonisolated init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.startedAt = try container.decode(Date.self, forKey: .startedAt)
+        self.endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
+        self.type = try container.decode(String.self, forKey: .type)
+        self.intensity = try container.decode(Int.self, forKey: .intensity)
+        self.painLocation = try container.decode(String.self, forKey: .painLocation)
+        self.painCharacter = try container.decode(String.self, forKey: .painCharacter)
+        self.notes = try container.decode(String.self, forKey: .notes)
+        self.symptoms = try container.decode([String].self, forKey: .symptoms)
+        self.triggers = try container.decode([String].self, forKey: .triggers)
+        self.functionalImpact = try container.decode(String.self, forKey: .functionalImpact)
+        self.menstruationStatus = try container.decode(String.self, forKey: .menstruationStatus)
+        self.medications = try container.decode([SyncMedicationEntryPayload].self, forKey: .medications)
+        self.continuousMedicationChecks = try container.decodeIfPresent(
+            [SyncContinuousMedicationCheckPayload].self,
+            forKey: .continuousMedicationChecks
+        ) ?? []
+        self.weatherSnapshot = try container.decodeIfPresent(SyncWeatherSnapshotPayload.self, forKey: .weatherSnapshot)
+        self.includesHealthContext = container.contains(.healthContext)
+        self.healthContext = try container.decodeIfPresent(HealthContextSnapshotData.self, forKey: .healthContext)
+    }
+
+    public nonisolated func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(startedAt, forKey: .startedAt)
+        try container.encodeIfPresent(endedAt, forKey: .endedAt)
+        try container.encode(type, forKey: .type)
+        try container.encode(intensity, forKey: .intensity)
+        try container.encode(painLocation, forKey: .painLocation)
+        try container.encode(painCharacter, forKey: .painCharacter)
+        try container.encode(notes, forKey: .notes)
+        try container.encode(symptoms, forKey: .symptoms)
+        try container.encode(triggers, forKey: .triggers)
+        try container.encode(functionalImpact, forKey: .functionalImpact)
+        try container.encode(menstruationStatus, forKey: .menstruationStatus)
+        try container.encode(medications, forKey: .medications)
+        try container.encode(continuousMedicationChecks, forKey: .continuousMedicationChecks)
+        try container.encodeIfPresent(weatherSnapshot, forKey: .weatherSnapshot)
+
+        if includesHealthContext {
+            if let healthContext {
+                try container.encode(healthContext, forKey: .healthContext)
+            } else {
+                try container.encodeNil(forKey: .healthContext)
+            }
+        }
     }
 }
 
@@ -222,6 +311,40 @@ public struct SyncMedicationEntryPayload: Codable, Equatable, Sendable {
             lhs.effectiveness == rhs.effectiveness &&
             lhs.reliefStartedAt == rhs.reliefStartedAt &&
             lhs.isRepeatDose == rhs.isRepeatDose
+    }
+}
+
+public struct SyncContinuousMedicationCheckPayload: Codable, Equatable, Sendable {
+    public nonisolated var id: String
+    public nonisolated var continuousMedicationID: String
+    public nonisolated var name: String
+    public nonisolated var dosage: String
+    public nonisolated var frequency: String
+    public nonisolated var wasTaken: Bool
+
+    public nonisolated init(
+        id: String,
+        continuousMedicationID: String,
+        name: String,
+        dosage: String,
+        frequency: String,
+        wasTaken: Bool
+    ) {
+        self.id = id
+        self.continuousMedicationID = continuousMedicationID
+        self.name = name
+        self.dosage = dosage
+        self.frequency = frequency
+        self.wasTaken = wasTaken
+    }
+
+    public nonisolated static func == (lhs: SyncContinuousMedicationCheckPayload, rhs: SyncContinuousMedicationCheckPayload) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.continuousMedicationID == rhs.continuousMedicationID &&
+            lhs.name == rhs.name &&
+            lhs.dosage == rhs.dosage &&
+            lhs.frequency == rhs.frequency &&
+            lhs.wasTaken == rhs.wasTaken
     }
 }
 
@@ -363,6 +486,34 @@ public struct SyncMedicationDefinitionPayload: Codable, Equatable, Sendable {
     }
 }
 
+public struct SyncContinuousMedicationPayload: Codable, Equatable, Sendable {
+    public nonisolated var id: String
+    public nonisolated var name: String
+    public nonisolated var dosage: String
+    public nonisolated var frequency: String
+    public nonisolated var startDate: Date
+    public nonisolated var endDate: Date?
+    public nonisolated var createdAt: Date
+
+    public nonisolated init(
+        id: String,
+        name: String,
+        dosage: String,
+        frequency: String,
+        startDate: Date,
+        endDate: Date?,
+        createdAt: Date
+    ) {
+        self.id = id
+        self.name = name
+        self.dosage = dosage
+        self.frequency = frequency
+        self.startDate = startDate
+        self.endDate = endDate
+        self.createdAt = createdAt
+    }
+}
+
 public struct SyncShadow: Codable, Equatable, Sendable {
     public nonisolated var envelope: SyncDocumentEnvelope
     public nonisolated var recordSystemFields: Data?
@@ -450,6 +601,11 @@ public enum SyncMergeEngine {
             let result = mergeMedicationDefinition(base: basePayload, local: localPayload, remote: remotePayload)
             payload = .medicationDefinition(result.payload)
             conflicts = result.conflicts
+        case (.continuousMedication(let localPayload), .continuousMedication(let remotePayload)):
+            let basePayload = base?.payload.continuousMedicationPayload
+            let result = mergeContinuousMedication(base: basePayload, local: localPayload, remote: remotePayload)
+            payload = .continuousMedication(result.payload)
+            conflicts = result.conflicts
         default:
             payload = local.payload
             conflicts = ["payload"]
@@ -497,11 +653,23 @@ public enum SyncMergeEngine {
             remote: index(remote.medications),
             conflicts: &conflicts
         )
+        let continuousMedicationChecks = mergeContinuousMedicationChecks(
+            base: index(base?.continuousMedicationChecks ?? []),
+            local: index(local.continuousMedicationChecks),
+            remote: index(remote.continuousMedicationChecks),
+            conflicts: &conflicts
+        )
 
         let weather = mergeWeather(
             base: base?.weatherSnapshot,
             local: local.weatherSnapshot,
             remote: remote.weatherSnapshot,
+            conflicts: &conflicts
+        )
+        let healthContext = mergeHealthContext(
+            base: base,
+            local: local,
+            remote: remote,
             conflicts: &conflicts
         )
 
@@ -520,7 +688,31 @@ public enum SyncMergeEngine {
                 functionalImpact: functionalImpact,
                 menstruationStatus: menstruationStatus,
                 medications: medications.sorted { $0.takenAt < $1.takenAt },
-                weatherSnapshot: weather
+                continuousMedicationChecks: continuousMedicationChecks.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending },
+                weatherSnapshot: weather,
+                healthContext: healthContext,
+                includesHealthContext: local.includesHealthContext || remote.includesHealthContext
+            ),
+            conflicts
+        )
+    }
+
+    private nonisolated static func mergeContinuousMedication(
+        base: SyncContinuousMedicationPayload?,
+        local: SyncContinuousMedicationPayload,
+        remote: SyncContinuousMedicationPayload
+    ) -> (payload: SyncContinuousMedicationPayload, conflicts: [String]) {
+        var conflicts: [String] = []
+
+        return (
+            SyncContinuousMedicationPayload(
+                id: local.id,
+                name: mergedValue(field: "name", base: base?.name, local: local.name, remote: remote.name, conflicts: &conflicts).value,
+                dosage: mergedValue(field: "dosage", base: base?.dosage, local: local.dosage, remote: remote.dosage, conflicts: &conflicts).value,
+                frequency: mergedValue(field: "frequency", base: base?.frequency, local: local.frequency, remote: remote.frequency, conflicts: &conflicts).value,
+                startDate: mergedValue(field: "startDate", base: base?.startDate, local: local.startDate, remote: remote.startDate, conflicts: &conflicts).value,
+                endDate: mergedValue(field: "endDate", base: base?.endDate, local: local.endDate, remote: remote.endDate, conflicts: &conflicts).value,
+                createdAt: mergedValue(field: "createdAt", base: base?.createdAt, local: local.createdAt, remote: remote.createdAt, conflicts: &conflicts).value
             ),
             conflicts
         )
@@ -548,6 +740,45 @@ public enum SyncMergeEngine {
             ),
             conflicts
         )
+    }
+
+    private nonisolated static func mergeContinuousMedicationChecks(
+        base: [String: SyncContinuousMedicationCheckPayload],
+        local: [String: SyncContinuousMedicationCheckPayload],
+        remote: [String: SyncContinuousMedicationCheckPayload],
+        conflicts: inout [String]
+    ) -> [SyncContinuousMedicationCheckPayload] {
+        let ids = Set(base.keys).union(local.keys).union(remote.keys)
+
+        return ids.compactMap { id in
+            switch (base[id], local[id], remote[id]) {
+            case let (base?, local?, remote?):
+                return SyncContinuousMedicationCheckPayload(
+                    id: id,
+                    continuousMedicationID: mergedValue(field: "continuousMedicationChecks.\(id).continuousMedicationID", base: base.continuousMedicationID, local: local.continuousMedicationID, remote: remote.continuousMedicationID, conflicts: &conflicts).value,
+                    name: mergedValue(field: "continuousMedicationChecks.\(id).name", base: base.name, local: local.name, remote: remote.name, conflicts: &conflicts).value,
+                    dosage: mergedValue(field: "continuousMedicationChecks.\(id).dosage", base: base.dosage, local: local.dosage, remote: remote.dosage, conflicts: &conflicts).value,
+                    frequency: mergedValue(field: "continuousMedicationChecks.\(id).frequency", base: base.frequency, local: local.frequency, remote: remote.frequency, conflicts: &conflicts).value,
+                    wasTaken: mergedValue(field: "continuousMedicationChecks.\(id).wasTaken", base: base.wasTaken, local: local.wasTaken, remote: remote.wasTaken, conflicts: &conflicts).value
+                )
+            case let (nil, local?, nil):
+                return local
+            case let (nil, nil, remote?):
+                return remote
+            case let (nil, local?, remote?):
+                if local == remote {
+                    return local
+                }
+                conflicts.append("continuousMedicationChecks.\(id)")
+                return local
+            case let (base?, local?, nil):
+                return local == base ? nil : local
+            case let (base?, nil, remote?):
+                return remote == base ? nil : remote
+            default:
+                return nil
+            }
+        }
     }
 
     private nonisolated static func mergeMedicationEntries(
@@ -642,7 +873,29 @@ public enum SyncMergeEngine {
         }
     }
 
+    private nonisolated static func mergeHealthContext(
+        base: SyncEpisodePayload?,
+        local: SyncEpisodePayload,
+        remote: SyncEpisodePayload,
+        conflicts: inout [String]
+    ) -> HealthContextSnapshotData? {
+        switch (base?.includesHealthContext == true ? base?.healthContext : nil, local.includesHealthContext, remote.includesHealthContext) {
+        case let (baseHealthContext, true, true):
+            return mergedValue(field: "healthContext", base: baseHealthContext, local: local.healthContext, remote: remote.healthContext, conflicts: &conflicts).value
+        case (_, true, false):
+            return local.healthContext
+        case (_, false, true):
+            return remote.healthContext
+        default:
+            return nil
+        }
+    }
+
     private nonisolated static func index(_ entries: [SyncMedicationEntryPayload]) -> [String: SyncMedicationEntryPayload] {
+        Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+    }
+
+    private nonisolated static func index(_ entries: [SyncContinuousMedicationCheckPayload]) -> [String: SyncContinuousMedicationCheckPayload] {
         Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
     }
 
@@ -701,6 +954,14 @@ private extension SyncDocumentEnvelope.Payload {
 
     nonisolated var medicationDefinitionPayload: SyncMedicationDefinitionPayload? {
         guard case .medicationDefinition(let payload) = self else {
+            return nil
+        }
+
+        return payload
+    }
+
+    nonisolated var continuousMedicationPayload: SyncContinuousMedicationPayload? {
+        guard case .continuousMedication(let payload) = self else {
             return nil
         }
 

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -60,6 +60,109 @@ struct SyncMergeEngineTests {
 
     @Test
     @MainActor
+    func localSyncRepositoryIncludesContinuousMedicationChecksAndHealthContext() throws {
+        let stack = try makeSyncTestStack()
+        let context = ModelContext(stack.container)
+        let episodeID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        let medicationID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-000000000001")!
+        let checkID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-000000000002")!
+        let episode = Episode(
+            id: episodeID,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 2_000),
+            type: .migraine,
+            intensity: 7,
+            notes: "mit Kontext",
+            continuousMedicationChecks: [
+                ContinuousMedicationCheck(
+                    id: checkID,
+                    continuousMedicationID: medicationID,
+                    name: "Metoprolol",
+                    dosage: "47,5 mg",
+                    frequency: "morgens",
+                    wasTaken: false
+                )
+            ]
+        )
+        let continuousMedication = ContinuousMedication(
+            id: medicationID,
+            name: "Metoprolol",
+            dosage: "47,5 mg",
+            frequency: "morgens",
+            startDate: Date(timeIntervalSince1970: 500),
+            updatedAt: Date(timeIntervalSince1970: 1_500)
+        )
+        context.insert(episode)
+        context.insert(continuousMedication)
+        try context.save()
+        try stack.healthContextStore.save(sampleHealthContext(), for: episodeID)
+
+        let envelopes = try stack.repository.allEnvelopes(deviceID: syncTestDeviceID)
+        let episodePayload = try #require(envelopes.first { $0.documentID == "episode:\(episodeID.uuidString)" }?.payload.episodePayload)
+        let continuousMedicationPayload = try #require(
+            envelopes.first { $0.documentID == "continuousMedication:\(medicationID.uuidString)" }?.payload.continuousMedicationPayload
+        )
+
+        #expect(episodePayload.continuousMedicationChecks.first?.id == checkID.uuidString)
+        #expect(episodePayload.healthContext?.stepCount == 4_200)
+        #expect(continuousMedicationPayload.name == "Metoprolol")
+    }
+
+    @Test
+    @MainActor
+    func remoteEpisodeSyncAppliesContinuousMedicationChecksAndHealthContext() throws {
+        let stack = try makeSyncTestStack()
+        let episodeID = UUID(uuidString: "22222222-3333-4444-5555-666666666666")!
+        let checkID = UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-000000000001")!
+        let medicationID = UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-000000000002")!
+        let remoteEnvelope = SyncDocumentEnvelope(
+            documentID: "episode:\(episodeID.uuidString)",
+            entityType: .episode,
+            modifiedAt: Date(timeIntervalSince1970: 2_000),
+            authorDeviceID: "device-remote",
+            payload: .episode(
+                SyncEpisodePayload(
+                    id: episodeID.uuidString,
+                    startedAt: Date(timeIntervalSince1970: 1_000),
+                    endedAt: nil,
+                    type: "Migräne",
+                    intensity: 6,
+                    painLocation: "",
+                    painCharacter: "",
+                    notes: "remote",
+                    symptoms: [],
+                    triggers: [],
+                    functionalImpact: "",
+                    menstruationStatus: "Nicht angegeben",
+                    medications: [],
+                    continuousMedicationChecks: [
+                        SyncContinuousMedicationCheckPayload(
+                            id: checkID.uuidString,
+                            continuousMedicationID: medicationID.uuidString,
+                            name: "Magnesium",
+                            dosage: "300 mg",
+                            frequency: "abends",
+                            wasTaken: true
+                        )
+                    ],
+                    weatherSnapshot: nil,
+                    healthContext: sampleHealthContext()
+                )
+            )
+        )
+
+        try stack.repository.apply(remote: remoteEnvelope)
+
+        let context = ModelContext(stack.container)
+        let episode = try #require(try context.fetch(FetchDescriptor<Episode>()).first { $0.id == episodeID })
+        let healthContext = stack.healthContextStore.load(for: episodeID)
+
+        #expect(episode.continuousMedicationChecks.first?.name == "Magnesium")
+        #expect(healthContext?.stepCount == 4_200)
+    }
+
+    @Test
+    @MainActor
     func conflictRemoteMergeLeavesLocalStateUntouchedUntilResolution() async throws {
         let stack = try makeSyncTestStack()
         let documentID = try insertBaseEpisode(in: stack.container)
@@ -124,6 +227,18 @@ struct SyncMergeEngineTests {
 
         #expect(result.conflicts == ["notes"])
         #expect(result.merged.payload.episodePayload?.notes == "lokal")
+    }
+
+    @Test
+    func continuousMedicationConflictIsReported() {
+        let base = continuousMedicationEnvelope(name: "Metoprolol", dosage: "47,5 mg")
+        let local = continuousMedicationEnvelope(name: "Metoprolol", dosage: "95 mg")
+        let remote = continuousMedicationEnvelope(name: "Metoprolol", dosage: "50 mg")
+
+        let result = SyncMergeEngine.merge(base: base, local: local, remote: remote)
+
+        #expect(result.conflicts == ["dosage"])
+        #expect(result.merged.payload.continuousMedicationPayload?.dosage == "95 mg")
     }
 
     @Test
@@ -276,7 +391,8 @@ private func makeSyncTestStack() throws -> (
     container: ModelContainer,
     stateStore: SyncStateStore,
     coordinator: SyncCoordinator,
-    repository: LocalSyncRepository
+    repository: LocalSyncRepository,
+    healthContextStore: HealthContextStore
 ) {
     let schema = Schema(versionedSchema: SymiSchemaV6.self)
     let configuration = ModelConfiguration(
@@ -288,16 +404,18 @@ private func makeSyncTestStack() throws -> (
     let container = try ModelContainer(for: schema, configurations: [configuration])
     let stateStore = SyncStateStore(baseDirectoryURL: try makeTemporaryDirectory())
     let appLogStore = AppLogStore(baseDirectoryURL: try makeTemporaryDirectory())
+    let healthContextStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
     let coordinator = SyncCoordinator(
         modelContainer: container,
         appLogStore: appLogStore,
+        healthContextStore: healthContextStore,
         stateStore: stateStore,
         deviceID: syncTestDeviceID,
         autostart: false
     )
-    let repository = LocalSyncRepository(modelContainer: container)
+    let repository = LocalSyncRepository(modelContainer: container, healthContextStore: healthContextStore)
 
-    return (container, stateStore, coordinator, repository)
+    return (container, stateStore, coordinator, repository, healthContextStore)
 }
 
 @MainActor
@@ -397,9 +515,51 @@ private func definitionEnvelope(name: String, deletedAt: Date?) -> SyncDocumentE
     )
 }
 
+private func continuousMedicationEnvelope(name: String, dosage: String) -> SyncDocumentEnvelope {
+    SyncDocumentEnvelope(
+        documentID: "continuousMedication-1",
+        entityType: .continuousMedication,
+        modifiedAt: Date(timeIntervalSince1970: 1_000),
+        authorDeviceID: "device-a",
+        payload: .continuousMedication(
+            SyncContinuousMedicationPayload(
+                id: "continuousMedication-1",
+                name: name,
+                dosage: dosage,
+                frequency: "morgens",
+                startDate: .distantPast,
+                endDate: nil,
+                createdAt: .distantPast
+            )
+        )
+    )
+}
+
+private func sampleHealthContext() -> HealthContextSnapshotData {
+    HealthContextSnapshotData(
+        recordedAt: Date(timeIntervalSince1970: 1_200),
+        source: "Test",
+        sleepMinutes: 420,
+        stepCount: 4_200,
+        averageHeartRate: nil,
+        restingHeartRate: 62,
+        heartRateVariability: nil,
+        menstrualFlow: nil,
+        symptoms: []
+    )
+}
+
 private extension SyncDocumentEnvelope.Payload {
     var episodePayload: SyncEpisodePayload? {
         guard case .episode(let payload) = self else {
+            return nil
+        }
+
+        return payload
+    }
+
+    var continuousMedicationPayload: SyncContinuousMedicationPayload? {
+        guard case .continuousMedication(let payload) = self else {
             return nil
         }
 

--- a/docs/Sync-Abdeckung.md
+++ b/docs/Sync-Abdeckung.md
@@ -1,0 +1,15 @@
+# Sync-Abdeckung
+
+CloudKit-Sync nutzt `SyncDocumentEnvelope` als fachliche Dokumentgrenze. Die folgende Matrix beschreibt, welche lokalen Daten aktuell synchronisiert werden.
+
+| Modell / Datenbereich | Sync-Dokument | Abdeckung |
+| --- | --- | --- |
+| `Episode` | `episode:<UUID>` | Vollständig inklusive Basisdaten, Symptome, Trigger, funktionaler Einschränkung und Menstruationsstatus |
+| `MedicationEntry` | Bestandteil des Episoden-Dokuments | Akutmedikation wird pro Episode synchronisiert und nach stabiler Entry-ID gemergt |
+| `ContinuousMedicationCheck` | Bestandteil des Episoden-Dokuments | Einnahme-Checks werden pro Episode synchronisiert und nach stabiler Check-ID gemergt |
+| `WeatherSnapshot` | Bestandteil des Episoden-Dokuments | Wetterkontext wird pro Episode synchronisiert |
+| `HealthContextSnapshotData` | Bestandteil des Episoden-Dokuments | Health-Kontext wird pro Episode synchronisiert; alte Records ohne HealthContext-Feld löschen lokale Sidecars nicht |
+| Custom `MedicationDefinition` | `medicationDefinition:<catalogKey>` | Eigene Medikamentendefinitionen werden synchronisiert, Seed-Katalogdaten bleiben lokal ableitbar |
+| `ContinuousMedication` | `continuousMedication:<UUID>` | Dauermedikationen werden eigenständig synchronisiert und nach stabiler Medikamenten-ID gemergt |
+
+Konfliktbehandlung läuft weiterhin über den dreiseitigen Merge aus Shadow, lokalem Dokument und Remote-Dokument. Konflikte bei Episoden-Sidecars werden mit Feldpfaden wie `continuousMedicationChecks.<id>.wasTaken` oder `healthContext` sichtbar gemacht; Konflikte bei Dauermedikationen werden auf den jeweiligen Feldern wie `dosage`, `frequency` oder `endDate` gemeldet.


### PR DESCRIPTION
## Änderung
- erweitert CloudKit-Sync um Dauermedikationen als eigene Sync-Dokumente
- synchronisiert Einnahme-Checks und HealthContext als Teil des Episoden-Payloads
- dokumentiert die Sync-Abdeckungsmatrix für die betroffenen Modelle

## Validierung
- `xcodebuild test -scheme SymiTests -project Symi.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SymiTests/SyncMergeEngineTests`

Closes #215
