### PR TITLE
Produktiven Startup-Safe-Mode ergänzen

### DIFF
--- a/Symi/Sources/App/StoreRecovery.swift
+++ b/Symi/Sources/App/StoreRecovery.swift
@@ -51,6 +51,47 @@ nonisolated enum PersistentStoreRecoveryFileError: LocalizedError, Equatable {
     }
 }
 
+nonisolated enum AppStartupPreparationError: LocalizedError, Equatable {
+    case applicationSupportDirectoryUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .applicationSupportDirectoryUnavailable:
+            "Das Application-Support-Verzeichnis konnte nicht gefunden werden."
+        }
+    }
+}
+
+nonisolated enum AppStartupFailureReason: Equatable, Sendable {
+    case bootstrapFailure
+    case recoveryUnavailable
+
+    var headline: String {
+        switch self {
+        case .bootstrapFailure:
+            "Symi konnte nicht vollständig gestartet werden."
+        case .recoveryUnavailable:
+            "Symi konnte den Wiederherstellungsmodus nicht vollständig vorbereiten."
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .bootstrapFailure:
+            "Symi bleibt in einem geschützten Safe-Mode, damit Diagnoseinformationen sichtbar bleiben und vorhandene Store-Dateien nicht verändert werden."
+        case .recoveryUnavailable:
+            "Der lokale Store wurde nicht geöffnet oder gelöscht. Du kannst vorhandene Store-Dateien sichern und Symi nach einem Update erneut starten."
+        }
+    }
+}
+
+nonisolated struct AppStartupFailureContext: Equatable, Sendable {
+    let reason: AppStartupFailureReason
+    let errorSummary: String
+    let storeURL: URL?
+    let recoveryContext: PersistentStoreRecoveryContext?
+}
+
 nonisolated enum PersistentStoreRecoveryService {
     static let unknownModelVersionErrorCode = 134504
     static let migrationErrorCodeRange = 134100...134199
@@ -154,6 +195,157 @@ nonisolated enum PersistentStoreRecoveryService {
         formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd-HHmmss"
         return formatter.string(from: date)
+    }
+}
+
+struct StartupSafeModeView: View {
+    let context: AppStartupFailureContext
+    let prepareStoreBackup: () throws -> [URL]
+    let startEmptyStore: @MainActor () throws -> AppRuntimeEnvironment
+    let didRecover: @MainActor (AppRuntimeEnvironment) -> Void
+
+    @State private var backupFileURLs: [URL] = []
+    @State private var statusMessage: String?
+    @State private var errorMessage: String?
+    @State private var isPreparingBackup = false
+    @State private var isStartingEmptyStore = false
+    @State private var showsDestructiveConfirmation = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    VStack(alignment: .leading, spacing: SymiSpacing.md) {
+                        Label("Safe-Mode aktiv", systemImage: "wrench.and.screwdriver")
+                            .font(.headline)
+                            .foregroundStyle(AppTheme.symiPetrol)
+
+                        Text(context.reason.headline)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiTextPrimary)
+
+                        Text(context.reason.explanation)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiTextSecondary)
+                    }
+                    .padding(.vertical, SymiSpacing.compact)
+                }
+
+                Section("Diagnose") {
+                    LabeledContent("Fehlercode", value: context.errorSummary)
+
+                    if let storeURL = context.storeURL {
+                        LabeledContent("Store", value: storeURL.lastPathComponent)
+                    }
+
+                    if let recoveryContext = context.recoveryContext {
+                        LabeledContent("Recovery-Grund", value: recoveryContext.reason.rawValue)
+                    }
+                }
+
+                if context.storeURL != nil {
+                    Section("Store-Sicherung") {
+                        Text("Vorhandene Store-Dateien bleiben unverändert. Du kannst sie für Support oder eine spätere Wiederherstellung sichern.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+
+                        Button {
+                            prepareBackup()
+                        } label: {
+                            Label(isPreparingBackup ? "Sicherung wird vorbereitet" : "Store-Dateien sichern", systemImage: "externaldrive.badge.plus")
+                        }
+                        .disabled(isPreparingBackup || isStartingEmptyStore)
+
+                        if !backupFileURLs.isEmpty {
+                            ShareLink(items: backupFileURLs) {
+                                Label("Sicherung teilen", systemImage: "square.and.arrow.up")
+                            }
+                        }
+                    }
+
+                    Section("Store-Recovery") {
+                        Text("Diese Option entfernt lokale Store-Dateien erst nach deiner Bestätigung und versucht danach einen leeren Neustart.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+
+                        Button(role: .destructive) {
+                            showsDestructiveConfirmation = true
+                        } label: {
+                            Label(isStartingEmptyStore ? "Leerer Store wird erstellt" : "Mit leerem Store starten", systemImage: "trash")
+                        }
+                        .disabled(isPreparingBackup || isStartingEmptyStore)
+                    }
+                }
+
+                if let statusMessage {
+                    Section {
+                        Text(statusMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiTextSecondary)
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.subheadline)
+                            .foregroundStyle(AppTheme.symiCoral)
+                    }
+                }
+            }
+            .navigationTitle("Safe-Mode")
+            .brandGroupedScreen()
+            .confirmationDialog(
+                "Lokale Store-Dateien löschen?",
+                isPresented: $showsDestructiveConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Store-Dateien löschen und leer starten", role: .destructive) {
+                    startWithEmptyStore()
+                }
+                Button("Abbrechen", role: .cancel) {}
+            } message: {
+                Text("Diese Aktion löscht den lokalen SwiftData-Store auf diesem Gerät. Sichere die Store-Dateien vorher, wenn du sie später wiederherstellen möchtest.")
+            }
+        }
+    }
+
+    private func prepareBackup() {
+        isPreparingBackup = true
+        statusMessage = nil
+        errorMessage = nil
+
+        do {
+            backupFileURLs = try prepareStoreBackup()
+            statusMessage = "Die Store-Dateien wurden für die Sicherung vorbereitet."
+        } catch {
+            errorMessage = userFacingMessage(for: error)
+        }
+
+        isPreparingBackup = false
+    }
+
+    private func startWithEmptyStore() {
+        isStartingEmptyStore = true
+        statusMessage = nil
+        errorMessage = nil
+
+        do {
+            let environment = try startEmptyStore()
+            didRecover(environment)
+        } catch {
+            errorMessage = userFacingMessage(for: error)
+            isStartingEmptyStore = false
+        }
+    }
+
+    private func userFacingMessage(for error: Error) -> String {
+        if let localizedError = error as? LocalizedError, let description = localizedError.errorDescription {
+            return description
+        }
+
+        let nsError = error as NSError
+        return "Der Vorgang konnte nicht abgeschlossen werden. Fehlercode: \(nsError.domain) \(nsError.code)"
     }
 }
 

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -64,10 +64,15 @@ struct SymiApp: App {
     @MainActor
     static func makeAppRuntimeEnvironment(
         launchConfiguration: AppLaunchConfiguration,
-        storeURL overrideStoreURL: URL? = nil
+        storeURL overrideStoreURL: URL? = nil,
+        applicationSupportDirectoryURL: URL? = nil
     ) throws -> AppRuntimeEnvironment {
         let schema = Schema(versionedSchema: SymiSchemaV6.self)
-        let storeURL = overrideStoreURL ?? (launchConfiguration.isRunningTests ? unitTestStoreURL() : defaultStoreURL())
+        let storeURL = try resolvedStoreURL(
+            overrideStoreURL: overrideStoreURL,
+            launchConfiguration: launchConfiguration,
+            applicationSupportDirectoryURL: applicationSupportDirectoryURL
+        )
         let configuration = ModelConfiguration(
             "default",
             schema: schema,
@@ -101,7 +106,7 @@ struct SymiApp: App {
     }
 
     @MainActor
-    private static func makeInitialStartupState(launchConfiguration: AppLaunchConfiguration) -> AppStartupState {
+    static func makeInitialStartupState(launchConfiguration: AppLaunchConfiguration) -> AppStartupState {
         do {
             if launchConfiguration.isScreenshotMode {
                 let environment = try ScreenshotBootstrap.makeEnvironment(seedName: launchConfiguration.screenshotSeedName)
@@ -126,10 +131,26 @@ struct SymiApp: App {
                     )
                 )
             } catch {
-                fatalError("Recovery-Container konnte nicht erstellt werden: \(error)")
+                logger.error("Recovery-Container konnte nicht erstellt werden. Safe-Mode wird angezeigt. Fehler: \(Self.sanitizedSummary(for: error), privacy: .public)")
+                return .safeMode(
+                    AppStartupFailureContext(
+                        reason: .recoveryUnavailable,
+                        errorSummary: sanitizedSummary(for: error),
+                        storeURL: context.storeURL,
+                        recoveryContext: context
+                    )
+                )
             }
         } catch {
-            fatalError("App-Start konnte nicht vorbereitet werden: \(error)")
+            logger.error("App-Start konnte nicht vorbereitet werden. Safe-Mode wird angezeigt. Fehler: \(Self.sanitizedSummary(for: error), privacy: .public)")
+            return .safeMode(
+                AppStartupFailureContext(
+                    reason: .bootstrapFailure,
+                    errorSummary: sanitizedSummary(for: error),
+                    storeURL: nil,
+                    recoveryContext: nil
+                )
+            )
         }
     }
 
@@ -173,9 +194,32 @@ struct SymiApp: App {
         }
     }
 
-    private static func defaultStoreURL() -> URL {
-        let applicationSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+    static func defaultStoreURL(
+        applicationSupportDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        guard let applicationSupportURL = applicationSupportDirectoryURL ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw AppStartupPreparationError.applicationSupportDirectoryUnavailable
+        }
+
+        try fileManager.createDirectory(at: applicationSupportURL, withIntermediateDirectories: true)
         return applicationSupportURL.appending(path: "default.store")
+    }
+
+    private static func resolvedStoreURL(
+        overrideStoreURL: URL?,
+        launchConfiguration: AppLaunchConfiguration,
+        applicationSupportDirectoryURL: URL?
+    ) throws -> URL {
+        if let overrideStoreURL {
+            return overrideStoreURL
+        }
+
+        if launchConfiguration.isRunningTests {
+            return unitTestStoreURL()
+        }
+
+        return try defaultStoreURL(applicationSupportDirectoryURL: applicationSupportDirectoryURL)
     }
 
     private static func unitTestStoreURL() -> URL {
@@ -206,12 +250,18 @@ struct SymiApp: App {
 
         return trimmed
     }
+
+    static func sanitizedSummary(for error: Error) -> String {
+        let nsError = error as NSError
+        return "\(nsError.domain) \(nsError.code)"
+    }
 }
 
 @MainActor
 enum AppStartupState {
     case app(AppRuntimeEnvironment)
     case recovery(StoreRecoveryEnvironment)
+    case safeMode(AppStartupFailureContext)
 }
 
 @MainActor
@@ -275,6 +325,31 @@ private struct AppRootView: View {
                 }
             )
             .modelContainer(environment.fallbackContainer)
+        case .safeMode(let context):
+            StartupSafeModeView(
+                context: context,
+                prepareStoreBackup: {
+                    guard let storeURL = context.storeURL else {
+                        throw PersistentStoreRecoveryFileError.noStoreFilesFound
+                    }
+
+                    return try PersistentStoreRecoveryService.copyStoreFilesForSharing(from: storeURL)
+                },
+                startEmptyStore: {
+                    guard let storeURL = context.storeURL else {
+                        throw PersistentStoreRecoveryFileError.noStoreFilesFound
+                    }
+
+                    try PersistentStoreRecoveryService.removeStoreFilesAfterUserConfirmation(at: storeURL)
+                    return try SymiApp.makeAppRuntimeEnvironment(
+                        launchConfiguration: launchConfiguration,
+                        storeURL: storeURL
+                    )
+                },
+                didRecover: { recoveredEnvironment in
+                    startupState = .app(recoveredEnvironment)
+                }
+            )
         }
     }
 

