### PR TITLE
Harden CloudKit sync envelope strategy

### DIFF
--- a/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
+++ b/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
@@ -286,7 +286,10 @@ enum CloudKitRecordCodec {
             recordID: recordID
         )
 
-        guard let data = try? encoder.encode(envelope), let payloadString = String(data: data, encoding: .utf8) else {
+        guard
+            let data = try? encodedPayloadData(for: envelope),
+            let payloadString = String(data: data, encoding: .utf8)
+        else {
             return nil
         }
 
@@ -310,7 +313,27 @@ enum CloudKitRecordCodec {
             return nil
         }
 
-        return try? decoder.decode(SyncDocumentEnvelope.self, from: data)
+        guard data.count <= SyncPayloadSchema.maximumCloudKitPayloadBytes else {
+            return nil
+        }
+
+        guard let envelope = try? decoder.decode(SyncDocumentEnvelope.self, from: data) else {
+            return nil
+        }
+
+        guard
+            record["documentID"] as? String == envelope.documentID,
+            record["entityType"] as? String == envelope.entityType.rawValue,
+            (record["schemaVersion"] as? NSNumber)?.intValue == envelope.schemaVersion
+        else {
+            return nil
+        }
+
+        return envelope
+    }
+
+    static func payloadByteCount(for envelope: SyncDocumentEnvelope) -> Int? {
+        try? encoder.encode(envelope).count
     }
 
     static func systemFields(for record: CKRecord) -> Data? {
@@ -349,10 +372,23 @@ enum CloudKitRecordCodec {
 
         return (record, nil)
     }
+
+    private static func encodedPayloadData(for envelope: SyncDocumentEnvelope) throws -> Data {
+        let data = try encoder.encode(envelope)
+        guard data.count <= SyncPayloadSchema.maximumCloudKitPayloadBytes else {
+            throw CloudKitRecordCodecError.payloadTooLarge(byteCount: data.count)
+        }
+
+        return data
+    }
 }
 
 enum CloudKitRecordSystemFieldsFallbackReason: String, Equatable, Sendable {
     case undecodableArchive
     case missingRecord
     case recordIDMismatch
+}
+
+private enum CloudKitRecordCodecError: Error {
+    case payloadTooLarge(byteCount: Int)
 }

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -262,6 +262,20 @@ enum RemoteSyncPayloadValidator {
     private static func validationIssues(for envelope: SyncDocumentEnvelope) -> [String] {
         var issues: [String] = []
 
+        if envelope.entityType != envelope.payload.entityType {
+            issues.append("entityType passt nicht zur Payload")
+        }
+
+        if !SyncPayloadSchema.supports(envelope.schemaVersion, for: envelope.entityType) {
+            let supportedVersions = SyncPayloadSchema.supportedVersions(for: envelope.entityType)
+            issues.append("schemaVersion \(envelope.schemaVersion) wird für \(envelope.entityType.rawValue) nicht unterstützt; unterstützt wird \(supportedVersions.lowerBound)...\(supportedVersions.upperBound)")
+        }
+
+        if let byteCount = CloudKitRecordCodec.payloadByteCount(for: envelope),
+           byteCount > SyncPayloadSchema.maximumCloudKitPayloadBytes {
+            issues.append("payloadJSON ist mit \(byteCount) Bytes größer als das Limit von \(SyncPayloadSchema.maximumCloudKitPayloadBytes) Bytes")
+        }
+
         switch envelope.payload {
         case .episode(let payload):
             validateUUID(payload.id, field: "episode.id", into: &issues)

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -35,6 +35,29 @@ public enum SyncEntityType: String, Codable, CaseIterable, Sendable {
     case continuousMedication
 }
 
+public enum SyncPayloadSchema {
+    public nonisolated static let currentVersion = 1
+    public nonisolated static let maximumCloudKitPayloadBytes = 900_000
+
+    public nonisolated static func currentVersion(for entityType: SyncEntityType) -> Int {
+        switch entityType {
+        case .episode, .medicationDefinition, .continuousMedication:
+            currentVersion
+        }
+    }
+
+    public nonisolated static func supportedVersions(for entityType: SyncEntityType) -> ClosedRange<Int> {
+        switch entityType {
+        case .episode, .medicationDefinition, .continuousMedication:
+            currentVersion...currentVersion
+        }
+    }
+
+    public nonisolated static func supports(_ version: Int, for entityType: SyncEntityType) -> Bool {
+        supportedVersions(for: entityType).contains(version)
+    }
+}
+
 public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
     public nonisolated var state: SyncServiceState
     public nonisolated var service: String
@@ -75,7 +98,7 @@ public struct SyncDocumentEnvelope: Codable, Equatable, Sendable {
     public nonisolated init(
         documentID: String,
         entityType: SyncEntityType,
-        schemaVersion: Int = 1,
+        schemaVersion: Int = SyncPayloadSchema.currentVersion,
         modifiedAt: Date,
         authorDeviceID: String,
         deletedAt: Date? = nil,
@@ -135,6 +158,17 @@ public struct SyncDocumentEnvelope: Codable, Equatable, Sendable {
                 try container.encode(payload, forKey: .medicationDefinition)
             case .continuousMedication(let payload):
                 try container.encode(payload, forKey: .continuousMedication)
+            }
+        }
+
+        public nonisolated var entityType: SyncEntityType {
+            switch self {
+            case .episode:
+                .episode
+            case .medicationDefinition:
+                .medicationDefinition
+            case .continuousMedication:
+                .continuousMedication
             }
         }
     }

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -104,6 +104,75 @@ struct SyncMergeEngineTests {
 
     @Test
     @MainActor
+    func cloudKitRecordCodecEnforcesPayloadByteBudget() throws {
+        let acceptedEnvelope = episodeEnvelopeNearCloudKitPayloadBudget()
+        let acceptedByteCount = try #require(CloudKitRecordCodec.payloadByteCount(for: acceptedEnvelope))
+
+        #expect(acceptedByteCount <= SyncPayloadSchema.maximumCloudKitPayloadBytes)
+        #expect(try record(from: acceptedEnvelope).recordID.recordName == acceptedEnvelope.documentID)
+
+        let oversizedEnvelope = oversizedEpisodeEnvelope()
+        let oversizedByteCount = try #require(CloudKitRecordCodec.payloadByteCount(for: oversizedEnvelope))
+
+        #expect(oversizedByteCount > SyncPayloadSchema.maximumCloudKitPayloadBytes)
+        #expect(
+            CloudKitRecordCodec.record(
+                for: oversizedEnvelope,
+                zoneID: syncTestZoneID,
+                existingSystemFields: nil
+            ) == nil
+        )
+    }
+
+    @Test
+    @MainActor
+    func cloudKitRecordCodecRejectsEnvelopeMetadataMismatch() throws {
+        let envelope = definitionEnvelope(name: "Sumatriptan", deletedAt: nil)
+        let record = try record(from: envelope)
+
+        record["schemaVersion"] = NSNumber(value: envelope.schemaVersion + 1)
+
+        #expect(CloudKitRecordCodec.envelope(from: record) == nil)
+    }
+
+    @Test
+    @MainActor
+    func syncPayloadFuzzCasesRoundTripWithinCloudKitBudget() throws {
+        for seed in 0..<32 {
+            let envelope = fuzzedEpisodeEnvelope(seed: seed)
+            let byteCount = try #require(CloudKitRecordCodec.payloadByteCount(for: envelope))
+            let record = try record(from: envelope)
+
+            #expect(byteCount <= SyncPayloadSchema.maximumCloudKitPayloadBytes)
+            #expect(CloudKitRecordCodec.envelope(from: record) == envelope)
+        }
+    }
+
+    @Test
+    @MainActor
+    func remoteValidatorRejectsUnsupportedSchemaVersionAndPayloadTypeMismatch() throws {
+        var unsupportedVersion = definitionEnvelope(name: "Sumatriptan", deletedAt: nil)
+        unsupportedVersion.schemaVersion = SyncPayloadSchema.currentVersion(for: unsupportedVersion.entityType) + 1
+
+        #expect(throws: RemoteSyncPayloadValidationError.self) {
+            try RemoteSyncPayloadValidator.validate(unsupportedVersion)
+        }
+
+        let mismatchedEnvelope = SyncDocumentEnvelope(
+            documentID: unsupportedVersion.documentID,
+            entityType: .episode,
+            modifiedAt: unsupportedVersion.modifiedAt,
+            authorDeviceID: unsupportedVersion.authorDeviceID,
+            payload: unsupportedVersion.payload
+        )
+
+        #expect(throws: RemoteSyncPayloadValidationError.self) {
+            try RemoteSyncPayloadValidator.validate(mismatchedEnvelope)
+        }
+    }
+
+    @Test
+    @MainActor
     func conflictFreeRemoteMergeStoresShadowForMergedState() async throws {
         let stack = try makeSyncTestStack()
         let documentID = try insertBaseEpisode(in: stack.container)
@@ -521,6 +590,78 @@ private func episodeEnvelope(
             )
         )
     )
