### PR TITLE
Backup-Import mit Vorschau und Rollback absichern

### DIFF
--- a/Symi/Sources/Core/Export/ExportCore.swift
+++ b/Symi/Sources/Core/Export/ExportCore.swift
@@ -5,7 +5,8 @@ protocol ExportRepository: Sendable {
     nonisolated func buildSummary(startDate: Date, endDate: Date) throws -> ExportPeriodSummary
     nonisolated func createPDF(summary: ExportPeriodSummary, mode: PDFReportMode) throws -> URL
     nonisolated func createBackup() throws -> URL
-    nonisolated func importBackup(from url: URL) throws
+    nonisolated func previewBackupImport(from url: URL) throws -> BackupImportPreview
+    nonisolated func importBackup(from url: URL) throws -> BackupImportResult
 }
 
 enum PDFReportMode: String, CaseIterable, Identifiable, Sendable {
@@ -61,9 +62,18 @@ struct CreateBackupUseCase {
 struct ImportBackupUseCase {
     let repository: ExportRepository
 
-    func execute(url: URL) async throws {
+    func preview(url: URL) async throws -> BackupImportPreview {
         let repository = repository
-        try await Task.detached(priority: .userInitiated) {
+        return try await Task.detached(priority: .userInitiated) {
+            try PerformanceInstrumentation.measure("BackupImportPreview") {
+                try repository.previewBackupImport(from: url)
+            }
+        }.value
+    }
+
+    func execute(url: URL) async throws -> BackupImportResult {
+        let repository = repository
+        return try await Task.detached(priority: .userInitiated) {
             try PerformanceInstrumentation.measure("BackupImport") {
                 try repository.importBackup(from: url)
             }
@@ -80,7 +90,11 @@ final class DataExportController {
     var exportErrorMessage: String?
     var dataExportURL: URL?
     var dataTransferMessage: String?
+    var importPreview: BackupImportPreview?
+    var importRollbackBackupURL: URL?
     var isImportingData = false
+    var isPreparingImportPreview = false
+    var isApplyingImport = false
     var isLoadingSummary = false
     var isPreparingPDF = false
     var includeAllDetails = false
@@ -248,6 +262,8 @@ final class DataExportController {
         dataExportTask?.cancel()
         dataTransferMessage = nil
         dataExportURL = nil
+        importPreview = nil
+        importRollbackBackupURL = nil
 
         dataExportTask = Task { [weak self] in
             await PerformanceInstrumentation.measure("DataExportControllerCreateBackup") {
@@ -280,25 +296,68 @@ final class DataExportController {
 
         dataImportTask?.cancel()
         dataTransferMessage = nil
-        isImportingData = true
+        importPreview = nil
+        importRollbackBackupURL = nil
+        isPreparingImportPreview = true
+
+        dataImportTask = Task { [weak self] in
+            await PerformanceInstrumentation.measure("DataExportControllerImportPreview") {
+                guard let self else { return }
+                defer { self.isPreparingImportPreview = false }
+                do {
+                    let preview = try await self.importBackupUseCase.preview(url: url)
+                    guard !Task.isCancelled else { return }
+                    self.importPreview = preview
+                    self.pendingImportURL = url
+                    self.dataTransferMessage = preview.hasChanges
+                        ? "Import-Vorschau erstellt. Bitte prüfen und bestätigen."
+                        : "Dry-Run abgeschlossen: Das Backup enthält keine neuen Änderungen."
+                } catch is CancellationError {
+                    return
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    self.dataTransferMessage = (error as? LocalizedError)?.errorDescription ?? "Fehler beim Prüfen der JSON5-Datei."
+                }
+            }
+        }
+    }
+
+    func confirmImport() {
+        guard let url = pendingImportURL else { return }
+
+        dataImportTask?.cancel()
+        dataTransferMessage = nil
+        isApplyingImport = true
 
         dataImportTask = Task { [weak self] in
             await PerformanceInstrumentation.measure("DataExportControllerImportBackup") {
                 guard let self else { return }
-                defer { self.isImportingData = false }
+                defer { self.isApplyingImport = false }
                 do {
-                    try await self.importBackupUseCase.execute(url: url)
+                    let result = try await self.importBackupUseCase.execute(url: url)
                     guard !Task.isCancelled else { return }
-                    self.dataTransferMessage = "JSON5-Daten wurden importiert."
+                    self.importPreview = nil
+                    self.pendingImportURL = nil
+                    self.importRollbackBackupURL = result.rollbackBackupURL
+                    self.dataTransferMessage = "JSON5-Daten wurden importiert. Vorheriger Stand wurde als Rollback-Backup gesichert."
                     await self.reloadSummary()
                 } catch is CancellationError {
                     return
                 } catch {
                     guard !Task.isCancelled else { return }
-                    self.dataTransferMessage = "Fehler beim Import der JSON5-Datei."
+                    self.dataTransferMessage = (error as? LocalizedError)?.errorDescription ?? "Fehler beim Import der JSON5-Datei."
                 }
             }
         }
+    }
+
+    func cancelImportPreview() {
+        dataImportTask?.cancel()
+        pendingImportURL = nil
+        importPreview = nil
+        dataTransferMessage = nil
+        isPreparingImportPreview = false
+        isApplyingImport = false
     }
 
     private static func defaultDateRange(calendar: Calendar = .current, now: Date = .now) -> (startDate: Date, endDate: Date) {
@@ -306,4 +365,6 @@ final class DataExportController {
         let startDate = calendar.date(byAdding: .month, value: -2, to: startOfCurrentMonth) ?? now
         return (startDate, now)
     }
+
+    @ObservationIgnored private var pendingImportURL: URL?
 }

--- a/Symi/Sources/Features/Export/DataExportView.swift
+++ b/Symi/Sources/Features/Export/DataExportView.swift
@@ -72,9 +72,39 @@ struct DataExportView: View {
                     controller.isImportingData = true
                 }
 
+                if controller.isPreparingImportPreview || controller.isApplyingImport {
+                    HStack {
+                        ProgressView()
+                        Text(controller.isPreparingImportPreview ? "Backup wird geprüft." : "Backup wird importiert.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if let importPreview = controller.importPreview {
+                    BackupImportPreviewView(preview: importPreview)
+
+                    HStack {
+                        Button("Abbrechen", role: .cancel) {
+                            controller.cancelImportPreview()
+                        }
+
+                        Button("Import ausführen", role: importPreview.conflicts.isEmpty ? nil : .destructive) {
+                            controller.confirmImport()
+                        }
+                        .disabled(controller.isApplyingImport)
+                    }
+                }
+
                 if let dataExportURL = controller.dataExportURL {
                     ShareLink(item: dataExportURL) {
                         Label("Backup teilen", systemImage: "square.and.arrow.up")
+                    }
+                }
+
+                if let rollbackURL = controller.importRollbackBackupURL {
+                    ShareLink(item: rollbackURL) {
+                        Label("Rollback-Backup teilen", systemImage: "arrow.uturn.backward.circle")
                     }
                 }
 
@@ -122,6 +152,45 @@ struct DataExportView: View {
             .datePickerStyle(.compact)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct BackupImportPreviewView: View {
+    let preview: BackupImportPreview
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.compact) {
+            Text("Import-Vorschau")
+                .font(.headline)
+
+            Text(summaryText)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            if let dateRange = preview.dateRange {
+                Text("Zeitraum: \(dateRange.start.formatted(date: .abbreviated, time: .omitted)) bis \(dateRange.end.formatted(date: .abbreviated, time: .omitted))")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !preview.conflicts.isEmpty {
+                ForEach(preview.conflicts, id: \.self) { conflict in
+                    Label(conflict, systemImage: "exclamationmark.triangle")
+                        .font(.subheadline)
+                        .foregroundStyle(AppTheme.symiCoral)
+                }
+            }
+        }
+        .padding(.vertical, SymiSpacing.xs)
+    }
+
+    private var summaryText: String {
+        [
+            "\(preview.newEpisodes) neu",
+            "\(preview.changedEpisodes) geändert",
+            "\(preview.deletedEpisodes) gelöscht",
+            "\(preview.conflicts.count) Konflikte"
+        ].joined(separator: " · ")
     }
 }
 

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -8,16 +8,50 @@ extension UTType {
 
 enum DataTransferError: LocalizedError {
     case invalidFormat
+    case fileTooLarge(limitInMegabytes: Int)
 
     var errorDescription: String? {
         switch self {
         case .invalidFormat:
             return "Die Datei enthält kein unterstütztes Datenformat für \(ProductBranding.displayName)."
+        case let .fileTooLarge(limitInMegabytes):
+            return "Die Backup-Datei ist größer als \(limitInMegabytes) MB und wurde nicht importiert."
         }
     }
 }
 
+struct BackupImportPreview: Equatable, Sendable {
+    struct DateRange: Equatable, Sendable {
+        let start: Date
+        let end: Date
+    }
+
+    let newEpisodes: Int
+    let changedEpisodes: Int
+    let deletedEpisodes: Int
+    let newMedicationDefinitions: Int
+    let changedMedicationDefinitions: Int
+    let newContinuousMedications: Int
+    let changedContinuousMedications: Int
+    let conflicts: [String]
+    let dateRange: DateRange?
+    let exportedAt: Date
+
+    var hasChanges: Bool {
+        newEpisodes + changedEpisodes + deletedEpisodes +
+            newMedicationDefinitions + changedMedicationDefinitions +
+            newContinuousMedications + changedContinuousMedications > 0
+    }
+}
+
+struct BackupImportResult: Sendable {
+    let preview: BackupImportPreview
+    let rollbackBackupURL: URL
+}
+
 struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
+    nonisolated static let maximumImportFileSizeInBytes = 10 * 1_024 * 1_024
+
     let formatVersion: Int
     let exportedAt: Date
     let episodes: [EpisodePayload]
@@ -73,7 +107,7 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
 
-        let fileName = "schmerztagebuch-export-\(Self.fileDateString(from: exportedAt)).json5"
+        let fileName = "schmerztagebuch-export-\(Self.fileDateString(from: exportedAt))-\(UUID().uuidString).json5"
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
         let data = try encoder.encode(self)
 
@@ -81,7 +115,7 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
         return url
     }
 
-    nonisolated static func load(from url: URL) throws -> DataTransferSnapshot {
+    nonisolated static func load(from url: URL, maximumFileSizeInBytes: Int = maximumImportFileSizeInBytes) throws -> DataTransferSnapshot {
         let shouldStopAccess = url.startAccessingSecurityScopedResource()
         defer {
             if shouldStopAccess {
@@ -89,17 +123,96 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
             }
         }
 
+        if let fileSize = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           fileSize > maximumFileSizeInBytes {
+            throw DataTransferError.fileTooLarge(limitInMegabytes: maximumFileSizeInBytes / 1_024 / 1_024)
+        }
+
         let data = try Data(contentsOf: url)
+        guard data.count <= maximumFileSizeInBytes else {
+            throw DataTransferError.fileTooLarge(limitInMegabytes: maximumFileSizeInBytes / 1_024 / 1_024)
+        }
+
         let decoder = JSONDecoder()
         decoder.allowsJSON5 = true
         decoder.dateDecodingStrategy = .iso8601
 
-        let snapshot = try decoder.decode(DataTransferSnapshot.self, from: data)
+        let snapshot: DataTransferSnapshot
+        do {
+            snapshot = try decoder.decode(DataTransferSnapshot.self, from: data)
+        } catch {
+            throw DataTransferError.invalidFormat
+        }
         guard snapshot.formatVersion == 1 else {
             throw DataTransferError.invalidFormat
         }
 
         return snapshot
+    }
+
+    nonisolated func previewImport(into context: ModelContext) throws -> BackupImportPreview {
+        let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
+        let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
+        let existingDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
+        let customDefinitionsByKey = Dictionary(
+            uniqueKeysWithValues: existingDefinitions
+                .filter(\.isCustom)
+                .map { ($0.catalogKey, $0) }
+        )
+        let existingContinuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
+        let continuousMedicationsByID = Dictionary(uniqueKeysWithValues: existingContinuousMedications.map { ($0.id, $0) })
+
+        var newEpisodes = 0
+        var changedEpisodes = 0
+        var deletedEpisodes = 0
+        var conflicts: [String] = []
+
+        for payload in episodes {
+            if payload.deletedAt != nil {
+                deletedEpisodes += 1
+            }
+
+            guard let existingEpisode = episodesByID[payload.id] else {
+                newEpisodes += 1
+                continue
+            }
+
+            if payload.differs(from: existingEpisode) {
+                changedEpisodes += 1
+            }
+
+            if existingEpisode.updatedAt > payload.updatedAt {
+                conflicts.append("Episode \(payload.startedAt.formatted(date: .numeric, time: .shortened)) ist lokal neuer als das Backup.")
+            }
+        }
+
+        let changedDefinitions = customMedicationDefinitions.filter { payload in
+            guard let existingDefinition = customDefinitionsByKey[payload.catalogKey] else { return false }
+            return existingDefinition.updatedAt != payload.updatedAt || existingDefinition.deletedAt != payload.deletedAt
+        }
+
+        let changedContinuousMedications = continuousMedications.filter { payload in
+            guard let existingMedication = continuousMedicationsByID[payload.id] else { return false }
+            return existingMedication.updatedAt != payload.updatedAt
+        }
+
+        let dateRange = episodes
+            .map(\.startedAt)
+            .min()
+            .flatMap { start in episodes.map(\.startedAt).max().map { BackupImportPreview.DateRange(start: start, end: $0) } }
+
+        return BackupImportPreview(
+            newEpisodes: newEpisodes,
+            changedEpisodes: changedEpisodes,
+            deletedEpisodes: deletedEpisodes,
+            newMedicationDefinitions: customMedicationDefinitions.filter { customDefinitionsByKey[$0.catalogKey] == nil }.count,
+            changedMedicationDefinitions: changedDefinitions.count,
+            newContinuousMedications: continuousMedications.filter { continuousMedicationsByID[$0.id] == nil }.count,
+            changedContinuousMedications: changedContinuousMedications.count,
+            conflicts: conflicts,
+            dateRange: dateRange,
+            exportedAt: exportedAt
+        )
     }
 
     nonisolated func merge(into context: ModelContext, healthContextStore: HealthContextStore) throws {
@@ -356,6 +469,24 @@ struct EpisodePayload: Codable, Sendable {
             context.delete(existingWeatherSnapshot)
             episode.weatherSnapshot = nil
         }
+    }
+
+    nonisolated func differs(from episode: Episode) -> Bool {
+        episode.startedAt != startedAt ||
+            episode.endedAt != endedAt ||
+            episode.updatedAt != updatedAt ||
+            episode.deletedAt != deletedAt ||
+            episode.type != type ||
+            episode.intensity != intensity ||
+            episode.painLocation != painLocation ||
+            episode.painCharacter != painCharacter ||
+            episode.notes != notes ||
+            episode.symptoms != symptoms ||
+            episode.triggers != triggers ||
+            episode.functionalImpact != functionalImpact ||
+            episode.menstruationStatus != menstruationStatus ||
+            episode.medications.map(\.id) != medications.map(\.id) ||
+            episode.continuousMedicationChecks.map(\.id) != continuousMedicationChecks.map(\.id)
     }
 
     nonisolated func applySidecars(to healthContextStore: HealthContextStore) throws {

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -403,10 +403,18 @@ final class SwiftDataExportRepository: ExportRepository, @unchecked Sendable {
         return try snapshot.writeToTemporaryFile()
     }
 
-    nonisolated func importBackup(from url: URL) throws {
+    nonisolated func previewBackupImport(from url: URL) throws -> BackupImportPreview {
         let snapshot = try DataTransferSnapshot.load(from: url)
+        return try snapshot.previewImport(into: readContext())
+    }
+
+    nonisolated func importBackup(from url: URL) throws -> BackupImportResult {
+        let rollbackBackupURL = try createBackup()
+        let snapshot = try DataTransferSnapshot.load(from: url)
+        let preview = try snapshot.previewImport(into: readContext())
         let context = writeContext()
         try snapshot.merge(into: context, healthContextStore: healthContextStore)
+        return BackupImportResult(preview: preview, rollbackBackupURL: rollbackBackupURL)
     }
 
     nonisolated private func readContext() -> ModelContext {

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -134,6 +134,75 @@ struct DataTransferHealthContextTests {
     }
 
     @Test
+    func importPreviewReportsChangesConflictsAndDoesNotMutateStore() throws {
+        let episodeID = UUID()
+        let sourceContainer = try makeInMemoryContainer()
+        try seedEpisode(id: episodeID, notes: "Backup-Stand", in: sourceContainer)
+        let backupURL = try SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        ).createBackup()
+
+        let targetContainer = try makeInMemoryContainer()
+        let newerDate = Date(timeIntervalSince1970: 1_700_000_500)
+        try seedEpisode(id: episodeID, notes: "Lokaler Stand", updatedAt: newerDate, in: targetContainer)
+        let repository = SwiftDataExportRepository(
+            modelContainer: targetContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        )
+
+        let preview = try repository.previewBackupImport(from: backupURL)
+        let storedEpisode = try #require(try ModelContext(targetContainer).fetch(FetchDescriptor<Episode>()).first)
+
+        #expect(preview.newEpisodes == 0)
+        #expect(preview.changedEpisodes == 1)
+        #expect(preview.conflicts.count == 1)
+        #expect(preview.dateRange != nil)
+        #expect(storedEpisode.notes == "Lokaler Stand")
+    }
+
+    @Test
+    func confirmedImportCreatesRollbackSnapshotBeforeMerging() throws {
+        let episodeID = UUID()
+        let sourceContainer = try makeInMemoryContainer()
+        try seedEpisode(id: episodeID, notes: "Importierter Stand", in: sourceContainer)
+        let backupURL = try SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        ).createBackup()
+
+        let targetContainer = try makeInMemoryContainer()
+        try seedEpisode(id: episodeID, notes: "Vorheriger Stand", in: targetContainer)
+        let repository = SwiftDataExportRepository(
+            modelContainer: targetContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        )
+
+        let result = try repository.importBackup(from: backupURL)
+        let rollbackText = try String(contentsOf: result.rollbackBackupURL, encoding: .utf8)
+        let importedEpisode = try #require(try ModelContext(targetContainer).fetch(FetchDescriptor<Episode>()).first)
+
+        #expect(result.preview.changedEpisodes == 1)
+        #expect(rollbackText.contains("Vorheriger Stand"))
+        #expect(importedEpisode.notes == "Importierter Stand")
+    }
+
+    @Test
+    func importRejectsFilesAboveSizeLimit() throws {
+        let url = try makeTemporaryDirectory().appending(path: "too-large.json5")
+        try Data(repeating: 0, count: DataTransferSnapshot.maximumImportFileSizeInBytes + 1).write(to: url)
+
+        var didThrowLimit = false
+        do {
+            _ = try DataTransferSnapshot.load(from: url)
+        } catch DataTransferError.fileTooLarge {
+            didThrowLimit = true
+        }
+
+        #expect(didThrowLimit)
+    }
+
+    @Test
     func importThrowsWhenHealthContextCannotBeWritten() throws {
         let episodeID = UUID()
         let sourceContainer = try makeInMemoryContainer()
@@ -174,14 +243,19 @@ private func makeInMemoryContainer() throws -> ModelContainer {
     return try ModelContainer(for: schema, configurations: [configuration])
 }
 
-private func seedEpisode(id: UUID, notes: String = "Migräne nach Wetterwechsel", in container: ModelContainer) throws {
+private func seedEpisode(
+    id: UUID,
+    notes: String = "Migräne nach Wetterwechsel",
+    updatedAt: Date? = nil,
+    in container: ModelContainer
+) throws {
     let context = ModelContext(container)
     let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
     let episode = Episode(
         id: id,
         startedAt: startedAt,
         endedAt: startedAt.addingTimeInterval(7_200),
-        updatedAt: startedAt.addingTimeInterval(60),
+        updatedAt: updatedAt ?? startedAt.addingTimeInterval(60),
         type: .migraine,
         intensity: 7,
         painLocation: "Stirn",


### PR DESCRIPTION
## Änderungen
- Backup-Import liest Dateien zuerst als Dry-Run und zeigt neue, geänderte, gelöschte Einträge, Zeitraum und Konflikte an.
- Import muss nach der Vorschau bestätigt werden und erstellt vorher ein Rollback-Backup.
- JSON5-Importe bekommen ein Größenlimit und klarere Fehler für defekte oder zu große Dateien.

## Validierung
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #223