--- a/SymiTests/PersistentStoreRecoveryTests.swift
+++ b/SymiTests/PersistentStoreRecoveryTests.swift
@@ -82,6 +82,25 @@ struct PersistentStoreRecoveryTests {
         #expect(try Data(contentsOf: walURL) == walData)
         #expect(backupURLs.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
     }
+
+    @Test
+    func applicationSupportDirectoryFailureDoesNotReachContainerStartup() throws {
+        let directory = try makeTemporaryDirectory()
+        let blockedApplicationSupportURL = directory.appending(path: "ApplicationSupport")
+        try Data("keine Schreibrechte auf Verzeichnis-Ebene".utf8).write(to: blockedApplicationSupportURL)
+        let launchConfiguration = AppLaunchConfiguration(arguments: [], environment: [:])
+
+        do {
+            _ = try SymiApp.makeAppRuntimeEnvironment(
+                launchConfiguration: launchConfiguration,
+                applicationSupportDirectoryURL: blockedApplicationSupportURL
+            )
+            Issue.record("Ein nicht nutzbares Application-Support-Ziel darf nicht in den normalen App-Start laufen.")
+        } catch {
+            let nsError = error as NSError
+            #expect(nsError.domain == NSCocoaErrorDomain)
+        }
+    }
 }
 
 private func makeTemporaryDirectory() throws -> URL {

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -6,6 +6,26 @@ import Testing
 
 struct SyncMergeEngineTests {
     @Test
+    func corruptSyncStateFileStartsWithCleanStateAndCanPersistAgain() async throws {
+        let baseDirectory = try makeTemporaryDirectory()
+        let syncDirectory = baseDirectory.appendingPathComponent("Symi", isDirectory: true)
+        try FileManager.default.createDirectory(at: syncDirectory, withIntermediateDirectories: true)
+        let syncStateURL = syncDirectory.appendingPathComponent("sync-state.json")
+        try Data("{ keine gültige Sync-State-Datei".utf8).write(to: syncStateURL)
+
+        let stateStore = SyncStateStore(baseDirectoryURL: baseDirectory)
+
+        #expect(await stateStore.syncEnabled() == false)
+
+        await stateStore.setSyncEnabled(true)
+        let persistedData = try Data(contentsOf: syncStateURL)
+        let persistedObject = try #require(
+            JSONSerialization.jsonObject(with: persistedData) as? [String: Any]
+        )
+        #expect(persistedObject["syncEnabled"] as? Bool == true)
+    }
+
+    @Test
     @MainActor
     func corruptRecordSystemFieldsPrepareFreshRecordWithoutCrashing() throws {
         let envelope = definitionEnvelope(name: "Sumatriptan", deletedAt: nil)


### PR DESCRIPTION
## Zusammenfassung
- ersetzt die letzten produktiven Startup-`fatalError`-Pfade durch einen Safe-Mode
- ergänzt Diagnose, Store-Sicherung und Store-Recovery ohne ModelContainer-Abhängigkeit
- deckt defektes Application-Support-Ziel und kaputte Sync-State-Dateien mit Tests ab

## Tests
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #217
