### PR TITLE
Reject invalid remote sync payloads

### DIFF
--- a/Symi/Sources/Features/Sync/SyncCoordinator.swift
+++ b/Symi/Sources/Features/Sync/SyncCoordinator.swift
@@ -318,6 +318,33 @@ final class SyncCoordinator {
         let localEnvelope = try? repository.envelope(documentID: remoteEnvelope.documentID, deviceID: deviceID)
 
         do {
+            try repository.validate(remote: remoteEnvelope)
+        } catch {
+            await stateStore.setLastError(error.localizedDescription)
+
+            if let localEnvelope {
+                await stateStore.saveConflict(
+                    SyncConflict(
+                        documentID: remoteEnvelope.documentID,
+                        entityType: remoteEnvelope.entityType,
+                        base: shadow?.envelope,
+                        local: localEnvelope,
+                        remote: remoteEnvelope,
+                        conflictingFields: validationFields(from: error)
+                    )
+                )
+            }
+
+            await log(level: .error, operation: "coordinator.applyRemoteRecord.validationFailed", message: "Remote-Record wurde wegen ungültiger Payload abgelehnt.", metadata: [
+                "documentID": remoteEnvelope.documentID,
+                "recordID": record.recordID.recordName,
+                "error": error.localizedDescription
+            ])
+            conflicts = await stateStore.conflicts()
+            return
+        }
+
+        do {
             if let localEnvelope {
                 if localEnvelope == remoteEnvelope {
                     await stateStore.saveShadow(
@@ -566,5 +593,13 @@ final class SyncCoordinator {
         }
 
         return values
+    }
+
+    private func validationFields(from error: any Error) -> [String] {
+        if let validationError = error as? RemoteSyncPayloadValidationError {
+            return validationError.issues
+        }
+
+        return ["payloadValidation"]
     }
 }

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -28,7 +28,13 @@ struct LocalSyncRepository {
         return envelopes.first { $0.documentID == documentID }
     }
 
+    func validate(remote envelope: SyncDocumentEnvelope) throws {
+        try RemoteSyncPayloadValidator.validate(envelope)
+    }
+
     func apply(remote envelope: SyncDocumentEnvelope) throws {
+        try validate(remote: envelope)
+
         let context = ModelContext(modelContainer)
 
         switch envelope.payload {
@@ -48,7 +54,7 @@ struct LocalSyncRepository {
         from envelope: SyncDocumentEnvelope,
         in context: ModelContext
     ) throws {
-        let episodeID = UUID(uuidString: payload.id) ?? UUID()
+        let episodeID = try RemoteSyncPayloadValidator.uuid(payload.id, field: "episode.id")
         let existing = try context.fetch(FetchDescriptor<Episode>()).first { $0.id == episodeID }
         let target = existing ?? Episode(
             id: episodeID,
@@ -87,9 +93,9 @@ struct LocalSyncRepository {
             target.weatherSnapshot = nil
         }
 
-        target.medications = payload.medications.map { medication in
+        target.medications = try payload.medications.map { medication in
             MedicationEntry(
-                id: UUID(uuidString: medication.id) ?? UUID(),
+                id: try RemoteSyncPayloadValidator.uuid(medication.id, field: "episode.medications.id"),
                 name: medication.name,
                 category: MedicationCategory(storageValue: medication.category),
                 dosage: medication.dosage,
@@ -101,10 +107,10 @@ struct LocalSyncRepository {
                 episode: target
             )
         }
-        target.continuousMedicationChecks = payload.continuousMedicationChecks.map { check in
+        target.continuousMedicationChecks = try payload.continuousMedicationChecks.map { check in
             ContinuousMedicationCheck(
-                id: UUID(uuidString: check.id) ?? UUID(),
-                continuousMedicationID: UUID(uuidString: check.continuousMedicationID) ?? UUID(),
+                id: try RemoteSyncPayloadValidator.uuid(check.id, field: "episode.continuousMedicationChecks.id"),
+                continuousMedicationID: try RemoteSyncPayloadValidator.uuid(check.continuousMedicationID, field: "episode.continuousMedicationChecks.continuousMedicationID"),
                 name: check.name,
                 dosage: check.dosage,
                 frequency: check.frequency,
@@ -112,9 +118,9 @@ struct LocalSyncRepository {
                 episode: target
             )
         }
-        target.weatherSnapshot = payload.weatherSnapshot.map { weather in
-            WeatherSnapshot(
-                id: UUID(uuidString: weather.id) ?? UUID(),
+        if let weather = payload.weatherSnapshot {
+            target.weatherSnapshot = WeatherSnapshot(
+                id: try RemoteSyncPayloadValidator.uuid(weather.id, field: "episode.weatherSnapshot.id"),
                 recordedAt: weather.recordedAt,
                 temperature: weather.temperature,
                 condition: weather.condition,
@@ -130,6 +136,8 @@ struct LocalSyncRepository {
                 contextPointsStorage: WeatherSnapshot.encodeContextPoints(weather.contextPoints),
                 episode: target
             )
+        } else {
+            target.weatherSnapshot = nil
         }
 
         if existing == nil {
@@ -184,7 +192,7 @@ struct LocalSyncRepository {
         from envelope: SyncDocumentEnvelope,
         in context: ModelContext
     ) throws {
-        let medicationID = UUID(uuidString: payload.id) ?? UUID()
+        let medicationID = try RemoteSyncPayloadValidator.uuid(payload.id, field: "continuousMedication.id")
         let existing = try context.fetch(FetchDescriptor<ContinuousMedication>()).first { $0.id == medicationID }
         let target = existing ?? ContinuousMedication(
             id: medicationID,
@@ -209,6 +217,154 @@ struct LocalSyncRepository {
             context.insert(target)
         }
     }
+}
+
+enum RemoteSyncPayloadValidationError: LocalizedError, Equatable {
+    case invalidPayload(documentID: String, issues: [String])
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPayload(let documentID, let issues):
+            "Remote-Payload \(documentID) ist ungültig: \(issues.joined(separator: ", "))"
+        }
+    }
+
+    var issues: [String] {
+        switch self {
+        case .invalidPayload(_, let issues):
+            issues
+        }
+    }
+}
+
+enum RemoteSyncPayloadValidator {
+    static func validate(_ envelope: SyncDocumentEnvelope) throws {
+        let issues = validationIssues(for: envelope)
+        guard issues.isEmpty else {
+            throw RemoteSyncPayloadValidationError.invalidPayload(
+                documentID: envelope.documentID,
+                issues: issues
+            )
+        }
+    }
+
+    static func uuid(_ value: String, field: String) throws -> UUID {
+        guard let id = UUID(uuidString: value) else {
+            throw RemoteSyncPayloadValidationError.invalidPayload(
+                documentID: field,
+                issues: ["\(field) ist keine gültige UUID"]
+            )
+        }
+
+        return id
+    }
+
+    private static func validationIssues(for envelope: SyncDocumentEnvelope) -> [String] {
+        var issues: [String] = []
+
+        switch envelope.payload {
+        case .episode(let payload):
+            validateUUID(payload.id, field: "episode.id", into: &issues)
+            validateDocumentID(envelope.documentID, expectedPrefix: "episode", payloadID: payload.id, into: &issues)
+            validateKnownValue(payload.type, field: "episode.type", allowedValues: episodeTypeValues, into: &issues)
+            validateKnownValue(payload.menstruationStatus, field: "episode.menstruationStatus", allowedValues: menstruationStatusValues, into: &issues)
+
+            for (index, medication) in payload.medications.enumerated() {
+                validateUUID(medication.id, field: "episode.medications[\(index)].id", into: &issues)
+                validateKnownValue(medication.category, field: "episode.medications[\(index)].category", allowedValues: medicationCategoryValues, into: &issues)
+                validateKnownValue(medication.effectiveness, field: "episode.medications[\(index)].effectiveness", allowedValues: medicationEffectivenessValues, into: &issues)
+            }
+
+            for (index, check) in payload.continuousMedicationChecks.enumerated() {
+                validateUUID(check.id, field: "episode.continuousMedicationChecks[\(index)].id", into: &issues)
+                validateUUID(check.continuousMedicationID, field: "episode.continuousMedicationChecks[\(index)].continuousMedicationID", into: &issues)
+            }
+
+            if let weatherSnapshot = payload.weatherSnapshot {
+                validateUUID(weatherSnapshot.id, field: "episode.weatherSnapshot.id", into: &issues)
+            }
+        case .medicationDefinition(let payload):
+            validateDocumentID(envelope.documentID, expectedPrefix: "medicationDefinition", payloadID: payload.catalogKey, into: &issues)
+            validateKnownValue(payload.category, field: "medicationDefinition.category", allowedValues: medicationCategoryValues, into: &issues)
+        case .continuousMedication(let payload):
+            validateUUID(payload.id, field: "continuousMedication.id", into: &issues)
+            validateDocumentID(envelope.documentID, expectedPrefix: "continuousMedication", payloadID: payload.id, into: &issues)
+        }
+
+        return issues
+    }
+
+    private static func validateUUID(_ value: String, field: String, into issues: inout [String]) {
+        if UUID(uuidString: value) == nil {
+            issues.append("\(field) ist keine gültige UUID")
+        }
+    }
+
+    private static func validateDocumentID(
+        _ documentID: String,
+        expectedPrefix: String,
+        payloadID: String,
+        into issues: inout [String]
+    ) {
+        let expectedDocumentID = "\(expectedPrefix):\(payloadID)"
+        if documentID != expectedDocumentID {
+            issues.append("documentID passt nicht zu \(expectedPrefix).id")
+        }
+    }
+
+    private static func validateKnownValue(
+        _ value: String,
+        field: String,
+        allowedValues: Set<String>,
+        into issues: inout [String]
+    ) {
+        if !allowedValues.contains(value) {
+            issues.append("\(field) enthält einen unbekannten Wert")
+        }
+    }
+
+    private static let episodeTypeValues: Set<String> = [
+        EpisodeType.migraine.rawValue,
+        EpisodeType.headache.rawValue,
+        EpisodeType.unclear.rawValue,
+        "Migräne",
+        "Kopfschmerz",
+        "Unklar"
+    ]
+
+    private static let menstruationStatusValues: Set<String> = [
+        MenstruationStatus.unknown.rawValue,
+        MenstruationStatus.none.rawValue,
+        MenstruationStatus.active.rawValue,
+        MenstruationStatus.expected.rawValue,
+        "Nicht angegeben",
+        "Nein",
+        "Aktuell",
+        "Erwartet"
+    ]
+
+    private static let medicationCategoryValues: Set<String> = [
+        MedicationCategory.triptan.rawValue,
+        MedicationCategory.nsar.rawValue,
+        MedicationCategory.paracetamol.rawValue,
+        MedicationCategory.antiemetic.rawValue,
+        MedicationCategory.other.rawValue,
+        "Triptan",
+        "nsar",
+        "NSAR",
+        "Paracetamol",
+        "Antiemetikum",
+        "Sonstiges"
+    ]
+
+    private static let medicationEffectivenessValues: Set<String> = [
+        MedicationEffectiveness.none.rawValue,
+        MedicationEffectiveness.partial.rawValue,
+        MedicationEffectiveness.good.rawValue,
+        "Keine",
+        "Teilweise",
+        "Gut"
+    ]
 }
 
 extension Episode {

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -185,6 +185,70 @@ struct SyncMergeEngineTests {
 
     @Test
     @MainActor
+    func invalidRemoteEpisodeIDIsRejectedWithoutCreatingLocalEpisode() async throws {
+        let stack = try makeSyncTestStack()
+        let remoteEnvelope = SyncDocumentEnvelope(
+            documentID: "episode:defekt",
+            entityType: .episode,
+            modifiedAt: Date(timeIntervalSince1970: 2_000),
+            authorDeviceID: "device-remote",
+            payload: .episode(
+                SyncEpisodePayload(
+                    id: "defekt",
+                    startedAt: Date(timeIntervalSince1970: 1_000),
+                    endedAt: nil,
+                    type: EpisodeType.migraine.rawValue,
+                    intensity: 6,
+                    painLocation: "",
+                    painCharacter: "",
+                    notes: "remote",
+                    symptoms: [],
+                    triggers: [],
+                    functionalImpact: "",
+                    menstruationStatus: MenstruationStatus.unknown.rawValue,
+                    medications: [],
+                    weatherSnapshot: nil
+                )
+            )
+        )
+
+        await stack.coordinator.applyRemoteRecord(try record(from: remoteEnvelope))
+
+        let context = ModelContext(stack.container)
+        let episodes = try context.fetch(FetchDescriptor<Episode>())
+        let conflicts = await stack.stateStore.conflicts()
+        let lastError = await stack.stateStore.lastError()
+
+        #expect(episodes.isEmpty)
+        #expect(conflicts.isEmpty)
+        #expect(lastError?.contains("episode.id ist keine gültige UUID") == true)
+    }
+
+    @Test
+    @MainActor
+    func invalidRemoteEnumValueCreatesConflictForExistingLocalDocument() async throws {
+        let stack = try makeSyncTestStack()
+        let documentID = try insertBaseEpisode(in: stack.container)
+        let baseEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        await stack.stateStore.saveShadow(SyncShadow(envelope: baseEnvelope), for: documentID)
+        let remoteEnvelope = episodeEnvelope(from: baseEnvelope, modifiedAt: Date(timeIntervalSince1970: 3_000)) { payload in
+            payload.type = "cluster"
+        }
+
+        await stack.coordinator.applyRemoteRecord(try record(from: remoteEnvelope))
+
+        let storedEnvelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        let conflict = try #require(await stack.stateStore.conflicts().first)
+        let lastError = await stack.stateStore.lastError()
+
+        #expect(storedEnvelope == baseEnvelope)
+        #expect(conflict.remote == remoteEnvelope)
+        #expect(conflict.conflictingFields == ["episode.type enthält einen unbekannten Wert"])
+        #expect(lastError?.contains("episode.type enthält einen unbekannten Wert") == true)
+    }
+
+    @Test
+    @MainActor
     func conflictRemoteMergeLeavesLocalStateUntouchedUntilResolution() async throws {
         let stack = try makeSyncTestStack()
         let documentID = try insertBaseEpisode(in: stack.container)


### PR DESCRIPTION
## Summary
- validate remote sync payload UUIDs, document IDs, and enum-like values before merge/apply
- reject invalid remote-only records with a visible sync error instead of creating replacement IDs
- store invalid updates for existing local documents as conflicts so the local state stays unchanged
- add negative SyncMergeEngine tests for invalid remote UUIDs and unknown enum values

## Validation
- `xcodebuild test -scheme SymiTests -project Symi.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SymiTests/SyncMergeEngineTests`
- `xcodebuild test -scheme SymiTests -project Symi.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #220