### PR TITLE
[codex] Break up app container feature wiring

### DIFF
--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -3,24 +3,9 @@ import SwiftData
 
 @MainActor
 final class AppContainer {
-    let modelContainer: ModelContainer
-    let syncCoordinator: SyncCoordinator
-    let appLogStore: AppLogStore
-    let weatherService: WeatherService
-    let locationService: LocationService
-    let healthService: HealthService
-    let healthContextStore: HealthContextStore
-    let episodeWeatherContextService: EpisodeWeatherContextProviding
-    let weatherBackfillService: WeatherBackfillService
-    let startupMaintenanceService: StartupMaintenanceService
+    let featureDependencies: AppFeatureDependencies
 
-    let episodeRepository: EpisodeRepository
-    let medicationCatalogRepository: MedicationCatalogRepository
-    let continuousMedicationRepository: ContinuousMedicationRepository
-    let exportRepository: ExportRepository
-    let insightEngine: InsightEngine
-    let syncService: SyncService
-    let appLogService: AppLogService
+    private let startupMaintenanceService: StartupMaintenanceService
 
     init(
         modelContainer: ModelContainer,
@@ -31,18 +16,11 @@ final class AppContainer {
         healthService: any HealthService = AppleHealthKitService(),
         healthContextStore: HealthContextStore = HealthContextStore()
     ) {
-        self.modelContainer = modelContainer
-        self.syncCoordinator = syncCoordinator
-        self.appLogStore = appLogStore
-        self.weatherService = weatherService
-        self.locationService = locationService
-        self.healthService = healthService
-        self.healthContextStore = healthContextStore
-        self.episodeWeatherContextService = EpisodeWeatherContextService(
+        let episodeWeatherContextService = EpisodeWeatherContextService(
             weatherService: weatherService,
             locationService: locationService
         )
-        self.weatherBackfillService = WeatherBackfillService(
+        let weatherBackfillService = WeatherBackfillService(
             modelContainer: modelContainer,
             weatherService: weatherService,
             locationService: locationService
@@ -51,58 +29,147 @@ final class AppContainer {
             modelContainer: modelContainer,
             weatherBackfillService: weatherBackfillService
         )
-        self.episodeRepository = SwiftDataEpisodeRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
-        self.medicationCatalogRepository = SwiftDataMedicationCatalogRepository(modelContainer: modelContainer)
-        self.continuousMedicationRepository = SwiftDataContinuousMedicationRepository(modelContainer: modelContainer)
-        self.exportRepository = SwiftDataExportRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
-        self.insightEngine = InsightEngine()
-        self.syncService = SyncServiceAdapter(coordinator: syncCoordinator)
-        self.appLogService = appLogStore
+
+        let episodeRepository = SwiftDataEpisodeRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
+        let medicationCatalogRepository = SwiftDataMedicationCatalogRepository(modelContainer: modelContainer)
+        let continuousMedicationRepository = SwiftDataContinuousMedicationRepository(modelContainer: modelContainer)
+        let exportRepository = SwiftDataExportRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
+        let insightEngine = InsightEngine()
+        let syncService = SyncServiceAdapter(coordinator: syncCoordinator)
+
+        let capture = CaptureFeatureDependencies(
+            makeEntryFlowCoordinator: { initialStartedAt in
+                EntryFlowCoordinator(
+                    initialStartedAt: initialStartedAt,
+                    episodeRepository: episodeRepository,
+                    medicationRepository: medicationCatalogRepository,
+                    continuousMedicationRepository: continuousMedicationRepository,
+                    weatherContextService: episodeWeatherContextService,
+                    healthService: healthService
+                )
+            },
+            makeEpisodeEditorController: { episodeID, initialStartedAt in
+                EpisodeEditorController(
+                    episodeID: episodeID,
+                    initialStartedAt: initialStartedAt,
+                    episodeRepository: episodeRepository,
+                    medicationRepository: medicationCatalogRepository,
+                    weatherContextService: episodeWeatherContextService,
+                    healthService: healthService
+                )
+            }
+        )
+        let history = HistoryFeatureDependencies(
+            makeHistoryController: {
+                HistoryController(repository: episodeRepository)
+            },
+            loadEpisodeDetail: { episodeID in
+                try await LoadEpisodeDetailUseCase(repository: episodeRepository).execute(id: episodeID)
+            },
+            deleteEpisode: { episodeID in
+                try await DeleteEpisodeUseCase(repository: episodeRepository).execute(id: episodeID)
+            },
+            capture: capture
+        )
+        let insights = InsightsFeatureDependencies(
+            loadResult: { period in
+                try await LoadInsightResultUseCase(
+                    repository: episodeRepository,
+                    insightEngine: insightEngine
+                ).execute(period: period)
+            }
+        )
+        let dataExport = DataExportFeatureDependencies(
+            makeDataExportController: {
+                DataExportController(repository: exportRepository)
+            }
+        )
+        let settings = SettingsFeatureDependencies(
+            makeSettingsController: {
+                SettingsController(
+                    episodeRepository: episodeRepository,
+                    medicationRepository: medicationCatalogRepository,
+                    continuousMedicationRepository: continuousMedicationRepository,
+                    syncService: syncService,
+                    appLogService: appLogStore,
+                    healthService: healthService
+                )
+            },
+            dataExport: dataExport
+        )
+        self.featureDependencies = AppFeatureDependencies(
+            home: HomeFeatureDependencies(
+                loadCalendarMonth: { month in
+                    try await LoadHistoryMonthUseCase(repository: episodeRepository).execute(month: month)
+                },
+                loadPatternPreview: {
+                    try await LoadHomePatternPreviewUseCase(
+                        repository: episodeRepository,
+                        insightEngine: insightEngine
+                    ).execute()
+                },
+                capture: capture,
+                history: history,
+                insights: insights
+            ),
+            capture: capture,
+            history: history,
+            insights: insights,
+            settings: settings,
+            dataExport: dataExport
+        )
     }
 
     func startDeferredMaintenanceIfNeeded() {
         startupMaintenanceService.startIfNeeded()
     }
+}
 
-    func makeEpisodeEditorController(episodeID: UUID? = nil, initialStartedAt: Date? = nil) -> EpisodeEditorController {
-        EpisodeEditorController(
-            episodeID: episodeID,
-            initialStartedAt: initialStartedAt,
-            episodeRepository: episodeRepository,
-            medicationRepository: medicationCatalogRepository,
-            weatherContextService: episodeWeatherContextService,
-            healthService: healthService
-        )
-    }
+@MainActor
+struct AppFeatureDependencies {
+    let home: HomeFeatureDependencies
+    let capture: CaptureFeatureDependencies
+    let history: HistoryFeatureDependencies
+    let insights: InsightsFeatureDependencies
+    let settings: SettingsFeatureDependencies
+    let dataExport: DataExportFeatureDependencies
+}
 
-    func makeEntryFlowCoordinator(initialStartedAt: Date? = nil) -> EntryFlowCoordinator {
-        EntryFlowCoordinator(
-            initialStartedAt: initialStartedAt,
-            episodeRepository: episodeRepository,
-            medicationRepository: medicationCatalogRepository,
-            continuousMedicationRepository: continuousMedicationRepository,
-            weatherContextService: episodeWeatherContextService,
-            healthService: healthService
-        )
-    }
+@MainActor
+struct HomeFeatureDependencies {
+    let loadCalendarMonth: (Date) async throws -> HistoryMonthData
+    let loadPatternPreview: () async throws -> HomePatternPreviewData
+    let capture: CaptureFeatureDependencies
+    let history: HistoryFeatureDependencies
+    let insights: InsightsFeatureDependencies
+}
 
-    func makeHistoryController() -> HistoryController {
-        HistoryController(repository: episodeRepository)
-    }
+@MainActor
+struct CaptureFeatureDependencies {
+    let makeEntryFlowCoordinator: (Date?) -> EntryFlowCoordinator
+    let makeEpisodeEditorController: (UUID?, Date?) -> EpisodeEditorController
+}
 
-    func makeSettingsController() -> SettingsController {
-        SettingsController(
-            episodeRepository: episodeRepository,
-            medicationRepository: medicationCatalogRepository,
-            continuousMedicationRepository: continuousMedicationRepository,
-            syncService: syncService,
-            appLogService: appLogService,
-            healthService: healthService
-        )
-    }
+@MainActor
+struct HistoryFeatureDependencies {
+    let makeHistoryController: () -> HistoryController
+    let loadEpisodeDetail: (UUID) async throws -> EpisodeRecord?
+    let deleteEpisode: (UUID) async throws -> Void
+    let capture: CaptureFeatureDependencies
+}
 
-    func makeDataExportController() -> DataExportController {
-        DataExportController(repository: exportRepository)
-    }
+@MainActor
+struct InsightsFeatureDependencies {
+    let loadResult: (InsightPeriod) async throws -> InsightResult
+}
 
+@MainActor
+struct SettingsFeatureDependencies {
+    let makeSettingsController: () -> SettingsController
+    let dataExport: DataExportFeatureDependencies
+}
+
+@MainActor
+struct DataExportFeatureDependencies {
+    let makeDataExportController: () -> DataExportController
 }

--- a/Symi/Sources/App/AppShellView.swift
+++ b/Symi/Sources/App/AppShellView.swift
@@ -32,6 +32,7 @@ enum AppSection: String, CaseIterable, Identifiable {
 
 struct AppShellView: View {
     let appContainer: AppContainer
+    private var features: AppFeatureDependencies { appContainer.featureDependencies }
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var selectedSection: AppSection = .diary
@@ -103,13 +104,13 @@ struct AppShellView: View {
     private func content(for section: AppSection) -> some View {
         switch section {
         case .diary:
-            HomeView(appContainer: appContainer)
+            HomeView(dependencies: features.home)
         case .insights:
-            InsightsView(appContainer: appContainer)
+            InsightsView(dependencies: features.insights)
         case .export:
-            DataExportView(appContainer: appContainer)
+            DataExportView(dependencies: features.dataExport)
         case .settings:
-            SettingsView(appContainer: appContainer, showsCloseButton: false)
+            SettingsView(dependencies: features.settings, showsCloseButton: false)
         case .information:
             ProductInformationView(mode: .standard)
         }

--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -299,6 +299,7 @@ struct ScreenshotRootView: View {
     let appContainer: AppContainer
     let configuration: AppLaunchConfiguration
     let seed: ScreenshotSeed
+    private var features: AppFeatureDependencies { appContainer.featureDependencies }
 
     var body: some View {
         rootView
@@ -309,30 +310,30 @@ struct ScreenshotRootView: View {
         switch configuration.screenshotRoute ?? .home {
         case .home:
             NavigationStack {
-                HomeView(appContainer: appContainer)
+                HomeView(dependencies: features.home)
             }
 
         case .newEntry:
-            EntryFlowCoordinatorView(appContainer: appContainer, initialStartedAt: seed.newEntryDate)
+            EntryFlowCoordinatorView(dependencies: features.capture, initialStartedAt: seed.newEntryDate)
 
         case .insights:
             NavigationStack {
-                InsightsView(appContainer: appContainer)
+                InsightsView(dependencies: features.insights)
             }
 
         case .history:
             NavigationStack {
-                HistoryView(appContainer: appContainer)
+                HistoryView(dependencies: features.history)
             }
 
         case .episodeDetail:
             NavigationStack {
-                EpisodeDetailView(appContainer: appContainer, episodeID: seed.primaryEpisodeID)
+                EpisodeDetailView(dependencies: features.history, episodeID: seed.primaryEpisodeID)
             }
 
         case .export:
             NavigationStack {
-                DataExportView(appContainer: appContainer)
+                DataExportView(dependencies: features.dataExport)
             }
 
         case .privacyInfo:

--- a/Symi/Sources/Features/Capture/CaptureView.swift
+++ b/Symi/Sources/Features/Capture/CaptureView.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
 struct CaptureView: View {
-    let appContainer: AppContainer
+    let dependencies: CaptureFeatureDependencies
 
     var body: some View {
-        EntryFlowCoordinatorView(appContainer: appContainer)
+        EntryFlowCoordinatorView(dependencies: dependencies)
     }
 }
 

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -7,13 +7,13 @@ struct EntryFlowCoordinatorView: View {
     private let onSaved: (() -> Void)?
 
     init(
-        appContainer: AppContainer,
+        dependencies: CaptureFeatureDependencies,
         initialStartedAt: Date? = nil,
         onSaved: (() -> Void)? = nil
     ) {
         self.onSaved = onSaved
         _coordinator = State(
-            initialValue: appContainer.makeEntryFlowCoordinator(initialStartedAt: initialStartedAt)
+            initialValue: dependencies.makeEntryFlowCoordinator(initialStartedAt)
         )
     }
 

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -7,17 +7,14 @@ struct EpisodeEditorView: View {
     private let onSaved: (() -> Void)?
 
     init(
-        appContainer: AppContainer,
+        dependencies: CaptureFeatureDependencies,
         episodeID: UUID? = nil,
         initialStartedAt: Date? = nil,
         onSaved: (() -> Void)? = nil
     ) {
         self.onSaved = onSaved
         _controller = State(
-            initialValue: appContainer.makeEpisodeEditorController(
-                episodeID: episodeID,
-                initialStartedAt: initialStartedAt
-            )
+            initialValue: dependencies.makeEpisodeEditorController(episodeID, initialStartedAt)
         )
     }
 

--- a/Symi/Sources/Features/Export/DataExportView.swift
+++ b/Symi/Sources/Features/Export/DataExportView.swift
@@ -4,8 +4,8 @@ import UniformTypeIdentifiers
 struct DataExportView: View {
     @State private var controller: DataExportController
 
-    init(appContainer: AppContainer) {
-        _controller = State(initialValue: appContainer.makeDataExportController())
+    init(dependencies: DataExportFeatureDependencies) {
+        _controller = State(initialValue: dependencies.makeDataExportController())
     }
 
     var body: some View {

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
-    let appContainer: AppContainer
+    let dependencies: SettingsFeatureDependencies
     let showsCloseButton: Bool
     @State private var controller: SettingsController
 
-    init(appContainer: AppContainer, showsCloseButton: Bool = true) {
-        self.appContainer = appContainer
+    init(dependencies: SettingsFeatureDependencies, showsCloseButton: Bool = true) {
+        self.dependencies = dependencies
         self.showsCloseButton = showsCloseButton
-        _controller = State(initialValue: appContainer.makeSettingsController())
+        _controller = State(initialValue: dependencies.makeSettingsController())
     }
 
     var body: some View {
@@ -46,7 +46,7 @@ struct SettingsView: View {
                 .tint(AppTheme.ocean)
 
                 NavigationLink {
-                    ManageCloudDataView(appContainer: appContainer, controller: controller)
+                    ManageCloudDataView(dataExportDependencies: dependencies.dataExport, controller: controller)
                 } label: {
                     Label("Cloud-Daten verwalten", systemImage: "icloud")
                 }
@@ -101,7 +101,7 @@ struct SettingsView: View {
                 }
 
                 NavigationLink {
-                    DataExportView(appContainer: appContainer)
+                    DataExportView(dependencies: dependencies.dataExport)
                 } label: {
                     Label("Daten und Backup", systemImage: "square.and.arrow.up")
                 }
@@ -602,7 +602,7 @@ private struct SyncStatusView: View {
 }
 
 private struct ManageCloudDataView: View {
-    let appContainer: AppContainer
+    let dataExportDependencies: DataExportFeatureDependencies
     @Bindable var controller: SettingsController
     @State private var selectedConflict: SyncConflict?
     @State private var isResolvingConflict = false
@@ -635,7 +635,7 @@ private struct ManageCloudDataView: View {
                 .disabled(!controller.isSyncEnabled || controller.syncStatus.lastError == nil)
 
                 NavigationLink {
-                    DataExportView(appContainer: appContainer)
+                    DataExportView(dependencies: dataExportDependencies)
                 } label: {
                     Text("Lokales JSON5-Backup erstellen")
                 }

--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct EpisodeDetailView: View {
     @Environment(\.dismiss) private var dismiss
 
-    let appContainer: AppContainer
+    let dependencies: HistoryFeatureDependencies
     let episodeID: UUID
     let onChanged: () -> Void
 
@@ -12,19 +12,14 @@ struct EpisodeDetailView: View {
     @State private var isLoading = true
     @State private var isShowingDeleteConfirmation = false
 
-    private let loadEpisodeDetailUseCase: LoadEpisodeDetailUseCase
-    private let deleteEpisodeUseCase: DeleteEpisodeUseCase
-
     init(
-        appContainer: AppContainer,
+        dependencies: HistoryFeatureDependencies,
         episodeID: UUID,
         onChanged: @escaping () -> Void = {}
     ) {
-        self.appContainer = appContainer
+        self.dependencies = dependencies
         self.episodeID = episodeID
         self.onChanged = onChanged
-        self.loadEpisodeDetailUseCase = LoadEpisodeDetailUseCase(repository: appContainer.episodeRepository)
-        self.deleteEpisodeUseCase = DeleteEpisodeUseCase(repository: appContainer.episodeRepository)
         _episode = State(initialValue: nil)
     }
 
@@ -78,7 +73,7 @@ struct EpisodeDetailView: View {
         .sheet(isPresented: $isEditing) {
             NavigationStack {
                 EpisodeEditorView(
-                    appContainer: appContainer,
+                    dependencies: dependencies.capture,
                     episodeID: episodeID,
                     onSaved: handleSavedEpisode
                 )
@@ -115,7 +110,7 @@ struct EpisodeDetailView: View {
     private func deleteEpisode() {
         Task {
             do {
-                try await deleteEpisodeUseCase.execute(id: episodeID)
+                try await dependencies.deleteEpisode(episodeID)
                 onChanged()
                 dismiss()
             } catch {
@@ -126,7 +121,7 @@ struct EpisodeDetailView: View {
 
     private func reload() async {
         isLoading = true
-        episode = try? await loadEpisodeDetailUseCase.execute(id: episodeID)
+        episode = try? await dependencies.loadEpisodeDetail(episodeID)
         isLoading = false
     }
 }

--- a/Symi/Sources/Features/History/HistoryView.swift
+++ b/Symi/Sources/Features/History/HistoryView.swift
@@ -1,16 +1,16 @@
 import SwiftUI
 
 struct HistoryView: View {
-    let appContainer: AppContainer
+    let dependencies: HistoryFeatureDependencies
     @State private var controller: HistoryController
     @State private var searchText = ""
     @State private var isSearchVisible = false
     @State private var isFilterSheetPresented = false
     @State private var filters = JournalFilters()
 
-    init(appContainer: AppContainer) {
-        self.appContainer = appContainer
-        _controller = State(initialValue: appContainer.makeHistoryController())
+    init(dependencies: HistoryFeatureDependencies) {
+        self.dependencies = dependencies
+        _controller = State(initialValue: dependencies.makeHistoryController())
     }
 
     var body: some View {
@@ -39,7 +39,7 @@ struct HistoryView: View {
                         ForEach(group.episodes) { episode in
                             NavigationLink {
                                 EpisodeDetailView(
-                                    appContainer: appContainer,
+                                    dependencies: dependencies,
                                     episodeID: episode.id,
                                     onChanged: { Task { await reloadJournal() } }
                                 )
@@ -106,7 +106,7 @@ struct HistoryView: View {
         .sheet(item: editingEpisodeBinding) { episodeID in
             NavigationStack {
                 EpisodeEditorView(
-                    appContainer: appContainer,
+                    dependencies: dependencies.capture,
                     episodeID: episodeID.id,
                     onSaved: {
                         controller.editingEpisodeID = nil
@@ -496,7 +496,7 @@ private struct JournalRemovableChip: View {
 
 private struct JournalEntryGroups: View {
     let groupedEpisodes: [JournalDayGroup]
-    let appContainer: AppContainer
+    let dependencies: HistoryFeatureDependencies
     let onChanged: () -> Void
     let onEdit: (UUID) -> Void
     let onDelete: (UUID) -> Void
@@ -517,7 +517,7 @@ private struct JournalEntryGroups: View {
                             ForEach(group.episodes) { episode in
                                 NavigationLink {
                                     EpisodeDetailView(
-                                        appContainer: appContainer,
+                                        dependencies: dependencies,
                                         episodeID: episode.id,
                                         onChanged: onChanged
                                     )

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct HomeView: View {
-    let appContainer: AppContainer
+    let dependencies: HomeFeatureDependencies
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var displayedMonth = Calendar.current.startOfMonth(for: .now)
@@ -10,8 +10,8 @@ struct HomeView: View {
     @State private var quickEntryIntensity = 5
     @State private var isPresentingEpisodeEditor = false
 
-    init(appContainer: AppContainer) {
-        self.appContainer = appContainer
+    init(dependencies: HomeFeatureDependencies) {
+        self.dependencies = dependencies
     }
 
     var body: some View {
@@ -32,7 +32,7 @@ struct HomeView: View {
             await reloadAll()
         }
         .fullScreenCover(isPresented: $isPresentingEpisodeEditor) {
-            EntryFlowCoordinatorView(appContainer: appContainer, initialStartedAt: .now) {
+            EntryFlowCoordinatorView(dependencies: dependencies.capture, initialStartedAt: .now) {
                 isPresentingEpisodeEditor = false
                 Task { await reloadAll() }
             }
@@ -53,7 +53,7 @@ struct HomeView: View {
                 }
                 .padding(.bottom, SymiSpacing.lg)
 
-                HomeAllEntriesLink(appContainer: appContainer)
+                HomeAllEntriesLink(dependencies: dependencies.history)
                     .padding(.bottom, SymiSpacing.lg)
 
                 HomeMonthCalendarView(
@@ -65,7 +65,7 @@ struct HomeView: View {
                     .padding(.bottom, SymiSpacing.lg)
 
                 HomePatternPreviewSection(data: patternPreviewData) {
-                    InsightsView(appContainer: appContainer)
+                    InsightsView(dependencies: dependencies.insights)
                 }
                 .padding(.bottom, SymiSpacing.xxxl + SymiSpacing.xxs)
             }
@@ -97,11 +97,11 @@ struct HomeView: View {
                 )
                     .padding(.bottom, SymiSpacing.lg)
 
-                HomeAllEntriesLink(appContainer: appContainer)
+                HomeAllEntriesLink(dependencies: dependencies.history)
                     .padding(.bottom, SymiSpacing.lg)
 
                 HomePatternPreviewSection(data: patternPreviewData) {
-                    InsightsView(appContainer: appContainer)
+                    InsightsView(dependencies: dependencies.insights)
                 }
                 .padding(.bottom, SymiSpacing.xxxl + SymiSpacing.xxs)
             }
@@ -121,14 +121,11 @@ struct HomeView: View {
 
     private func reloadCalendarMonth() async {
         let month = displayedMonth
-        calendarMonthData = (try? await LoadHistoryMonthUseCase(repository: appContainer.episodeRepository).execute(month: month)) ?? HistoryMonthData(month: month, episodesByDay: [:])
+        calendarMonthData = (try? await dependencies.loadCalendarMonth(month)) ?? HistoryMonthData(month: month, episodesByDay: [:])
     }
 
     private func reloadPatternPreview() async {
-        patternPreviewData = (try? await LoadHomePatternPreviewUseCase(
-            repository: appContainer.episodeRepository,
-            insightEngine: appContainer.insightEngine
-        ).execute()) ?? HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
+        patternPreviewData = (try? await dependencies.loadPatternPreview()) ?? HomePatternPreviewData(totalPainEpisodeCount: 0, cards: [])
     }
 
     private func showPreviousMonth() {
@@ -396,12 +393,12 @@ private struct PrimaryEntryButton: View {
 }
 
 private struct HomeAllEntriesLink: View {
-    let appContainer: AppContainer
+    let dependencies: HistoryFeatureDependencies
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         NavigationLink {
-            HistoryView(appContainer: appContainer)
+            HistoryView(dependencies: dependencies)
         } label: {
             HStack(spacing: SymiSpacing.sm) {
                 Image(systemName: "list.bullet.rectangle")
@@ -592,7 +589,7 @@ private struct HomePatternEmptyState: View {
 }
 
 struct InsightsView: View {
-    let appContainer: AppContainer
+    let dependencies: InsightsFeatureDependencies
     @State private var data = InsightResult(totalQualifiedEpisodeCount: 0, insights: [])
     @State private var selectedPeriod: InsightPeriod = .thirtyDays
 
@@ -623,10 +620,7 @@ struct InsightsView: View {
     }
 
     private func reload() async {
-        data = (try? await LoadInsightResultUseCase(
-            repository: appContainer.episodeRepository,
-            insightEngine: appContainer.insightEngine
-        ).execute(period: selectedPeriod)) ?? InsightResult(
+        data = (try? await dependencies.loadResult(selectedPeriod)) ?? InsightResult(
             period: selectedPeriod,
             totalQualifiedEpisodeCount: 0,
             insights: []

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -157,6 +157,34 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func featureSourcesDoNotWireAppContainerOrInfrastructureImplementations() throws {
+        let featureFiles = try swiftSourceFiles(in: "Symi/Sources/Features")
+        #expect(!featureFiles.isEmpty)
+        let forbiddenReferences = [
+            "AppContainer",
+            "SwiftDataEpisodeRepository",
+            "SwiftDataMedicationCatalogRepository",
+            "SwiftDataContinuousMedicationRepository",
+            "SwiftDataExportRepository",
+            "AppleHealthKitService",
+            "AppleWeatherKitWeatherService",
+            "SystemLocationService",
+            "SyncServiceAdapter"
+        ]
+
+        for file in featureFiles {
+            let contents = try String(contentsOf: file, encoding: .utf8)
+
+            for reference in forbiddenReferences {
+                #expect(
+                    !contents.contains(reference),
+                    "\(file.lastPathComponent) verdrahtet \(reference) direkt statt Feature-Dependencies zu verwenden."
+                )
+            }
+        }
+    }
+
+    @Test
     func appleWeatherKitServiceSkipsDatesBeforeHourlyHistory() async throws {
         let service = AppleWeatherKitWeatherService()
         let oldDate = Date(timeIntervalSince1970: 1_627_775_999)
@@ -761,6 +789,31 @@ private func fixedCalendar() -> Calendar {
     calendar.timeZone = TimeZone(secondsFromGMT: 0)!
     calendar.firstWeekday = 2
     return calendar
+}
+
+private func swiftSourceFiles(in relativePath: String) throws -> [URL] {
+    let testFileURL = URL(fileURLWithPath: #filePath)
+    let repositoryRoot = testFileURL
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    let directory = repositoryRoot.appending(path: relativePath, directoryHint: .isDirectory)
+
+    guard let enumerator = FileManager.default.enumerator(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+    ) else {
+        return []
+    }
+
+    return try enumerator.compactMap { item -> URL? in
+        guard let url = item as? URL, url.pathExtension == "swift" else {
+            return nil
+        }
+
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+        return values.isRegularFile == true ? url : nil
+    }
 }
 
 private func sampleEnvelope() -> SyncDocumentEnvelope {


### PR DESCRIPTION
## Änderungen

- `AppContainer` baut konkrete Repositories und Services nur noch in der Composition Root zusammen.
- Feature-Views erhalten eigene Dependency-Structs statt den gesamten Container.
- Home, Insights, History, Capture, Settings und Export nutzen dadurch gezielte Factories/Loader.
- Architekturtest verhindert neue direkte Verdrahtung von `AppContainer` oder konkreten Infrastrukturimplementierungen in `Symi/Sources/Features`.

## Validierung

- `xcodebuild test -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath build/CodexDerivedData`

Closes #216