+}
+
+@MainActor
+private func episodeEnvelopeNearCloudKitPayloadBudget() -> SyncDocumentEnvelope {
+    var lowerBound = 0
+    var upperBound = SyncPayloadSchema.maximumCloudKitPayloadBytes
+    var best = episodeEnvelope(notes: "", symptoms: [])
+
+    while lowerBound <= upperBound {
+        let midpoint = (lowerBound + upperBound) / 2
+        let candidate = episodeEnvelope(notes: String(repeating: "a", count: midpoint), symptoms: ["Aura"])
+        let byteCount = CloudKitRecordCodec.payloadByteCount(for: candidate) ?? Int.max
+
+        if byteCount <= SyncPayloadSchema.maximumCloudKitPayloadBytes {
+            best = candidate
+            lowerBound = midpoint + 1
+        } else {
+            upperBound = midpoint - 1
+        }
+    }
+
+    return best
+}
+
+@MainActor
+private func oversizedEpisodeEnvelope() -> SyncDocumentEnvelope {
+    var notes = String(repeating: "a", count: SyncPayloadSchema.maximumCloudKitPayloadBytes)
+    var envelope = episodeEnvelope(notes: notes, symptoms: ["Aura"])
+
+    while (CloudKitRecordCodec.payloadByteCount(for: envelope) ?? 0) <= SyncPayloadSchema.maximumCloudKitPayloadBytes {
+        notes += "übel "
+        envelope = episodeEnvelope(notes: notes, symptoms: ["Aura"])
+    }
+
+    return envelope
+}
+
+private func fuzzedEpisodeEnvelope(seed: Int) -> SyncDocumentEnvelope {
+    let fragments = [
+        "Migräne",
+        "Übelkeit",
+        "Aura",
+        "Lärm",
+        "Licht",
+        "Stress",
+        "Schlaf",
+        "Wärme"
+    ]
+    let notes = (0...seed).map { index in
+        fragments[(seed + index) % fragments.count]
+    }.joined(separator: " · ")
+    let symptoms = Array(fragments.prefix((seed % fragments.count) + 1))
+
+    var envelope = episodeEnvelope(
+        notes: notes,
+        symptoms: symptoms,
+        medications: [
+            SyncMedicationEntryPayload(
+                id: UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012d", seed + 1))")!.uuidString,
+                name: "Ibuprofen \(seed)",
+                category: MedicationCategory.nsar.rawValue,
+                dosage: "\(200 + seed) mg",
+                quantity: max(1, seed % 4),
+                takenAt: Date(timeIntervalSince1970: TimeInterval(seed * 60)),
+                effectiveness: MedicationEffectiveness.partial.rawValue,
+                reliefStartedAt: nil,
+                isRepeatDose: seed.isMultiple(of: 3)
+            )
+        ]
+    )
+    envelope.modifiedAt = Date(timeIntervalSince1970: TimeInterval(seed + 1_000))
+    return envelope
 }
 
 private let syncTestDeviceID = "device-local"

