### PR TITLE
Stabilize persisted enum keys

### DIFF
--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -1520,6 +1520,16 @@
         }
       }
     },
+    "Erwartet" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expected"
+          }
+        }
+      }
+    },
     "Export" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2354,6 +2364,16 @@
     "Nicht ausgewählt" : {
 
     },
+    "Nicht angegeben" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not specified"
+          }
+        }
+      }
+    },
     "Noch kein Eintrag für diesen Tag." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2405,6 +2425,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "NSAID"
+          }
+        }
+      }
+    },
+    "Nein" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
           }
         }
       }
@@ -2576,6 +2606,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PDF"
+          }
+        }
+      }
+    },
+    "Paracetamol" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acetaminophen"
           }
         }
       }
@@ -3175,6 +3215,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Triggers"
+          }
+        }
+      }
+    },
+    "Triptan" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Triptan"
           }
         }
       }

--- a/Symi/Sources/App/StartupMaintenanceService.swift
+++ b/Symi/Sources/App/StartupMaintenanceService.swift
@@ -30,6 +30,7 @@ final class StartupMaintenanceService {
             }
 
             await Task.detached(priority: .utility) {
+                try? Self.normalizePersistentEnumValues(in: modelContainer)
                 MedicationCatalog.importSeedDataIfNeeded(into: modelContainer)
             }.value
 