--- a/docs/Sync-Abdeckung.md
+++ b/docs/Sync-Abdeckung.md
@@ -13,3 +13,13 @@ CloudKit-Sync nutzt `SyncDocumentEnvelope` als fachliche Dokumentgrenze. Die fol
 | `ContinuousMedication` | `continuousMedication:<UUID>` | Dauermedikationen werden eigenständig synchronisiert und nach stabiler Medikamenten-ID gemergt |
 
 Konfliktbehandlung läuft weiterhin über den dreiseitigen Merge aus Shadow, lokalem Dokument und Remote-Dokument. Konflikte bei Episoden-Sidecars werden mit Feldpfaden wie `continuousMedicationChecks.<id>.wasTaken` oder `healthContext` sichtbar gemacht; Konflikte bei Dauermedikationen werden auf den jeweiligen Feldern wie `dosage`, `frequency` oder `endDate` gemeldet.
+
+## CloudKit-Record-Design
+
+Symi speichert pro fachlichem Sync-Dokument weiterhin einen vollständigen `SyncDocumentEnvelope` als JSON in `payloadJSON`. Die CloudKit-Felder `documentID`, `entityType`, `schemaVersion`, `modifiedAt`, `authorDeviceID` und `deletedAt` bleiben zusätzlich als Record-Metadaten erhalten. Diese Entscheidung ist bewusst: Der Envelope hält die fachliche Dokumentgrenze stabil, vermeidet fragmentierte Teil-Records für Episoden-Sidecars und erlaubt den bestehenden dreiseitigen Merge gegen lokale Shadows ohne CloudKit-spezifische Feldlogik.
+
+Die Kehrseite wird explizit begrenzt. `payloadJSON` hat ein hartes Budget von 900.000 UTF-8-Bytes und wird beim Schreiben und Lesen abgelehnt, wenn dieses Budget überschritten wird. Das lässt Reserve unterhalb der CloudKit-Record-Grenze für Systemfelder und zukünftige Metadaten. Zusätzlich prüfen Tests große Grenz-Payloads und deterministische Fuzz-Payloads mit Umlauten und variierenden Listen.
+
+Schema-Evolution läuft pro `entityType` über `schemaVersion`. Aktuell unterstützen `episode`, `medicationDefinition` und `continuousMedication` ausschließlich Version 1. Remote-Payloads mit unbekannter Version oder mit nicht passendem `entityType`/Payload-Typ werden abgelehnt statt stillschweigend gemergt. Für zukünftige Versionen wird zuerst der unterstützte Versionsbereich pro Typ erweitert und ein expliziter Migrationsschritt von alter zu aktueller Envelope-Version ergänzt, bevor neue Payload-Felder verpflichtend werden.
+
+Normalisierte CloudKit-Felder bleiben eine spätere Option, falls konkrete Anforderungen entstehen, die der Envelope nicht gut tragen kann: serverseitige Feldabfragen, einzelne große Sidecars, häufige Teilkonflikte innerhalb eines Dokuments oder Payloads nahe am Größenbudget. Bis dahin ist JSON-Envelope plus validierte Metadaten die gewählte Strategie.


### PR DESCRIPTION
## Änderungen
- führt zentrale Sync-Payload-Schema-Metadaten und ein 900.000-Byte-Budget für `payloadJSON` ein
- lehnt zu große oder metadata-inkonsistente CloudKit-Envelopes beim Lesen/Schreiben ab
- validiert Remote-Payloads auf Schema-Version und passenden Payload-Typ
- dokumentiert die bewusste JSON-Envelope-Strategie und spätere Normalisierungskriterien
- ergänzt Grenzgrößen- und Fuzz-Tests für CloudKit-Sync-Payloads

## Tests
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SymiTests/SyncMergeEngineTests`

Closes #222