@@ -44,5 +45,52 @@ final class StartupMaintenanceService {
 
     deinit {
         maintenanceTask?.cancel()
+    }
+
+    nonisolated static func normalizePersistentEnumValues(in modelContainer: ModelContainer) throws {
+        let context = ModelContext(modelContainer)
+        var didChange = false
+
+        let episodes = try context.fetch(FetchDescriptor<Episode>())
+        for episode in episodes {
+            let normalizedType = EpisodeType(storageValue: episode.typeRaw).rawValue
+            if episode.typeRaw != normalizedType {
+                episode.typeRaw = normalizedType
+                didChange = true
+            }
+
+            let normalizedMenstruationStatus = MenstruationStatus(storageValue: episode.menstruationStatusRaw).rawValue
+            if episode.menstruationStatusRaw != normalizedMenstruationStatus {
+                episode.menstruationStatusRaw = normalizedMenstruationStatus
+                didChange = true
+            }
+
+            for medication in episode.medications {
+                let normalizedCategory = MedicationCategory(storageValue: medication.categoryRaw).rawValue
+                if medication.categoryRaw != normalizedCategory {
+                    medication.categoryRaw = normalizedCategory
+                    didChange = true
+                }
+
+                let normalizedEffectiveness = MedicationEffectiveness(storageValue: medication.effectivenessRaw).rawValue
+                if medication.effectivenessRaw != normalizedEffectiveness {
+                    medication.effectivenessRaw = normalizedEffectiveness
+                    didChange = true
+                }
+            }
+        }
+
+        let definitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
+        for definition in definitions {
+            let normalizedCategory = MedicationCategory(storageValue: definition.categoryRaw).rawValue
+            if definition.categoryRaw != normalizedCategory {
+                definition.categoryRaw = normalizedCategory
+                didChange = true
+            }
+        }
+
+        if didChange {
+            try context.save()
+        }
     }
 }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -720,7 +720,7 @@ private struct EntryReviewStepView: View {
             lines.append("Gefühl: \(feeling)")
         }
         if draft.menstruationStatus != .unknown {
-            lines.append("Regel: \(draft.menstruationStatus.rawValue)")
+            lines.append("Regel: \(draft.menstruationStatus.displayName)")
         }
 
         return lines

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -159,7 +159,7 @@ private struct EpisodeScaleSection: View {
         Section {
             Picker("Typ", selection: $draft.type) {
                 ForEach(EpisodeType.allCases) { episodeType in
-                    Text(episodeType.rawValue).tag(episodeType)
+                    Text(episodeType.displayName).tag(episodeType)
                 }
             }
             .pickerStyle(.segmented)
@@ -253,7 +253,7 @@ private struct EpisodeOptionalDetailsSection: View {
 
                 Picker("Menstruationsstatus", selection: $draft.menstruationStatus) {
                     ForEach(MenstruationStatus.allCases) { status in
-                        Text(status.rawValue).tag(status)
+                        Text(status.displayName).tag(status)
                     }
                 }
 
@@ -652,7 +652,7 @@ struct CustomMedicationEditorSheet: View {
 
                 Picker("Kategorie", selection: $category) {
                     ForEach(MedicationCategory.allCases) { item in
-                        Text(item.rawValue).tag(item)
+                        Text(item.displayName).tag(item)
                     }
                 }
 

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -683,7 +683,7 @@ private struct ManageCloudDataView: View {
                         HStack {
                             VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                                 Text(episode.startedAt.formatted(date: .abbreviated, time: .shortened))
-                                Text(episode.type.rawValue)
+                                Text(episode.type.displayName)
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)
                             }
@@ -699,7 +699,7 @@ private struct ManageCloudDataView: View {
                         HStack {
                             VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                                 Text(definition.name)
-                                Text(definition.category.rawValue)
+                                Text(definition.category.displayName)
                                     .font(.subheadline)
                                     .foregroundStyle(.secondary)
                             }

--- a/Symi/Sources/Features/Export/PDFExportWriter.swift
+++ b/Symi/Sources/Features/Export/PDFExportWriter.swift
@@ -127,7 +127,7 @@ nonisolated enum PDFExportWriter {
             lines.append(formatted("Schmerzcharakter: %@", record.painCharacter))
         }
 
-        if record.menstruationStatus != MenstruationStatus.unknown.rawValue {
+        if record.menstruationStatus != MenstruationStatus.unknown.displayName {
             lines.append(formatted("Menstruationsstatus: %@", localizedExportValue(record.menstruationStatus)))
         }
 
@@ -148,7 +148,7 @@ nonisolated enum PDFExportWriter {
                 let category = localizedExportValue(medication.category)
                 let dosageText = medication.dosage.isEmpty ? category : "\(category), \(medication.dosage)"
                 let quantityText = medication.quantity > 1 ? formatted(", Anzahl: %lld", Int64(medication.quantity)) : ""
-                let effectivenessText = medication.effectiveness == MedicationEffectiveness.partial.rawValue
+                let effectivenessText = medication.effectiveness == MedicationEffectiveness.partial.displayName
                     ? ""
                     : formatted(", Wirkung: %@", localizedExportValue(medication.effectiveness))
                 return "\(medication.name) (\(dosageText)\(quantityText)\(effectivenessText))"
@@ -322,22 +322,36 @@ nonisolated enum PDFExportWriter {
 
     private static func localizedExportValue(_ value: String) -> String {
         switch value {
-        case EpisodeType.migraine.rawValue,
-            EpisodeType.headache.rawValue,
-            EpisodeType.unclear.rawValue,
-            MedicationCategory.triptan.rawValue,
-            MedicationCategory.nsar.rawValue,
-            MedicationCategory.paracetamol.rawValue,
-            MedicationCategory.antiemetic.rawValue,
-            MedicationCategory.other.rawValue,
-            MenstruationStatus.unknown.rawValue,
-            MenstruationStatus.none.rawValue,
-            MenstruationStatus.active.rawValue,
-            MenstruationStatus.expected.rawValue,
-            MedicationEffectiveness.none.rawValue,
-            MedicationEffectiveness.partial.rawValue,
-            MedicationEffectiveness.good.rawValue:
-            return localized(value)
+        case EpisodeType.migraine.rawValue, "Migräne":
+            return EpisodeType.migraine.displayName
+        case EpisodeType.headache.rawValue, "Kopfschmerz":
+            return EpisodeType.headache.displayName
+        case EpisodeType.unclear.rawValue, "Unklar":
+            return EpisodeType.unclear.displayName
+        case MedicationCategory.triptan.rawValue, "Triptan":
+            return MedicationCategory.triptan.displayName
+        case MedicationCategory.nsar.rawValue, "nsar", "NSAR":
+            return MedicationCategory.nsar.displayName
+        case MedicationCategory.paracetamol.rawValue, "Paracetamol":
+            return MedicationCategory.paracetamol.displayName
+        case MedicationCategory.antiemetic.rawValue, "Antiemetikum":
+            return MedicationCategory.antiemetic.displayName
+        case MedicationCategory.other.rawValue, "Sonstiges":
+            return MedicationCategory.other.displayName
+        case MenstruationStatus.unknown.rawValue, "Nicht angegeben":
+            return MenstruationStatus.unknown.displayName
+        case MenstruationStatus.none.rawValue, "Nein":
+            return MenstruationStatus.none.displayName
+        case MenstruationStatus.active.rawValue, "Aktuell":
+            return MenstruationStatus.active.displayName
+        case MenstruationStatus.expected.rawValue, "Erwartet":
+            return MenstruationStatus.expected.displayName
+        case MedicationEffectiveness.none.rawValue, "Keine":
+            return MedicationEffectiveness.none.displayName
+        case MedicationEffectiveness.partial.rawValue, "Teilweise":
+            return MedicationEffectiveness.partial.displayName
+        case MedicationEffectiveness.good.rawValue, "Gut":
+            return MedicationEffectiveness.good.displayName
         default:
             return value
         }

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -56,7 +56,7 @@ struct LocalSyncRepository {
             endedAt: payload.endedAt,
             updatedAt: envelope.modifiedAt,
             deletedAt: envelope.deletedAt,
-            type: EpisodeType(rawValue: payload.type) ?? .unclear,
+            type: EpisodeType(storageValue: payload.type),
             intensity: payload.intensity
         )
 
@@ -64,7 +64,7 @@ struct LocalSyncRepository {
         target.endedAt = payload.endedAt
         target.updatedAt = envelope.modifiedAt
         target.deletedAt = envelope.deletedAt
-        target.type = EpisodeType(rawValue: payload.type) ?? .unclear
+        target.type = EpisodeType(storageValue: payload.type)
         target.intensity = payload.intensity
         target.painLocation = payload.painLocation
         target.painCharacter = payload.painCharacter
@@ -72,7 +72,7 @@ struct LocalSyncRepository {
         target.symptoms = payload.symptoms
         target.triggers = payload.triggers
         target.functionalImpact = payload.functionalImpact
-        target.menstruationStatus = MenstruationStatus(rawValue: payload.menstruationStatus) ?? .unknown
+        target.menstruationStatus = MenstruationStatus(storageValue: payload.menstruationStatus)
 
         for medication in target.medications {
             context.delete(medication)
@@ -91,11 +91,11 @@ struct LocalSyncRepository {
             MedicationEntry(
                 id: UUID(uuidString: medication.id) ?? UUID(),
                 name: medication.name,
-                category: MedicationCategory(rawValue: medication.category) ?? .other,
+                category: MedicationCategory(storageValue: medication.category),
                 dosage: medication.dosage,
                 quantity: medication.quantity,
                 takenAt: medication.takenAt,
-                effectiveness: MedicationEffectiveness(rawValue: medication.effectiveness) ?? .partial,
+                effectiveness: MedicationEffectiveness(storageValue: medication.effectiveness),
                 reliefStartedAt: medication.reliefStartedAt,
                 isRepeatDose: medication.isRepeatDose,
                 episode: target
@@ -153,7 +153,7 @@ struct LocalSyncRepository {
             groupTitle: payload.groupTitle,
             groupFooter: payload.groupFooter,
             name: payload.name,
-            category: MedicationCategory(rawValue: payload.category) ?? .other,
+            category: MedicationCategory(storageValue: payload.category),
             suggestedDosage: payload.suggestedDosage,
             sortOrder: payload.sortOrder,
             isCustom: payload.isCustom,
@@ -166,7 +166,7 @@ struct LocalSyncRepository {
         target.groupTitle = payload.groupTitle
         target.groupFooter = payload.groupFooter
         target.name = payload.name
-        target.category = MedicationCategory(rawValue: payload.category) ?? .other
+        target.category = MedicationCategory(storageValue: payload.category)
         target.suggestedDosage = payload.suggestedDosage
         target.sortOrder = payload.sortOrder
         target.isCustom = payload.isCustom

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -1,38 +1,166 @@
 import Foundation
 
 enum EpisodeType: String, CaseIterable, Codable, Identifiable {
-    case migraine = "Migräne"
-    case headache = "Kopfschmerz"
-    case unclear = "Unklar"
+    case migraine = "migraine"
+    case headache = "headache"
+    case unclear = "unclear"
 
-    var id: String { rawValue }
+    nonisolated var id: String { rawValue }
+
+    nonisolated var displayName: String {
+        switch self {
+        case .migraine:
+            String(localized: "Migräne")
+        case .headache:
+            String(localized: "Kopfschmerz")
+        case .unclear:
+            String(localized: "Unklar")
+        }
+    }
+
+    nonisolated init(storageValue: String) {
+        switch storageValue {
+        case Self.migraine.rawValue, "Migräne":
+            self = .migraine
+        case Self.headache.rawValue, "Kopfschmerz":
+            self = .headache
+        case Self.unclear.rawValue, "Unklar":
+            self = .unclear
+        default:
+            self = .unclear
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(storageValue: try container.decode(String.self))
+    }
 }
 
 enum MenstruationStatus: String, CaseIterable, Codable, Identifiable {
-    case unknown = "Nicht angegeben"
-    case none = "Nein"
-    case active = "Aktuell"
-    case expected = "Erwartet"
+    case unknown = "unknown"
+    case none = "none"
+    case active = "active"
+    case expected = "expected"
 
-    var id: String { rawValue }
+    nonisolated var id: String { rawValue }
+
+    nonisolated var displayName: String {
+        switch self {
+        case .unknown:
+            String(localized: "Nicht angegeben")
+        case .none:
+            String(localized: "Nein")
+        case .active:
+            String(localized: "Aktuell")
+        case .expected:
+            String(localized: "Erwartet")
+        }
+    }
+
+    nonisolated init(storageValue: String) {
+        switch storageValue {
+        case Self.unknown.rawValue, "Nicht angegeben":
+            self = .unknown
+        case Self.none.rawValue, "Nein":
+            self = .none
+        case Self.active.rawValue, "Aktuell":
+            self = .active
+        case Self.expected.rawValue, "Erwartet":
+            self = .expected
+        default:
+            self = .unknown
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(storageValue: try container.decode(String.self))
+    }
 }
 
 enum MedicationCategory: String, CaseIterable, Codable, Identifiable {
-    case triptan = "Triptan"
-    case nsar = "NSAR"
-    case paracetamol = "Paracetamol"
-    case antiemetic = "Antiemetikum"
-    case other = "Sonstiges"
+    case triptan = "triptan"
+    case nsar = "nsaid"
+    case paracetamol = "paracetamol"
+    case antiemetic = "antiemetic"
+    case other = "other"
 
-    var id: String { rawValue }
+    nonisolated var id: String { rawValue }
+
+    nonisolated var displayName: String {
+        switch self {
+        case .triptan:
+            String(localized: "Triptan")
+        case .nsar:
+            String(localized: "NSAR")
+        case .paracetamol:
+            String(localized: "Paracetamol")
+        case .antiemetic:
+            String(localized: "Antiemetikum")
+        case .other:
+            String(localized: "Sonstiges")
+        }
+    }
+
+    nonisolated init(storageValue: String) {
+        switch storageValue {
+        case Self.triptan.rawValue, "Triptan":
+            self = .triptan
+        case Self.nsar.rawValue, "nsar", "NSAR":
+            self = .nsar
+        case Self.paracetamol.rawValue, "Paracetamol":
+            self = .paracetamol
+        case Self.antiemetic.rawValue, "Antiemetikum":
+            self = .antiemetic
+        case Self.other.rawValue, "Sonstiges":
+            self = .other
+        default:
+            self = .other
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(storageValue: try container.decode(String.self))
+    }
 }
 
 enum MedicationEffectiveness: String, CaseIterable, Codable, Identifiable {
-    case none = "Keine"
-    case partial = "Teilweise"
-    case good = "Gut"
+    case none = "none"
+    case partial = "partial"
+    case good = "good"
 
-    var id: String { rawValue }
+    nonisolated var id: String { rawValue }
+
+    nonisolated var displayName: String {
+        switch self {
+        case .none:
+            String(localized: "Keine")
+        case .partial:
+            String(localized: "Teilweise")
+        case .good:
+            String(localized: "Gut")
+        }
+    }
+
+    nonisolated init(storageValue: String) {
+        switch storageValue {
+        case Self.none.rawValue, "Keine":
+            self = .none
+        case Self.partial.rawValue, "Teilweise":
+            self = .partial
+        case Self.good.rawValue, "Gut":
+            self = .good
+        default:
+            self = .partial
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.init(storageValue: try container.decode(String.self))
+    }
 }
 
 struct MedicationTextFormatter {
@@ -94,12 +222,12 @@ extension Episode {
     }
 
     var type: EpisodeType {
-        get { EpisodeType(rawValue: typeRaw) ?? .unclear }
+        get { EpisodeType(storageValue: typeRaw) }
         set { typeRaw = newValue.rawValue }
     }
 
     var menstruationStatus: MenstruationStatus {
-        get { MenstruationStatus(rawValue: menstruationStatusRaw) ?? .unknown }
+        get { MenstruationStatus(storageValue: menstruationStatusRaw) }
         set { menstruationStatusRaw = newValue.rawValue }
     }
 
@@ -191,12 +319,12 @@ extension MedicationEntry {
     }
 
     var category: MedicationCategory {
-        get { MedicationCategory(rawValue: categoryRaw) ?? .other }
+        get { MedicationCategory(storageValue: categoryRaw) }
         set { categoryRaw = newValue.rawValue }
     }
 
     var effectiveness: MedicationEffectiveness {
-        get { MedicationEffectiveness(rawValue: effectivenessRaw) ?? .partial }
+        get { MedicationEffectiveness(storageValue: effectivenessRaw) }
         set { effectivenessRaw = newValue.rawValue }
     }
 }
@@ -233,7 +361,7 @@ extension MedicationDefinition {
     }
 
     var category: MedicationCategory {
-        get { MedicationCategory(rawValue: categoryRaw) ?? .other }
+        get { MedicationCategory(storageValue: categoryRaw) }
         set { categoryRaw = newValue.rawValue }
     }
 

--- a/Symi/Sources/Models/ExportModels.swift
+++ b/Symi/Sources/Models/ExportModels.swift
@@ -21,11 +21,11 @@ nonisolated struct EpisodeExportRecord: Identifiable, Sendable {
         self.id = episode.id
         self.startedAt = episode.startedAt
         self.endedAt = episode.endedAt
-        self.type = episode.type.rawValue
+        self.type = episode.type.displayName
         self.intensity = episode.intensity
         self.painLocation = episode.painLocation
         self.painCharacter = episode.painCharacter
-        self.menstruationStatus = episode.menstruationStatus.rawValue
+        self.menstruationStatus = episode.menstruationStatus.displayName
         self.symptoms = episode.symptoms
         self.triggers = episode.triggers
         self.notes = episode.notes
@@ -33,10 +33,10 @@ nonisolated struct EpisodeExportRecord: Identifiable, Sendable {
         self.medications = episode.medications.map {
             MedicationLine(
                 name: $0.name,
-                category: $0.category.rawValue,
+                category: $0.category.displayName,
                 dosage: $0.dosage,
                 quantity: $0.quantity,
-                effectiveness: $0.effectiveness.rawValue
+                effectiveness: $0.effectiveness.displayName
             )
         }
         if let weatherSnapshot = episode.weatherSnapshot {

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -303,11 +303,11 @@ struct CoreArchitectureTests {
 
     @Test
     func medicationSelectionKeyNormalizesEmptyWhitespaceAndCombinations() {
-        #expect(MedicationSelectionKey.make(name: "", category: .other, dosage: "") == "|Sonstiges|")
-        #expect(MedicationSelectionKey.make(name: "  ", category: .other, dosage: "\n\t") == "|Sonstiges|")
-        #expect(MedicationSelectionKey.make(name: " Sumatriptan ", category: .triptan, dosage: "") == "sumatriptan|Triptan|")
-        #expect(MedicationSelectionKey.make(name: "", category: .nsar, dosage: " 400 MG ") == "|NSAR|400 mg")
-        #expect(MedicationSelectionKey.make(name: " IBUprofen ", category: .nsar, dosage: " 400 MG ") == "ibuprofen|NSAR|400 mg")
+        #expect(MedicationSelectionKey.make(name: "", category: .other, dosage: "") == "|other|")
+        #expect(MedicationSelectionKey.make(name: "  ", category: .other, dosage: "\n\t") == "|other|")
+        #expect(MedicationSelectionKey.make(name: " Sumatriptan ", category: .triptan, dosage: "") == "sumatriptan|triptan|")
+        #expect(MedicationSelectionKey.make(name: "", category: .nsar, dosage: " 400 MG ") == "|nsaid|400 mg")
+        #expect(MedicationSelectionKey.make(name: " IBUprofen ", category: .nsar, dosage: " 400 MG ") == "ibuprofen|nsaid|400 mg")
     }
 
     @Test

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -49,6 +49,36 @@ struct DataTransferHealthContextTests {
     }
 
     @Test
+    func backupUsesStableEnumKeysAndImportsLegacyGermanValues() throws {
+        let episodeID = UUID(uuidString: "33333333-4444-5555-6666-777777777777")!
+        let sourceContainer = try makeInMemoryContainer()
+        try seedEpisode(id: episodeID, in: sourceContainer)
+
+        let backupURL = try SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        ).createBackup()
+        let backupText = try String(contentsOf: backupURL, encoding: .utf8)
+        #expect(backupText.contains(#""type" : "migraine""#))
+        #expect(backupText.contains(#""menstruationStatus" : "none""#))
+        #expect(backupText.contains(#""category" : "triptan""#))
+        #expect(backupText.contains(#""effectiveness" : "good""#))
+
+        let legacyBackupURL = try makeLegacyGermanBackupURL(episodeID: episodeID)
+        let targetContainer = try makeInMemoryContainer()
+        try SwiftDataExportRepository(
+            modelContainer: targetContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        ).importBackup(from: legacyBackupURL)
+
+        let importedEpisode = try #require(try ModelContext(targetContainer).fetch(FetchDescriptor<Episode>()).first)
+        #expect(importedEpisode.typeRaw == "migraine")
+        #expect(importedEpisode.menstruationStatusRaw == "none")
+        #expect(importedEpisode.medications.first?.categoryRaw == "triptan")
+        #expect(importedEpisode.medications.first?.effectivenessRaw == "good")
+    }
+
+    @Test
     func importWithoutHealthContextKeyKeepsExistingContext() throws {
         let episodeID = UUID()
         let existingHealthContext = makeHealthContext(source: "Bestehender Kontext")
@@ -267,6 +297,48 @@ private func backupURLByAddingExplicitNullHealthContext(to backupURL: URL) throw
     let explicitNullData = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
     let url = try makeTemporaryDirectory().appending(path: "explicit-null-health-context.json5")
     try explicitNullData.write(to: url, options: .atomic)
+    return url
+}
+
+private func makeLegacyGermanBackupURL(episodeID: UUID) throws -> URL {
+    let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let payload: [String: Any] = [
+        "formatVersion": 1,
+        "exportedAt": ISO8601DateFormatter().string(from: startedAt),
+        "customMedicationDefinitions": [],
+        "continuousMedications": [],
+        "episodes": [
+            [
+                "id": episodeID.uuidString,
+                "startedAt": ISO8601DateFormatter().string(from: startedAt),
+                "updatedAt": ISO8601DateFormatter().string(from: startedAt.addingTimeInterval(60)),
+                "type": "Migräne",
+                "intensity": 7,
+                "painLocation": "",
+                "painCharacter": "",
+                "notes": "",
+                "symptoms": [],
+                "triggers": [],
+                "functionalImpact": "",
+                "menstruationStatus": "Nein",
+                "medications": [
+                    [
+                        "id": UUID().uuidString,
+                        "name": "Sumatriptan",
+                        "category": "Triptan",
+                        "dosage": "50 mg",
+                        "quantity": 1,
+                        "takenAt": ISO8601DateFormatter().string(from: startedAt.addingTimeInterval(900)),
+                        "effectiveness": "Gut",
+                        "isRepeatDose": false
+                    ]
+                ]
+            ]
+        ]
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    let url = FileManager.default.temporaryDirectory.appending(path: "legacy-\(UUID().uuidString).json5")
+    try data.write(to: url)
     return url
 }
 

--- a/SymiTests/SwiftDataMigrationTests.swift
+++ b/SymiTests/SwiftDataMigrationTests.swift
@@ -166,6 +166,53 @@ struct SwiftDataMigrationTests {
         #expect(episode.continuousMedicationChecks.isEmpty)
         #expect(try context.fetch(FetchDescriptor<ContinuousMedication>()).isEmpty)
     }
+
+    @Test
+    func normalizesLegacyGermanEnumValuesInCurrentStore() throws {
+        let container = try makeCurrentContainer(storeURL: try makeStoreURL())
+        let context = ModelContext(container)
+        let startedAt = Date(timeIntervalSince1970: 1_730_000_000)
+        let episode = Episode(
+            startedAt: startedAt,
+            typeRaw: "Migräne",
+            intensity: 6,
+            menstruationStatusRaw: "Nein"
+        )
+        episode.medications = [
+            MedicationEntry(
+                name: "Sumatriptan",
+                categoryRaw: "Triptan",
+                dosage: "50 mg",
+                takenAt: startedAt,
+                effectivenessRaw: "Gut",
+                episode: episode
+            )
+        ]
+        let definition = MedicationDefinition(
+            catalogKey: "custom:legacy",
+            groupID: "custom",
+            groupTitle: "Eigene Medikamente",
+            name: "Ibuprofen",
+            categoryRaw: "NSAR",
+            suggestedDosage: "400 mg",
+            sortOrder: 0,
+            isCustom: true
+        )
+        context.insert(episode)
+        context.insert(definition)
+        try context.save()
+
+        try StartupMaintenanceService.normalizePersistentEnumValues(in: container)
+
+        let migratedContext = ModelContext(container)
+        let migratedEpisode = try #require(try migratedContext.fetch(FetchDescriptor<Episode>()).first)
+        let migratedDefinition = try #require(try migratedContext.fetch(FetchDescriptor<MedicationDefinition>()).first)
+        #expect(migratedEpisode.typeRaw == "migraine")
+        #expect(migratedEpisode.menstruationStatusRaw == "none")
+        #expect(migratedEpisode.medications.first?.categoryRaw == "triptan")
+        #expect(migratedEpisode.medications.first?.effectivenessRaw == "good")
+        #expect(migratedDefinition.categoryRaw == "nsaid")
+    }
 }
 
 private func makeStoreURL() throws -> URL {

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -177,6 +177,8 @@ struct SyncMergeEngineTests {
         let episode = try #require(try context.fetch(FetchDescriptor<Episode>()).first { $0.id == episodeID })
         let healthContext = stack.healthContextStore.load(for: episodeID)
 
+        #expect(episode.typeRaw == "migraine")
+        #expect(episode.menstruationStatusRaw == "unknown")
         #expect(episode.continuousMedicationChecks.first?.name == "Magnesium")
         #expect(healthContext?.stepCount == 4_200)
     }


### PR DESCRIPTION
## Summary
- persist stable enum keys for episode, menstruation and medication values
- keep legacy German backup and Cloud payload values importable
- normalize existing SwiftData records during startup maintenance and keep display text localized

## Tests
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath build/CodexDerivedData

Closes mpwg/Symi#218