### PR TITLE
[codex] File Protection und Export-Lifecycle einführen

### DIFF
--- a/Symi/Sources/App/StoreRecovery.swift
+++ b/Symi/Sources/App/StoreRecovery.swift
@@ -151,6 +151,7 @@ nonisolated enum PersistentStoreRecoveryService {
         let targetDirectory = fileManager.temporaryDirectory
             .appending(path: "Symi-Store-Sicherung-\(fileDateString(from: now))-\(UUID().uuidString)", directoryHint: .isDirectory)
         try fileManager.createDirectory(at: targetDirectory, withIntermediateDirectories: true)
+        try ProtectedFileStorage.applyProtection(to: targetDirectory, fileManager: fileManager, excludedFromBackup: true)
 
         return try sourceURLs.map { sourceURL in
             let targetURL = targetDirectory.appending(path: sourceURL.lastPathComponent)
@@ -158,6 +159,7 @@ nonisolated enum PersistentStoreRecoveryService {
                 try fileManager.removeItem(at: targetURL)
             }
             try fileManager.copyItem(at: sourceURL, to: targetURL)
+            try ProtectedFileStorage.applyProtection(to: targetURL, fileManager: fileManager, excludedFromBackup: true)
             return targetURL
         }
     }
@@ -176,7 +178,7 @@ nonisolated enum PersistentStoreRecoveryService {
         return "\(nsError.domain) \(nsError.code)"
     }
 
-    private static func storeFileCandidates(for storeURL: URL) -> [URL] {
+    static func storeFileCandidates(for storeURL: URL) -> [URL] {
         let directoryURL = storeURL.deletingLastPathComponent()
         let storeFileName = storeURL.lastPathComponent
 

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -51,7 +51,9 @@ struct SymiApp: App {
     ) throws -> ModelContainer {
         do {
             logger.debug("Versuche ModelContainer für lokalen Store zu laden.")
-            return try loadContainer()
+            let container = try loadContainer()
+            try protectPersistentStoreFiles(at: configuration.url)
+            return container
         } catch {
             let context = PersistentStoreRecoveryService.recoveryContext(for: error, storeURL: configuration.url)
             logger.error(
@@ -203,7 +205,19 @@ struct SymiApp: App {
         }
 
         try fileManager.createDirectory(at: applicationSupportURL, withIntermediateDirectories: true)
+        try ProtectedFileStorage.applyProtection(to: applicationSupportURL, fileManager: fileManager)
         return applicationSupportURL.appending(path: "default.store")
+    }
+
+    static func protectPersistentStoreFiles(at storeURL: URL, fileManager: FileManager = .default) throws {
+        try ProtectedFileStorage.applyProtection(to: storeURL.deletingLastPathComponent(), fileManager: fileManager)
+        for fileURL in PersistentStoreRecoveryService.storeFileCandidates(for: storeURL) where fileManager.fileExists(atPath: fileURL.path) {
+            if fileURL.hasDirectoryPath {
+                try ProtectedFileStorage.applyProtectionRecursively(to: fileURL, fileManager: fileManager)
+            } else {
+                try ProtectedFileStorage.applyProtection(to: fileURL, fileManager: fileManager)
+            }
+        }
     }
 
     private static func resolvedStoreURL(

--- a/Symi/Sources/Core/Export/ExportCore.swift
+++ b/Symi/Sources/Core/Export/ExportCore.swift
@@ -137,7 +137,7 @@ final class DataExportController {
     func scheduleSummaryReload(debounce: Duration? = .milliseconds(350)) {
         summaryReloadTask?.cancel()
         pdfPreparationTask?.cancel()
-        exportURL = nil
+        clearPreparedPDF()
         exportErrorMessage = nil
         isLoadingSummary = true
         isPreparingPDF = false
@@ -196,7 +196,7 @@ final class DataExportController {
 
     func schedulePDFPreparation(delay: Duration? = .milliseconds(350)) {
         pdfPreparationTask?.cancel()
-        exportURL = nil
+        clearPreparedPDF()
         exportErrorMessage = nil
 
         let requestedSummary = summary
@@ -233,7 +233,7 @@ final class DataExportController {
     ) async {
         await PerformanceInstrumentation.measure("DataExportControllerPreparePDF") {
             exportErrorMessage = nil
-            exportURL = nil
+            clearPreparedPDF()
 
             guard requestedStartDate <= requestedEndDate else {
                 exportErrorMessage = "Der Zeitraum ist ungültig."
@@ -261,7 +261,7 @@ final class DataExportController {
     func createBackup() {
         dataExportTask?.cancel()
         dataTransferMessage = nil
-        dataExportURL = nil
+        clearPreparedBackup()
         importPreview = nil
         importRollbackBackupURL = nil
 
@@ -336,6 +336,7 @@ final class DataExportController {
                 do {
                     let result = try await self.importBackupUseCase.execute(url: url)
                     guard !Task.isCancelled else { return }
+                    self.clearPreparedBackup()
                     self.importPreview = nil
                     self.pendingImportURL = nil
                     self.importRollbackBackupURL = result.rollbackBackupURL
@@ -358,6 +359,16 @@ final class DataExportController {
         dataTransferMessage = nil
         isPreparingImportPreview = false
         isApplyingImport = false
+    }
+
+    private func clearPreparedPDF() {
+        TemporaryExportFileLifecycle.cleanupManagedFile(at: exportURL)
+        exportURL = nil
+    }
+
+    private func clearPreparedBackup() {
+        TemporaryExportFileLifecycle.cleanupManagedFile(at: dataExportURL)
+        dataExportURL = nil
     }
 
     private static func defaultDateRange(calendar: Calendar = .current, now: Date = .now) -> (startDate: Date, endDate: Date) {

--- a/Symi/Sources/Features/Export/DataExportView.swift
+++ b/Symi/Sources/Features/Export/DataExportView.swift
@@ -32,6 +32,10 @@ struct DataExportView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 
+                Text("Geteilte PDFs verlassen die geschützte App-Sandbox. Speichere oder sende sie nur an Orte, denen du vertraust.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
                 if let exportErrorMessage = controller.exportErrorMessage {
                     Text(exportErrorMessage)
                         .font(.subheadline)
@@ -61,6 +65,10 @@ struct DataExportView: View {
 
             Section("Backup") {
                 Text("Das Backup enthält alle Einträge, eigene Medikamentenvorlagen, Wetter-Snapshots und gespeicherten Apple-Health-Kontext, inklusive Papierkorb-Einträgen.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Text("Geteilte Backup-Dateien können außerhalb der App-Sandbox liegen und dort anderen Schutzregeln unterliegen.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -111,7 +111,9 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
         let data = try encoder.encode(self)
 
+        try TemporaryExportFileLifecycle.prepareProtectedTemporaryFile(at: url)
         try data.write(to: url, options: .atomic)
+        try TemporaryExportFileLifecycle.finalizeProtectedTemporaryFile(at: url)
         return url
     }
 

--- a/Symi/Sources/Features/Export/PDFExportWriter.swift
+++ b/Symi/Sources/Features/Export/PDFExportWriter.swift
@@ -11,8 +11,10 @@ nonisolated enum PDFExportWriter {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
         let layout = PDFLayout(pageRect: PDFLayout.defaultPageRect)
 
+        try TemporaryExportFileLifecycle.prepareProtectedTemporaryFile(at: url)
         try writeRawPDF(summary: summary, mode: mode, to: url, layout: layout)
         try finalizeDocument(at: url)
+        try TemporaryExportFileLifecycle.finalizeProtectedTemporaryFile(at: url)
 
         return url
     }
@@ -102,6 +104,7 @@ nonisolated enum PDFExportWriter {
         }
 
         try data.write(to: url, options: .atomic)
+        try TemporaryExportFileLifecycle.finalizeProtectedTemporaryFile(at: url)
     }
 
     private static func exportLines(for record: EpisodeExportRecord) -> [String] {

--- a/Symi/Sources/Features/Sync/SyncStateStore.swift
+++ b/Symi/Sources/Features/Sync/SyncStateStore.swift
@@ -88,7 +88,7 @@ actor SyncStateStore {
         var initialEvents: [PersistenceEvent] = []
 
         do {
-            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try ProtectedFileStorage.createProtectedDirectory(at: directory, fileManager: fileManager)
         } catch {
             let message = "Sync-State-Verzeichnis konnte nicht erstellt werden: \(error.localizedDescription)"
             initialState.lastError = message
@@ -243,6 +243,7 @@ actor SyncStateStore {
         do {
             let data = try encoder.encode(state)
             try data.write(to: url, options: .atomic)
+            try ProtectedFileStorage.applyProtection(to: url)
         } catch {
             recordPersistenceFailure(
                 operation: "stateStore.persist.error",
@@ -278,6 +279,7 @@ actor SyncStateStore {
 
         do {
             try fileManager.copyItem(at: url, to: backupURL)
+            try ProtectedFileStorage.applyProtection(to: backupURL, fileManager: fileManager)
             return (backupURL, nil)
         } catch {
             return (nil, error.localizedDescription)

--- a/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
+++ b/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
@@ -24,9 +24,10 @@ final class HealthContextStore: @unchecked Sendable {
             return
         }
 
-        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try ProtectedFileStorage.createProtectedDirectory(at: directoryURL)
         let data = try encoder.encode(snapshot)
         try data.write(to: url, options: .atomic)
+        try ProtectedFileStorage.applyProtection(to: url)
     }
 
     nonisolated func load(for episodeID: UUID) -> HealthContextRecord? {

--- a/Symi/Sources/Shared/AppLogging.swift
+++ b/Symi/Sources/Shared/AppLogging.swift
@@ -103,11 +103,11 @@ public actor AppLogStore {
         let baseURL = baseDirectoryURL ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory
         let directoryURL = baseURL.appendingPathComponent("Symi", isDirectory: true)
-        try? fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try? ProtectedFileStorage.createProtectedDirectory(at: directoryURL, fileManager: fileManager)
 
         self.fileURL = directoryURL.appendingPathComponent("app-log.ndjson")
         self.snapshotDirectoryURL = directoryURL.appendingPathComponent("Snapshots", isDirectory: true)
-        try? fileManager.createDirectory(at: snapshotDirectoryURL, withIntermediateDirectories: true)
+        try? ProtectedFileStorage.createProtectedDirectory(at: snapshotDirectoryURL, fileManager: fileManager)
         self.entries = []
 
         self.encoder.dateEncodingStrategy = .iso8601
@@ -174,6 +174,7 @@ public actor AppLogStore {
 
         do {
             try lines.joined(separator: "\n").appending("\n").write(to: exportURL, atomically: true, encoding: .utf8)
+            try ProtectedFileStorage.applyProtection(to: exportURL, excludedFromBackup: true)
             return exportURL
         } catch {
             return nil
@@ -264,6 +265,7 @@ public actor AppLogStore {
                 }
             } else {
                 try lines.joined(separator: "\n").appending("\n").write(to: fileURL, atomically: true, encoding: .utf8)
+                try ProtectedFileStorage.applyProtection(to: fileURL, fileManager: fileManager)
             }
         } catch {
             // Logging darf den App-Fluss nicht blockieren.

--- a/Symi/Sources/Shared/ProtectedFileStorage.swift
+++ b/Symi/Sources/Shared/ProtectedFileStorage.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+nonisolated enum ProtectedFileStorage {
+    static let fileProtectionType = FileProtectionType.complete
+
+    static func createProtectedDirectory(
+        at url: URL,
+        fileManager: FileManager = .default,
+        excludedFromBackup: Bool = false
+    ) throws {
+        try fileManager.createDirectory(
+            at: url,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: fileProtectionType]
+        )
+        try applyProtection(to: url, fileManager: fileManager, excludedFromBackup: excludedFromBackup)
+    }
+
+    static func applyProtection(
+        to url: URL,
+        fileManager: FileManager = .default,
+        excludedFromBackup: Bool = false
+    ) throws {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+
+        try fileManager.setAttributes([.protectionKey: fileProtectionType], ofItemAtPath: url.path)
+        try setBackupExclusion(excludedFromBackup, for: url)
+    }
+
+    static func applyProtectionRecursively(
+        to url: URL,
+        fileManager: FileManager = .default,
+        excludedFromBackup: Bool = false
+    ) throws {
+        try applyProtection(to: url, fileManager: fileManager, excludedFromBackup: excludedFromBackup)
+
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for case let itemURL as URL in enumerator {
+            try applyProtection(to: itemURL, fileManager: fileManager, excludedFromBackup: excludedFromBackup)
+        }
+    }
+
+    private static func setBackupExclusion(_ excluded: Bool, for url: URL) throws {
+        var mutableURL = url
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = excluded
+        try mutableURL.setResourceValues(resourceValues)
+    }
+}
+
+nonisolated enum TemporaryExportFileLifecycle {
+    static let expirationInterval: TimeInterval = 60 * 60 * 24
+
+    static let managedFilePrefixes = [
+        "Symi-Bericht-",
+        "schmerztagebuch-export-",
+        "sync-log-"
+    ]
+
+    static func prepareProtectedTemporaryFile(
+        at url: URL,
+        fileManager: FileManager = .default,
+        now: Date = .now
+    ) throws {
+        try cleanupExpiredFiles(fileManager: fileManager, now: now)
+
+        if fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
+    }
+
+    static func finalizeProtectedTemporaryFile(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        try ProtectedFileStorage.applyProtection(to: url, fileManager: fileManager, excludedFromBackup: true)
+    }
+
+    static func cleanupManagedFile(at url: URL?, fileManager: FileManager = .default) {
+        guard let url, isManagedTemporaryFile(url) else {
+            return
+        }
+
+        try? fileManager.removeItem(at: url)
+    }
+
+    static func cleanupExpiredFiles(
+        fileManager: FileManager = .default,
+        now: Date = .now
+    ) throws {
+        let temporaryDirectory = fileManager.temporaryDirectory
+        let fileURLs = try fileManager.contentsOfDirectory(
+            at: temporaryDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        for fileURL in fileURLs where isManagedTemporaryFile(fileURL) {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey])
+            guard resourceValues.isRegularFile == true else {
+                continue
+            }
+
+            let modificationDate = resourceValues.contentModificationDate ?? .distantPast
+            if now.timeIntervalSince(modificationDate) > expirationInterval {
+                try? fileManager.removeItem(at: fileURL)
+            }
+        }
+    }
+
+    static func isManagedTemporaryFile(_ url: URL, fileManager: FileManager = .default) -> Bool {
+        url.deletingLastPathComponent().standardizedFileURL == fileManager.temporaryDirectory.standardizedFileURL
+            && managedFilePrefixes.contains { url.lastPathComponent.hasPrefix($0) }
+    }
+}

--- a/SymiTests/FileProtectionPolicyTests.swift
+++ b/SymiTests/FileProtectionPolicyTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import Symi
+
+struct FileProtectionPolicyTests {
+    @Test
+    func protectedDirectoryAndFileUseCompleteProtection() throws {
+        let directory = try makeTemporaryDirectory()
+        let protectedDirectory = directory.appendingPathComponent("Protected", isDirectory: true)
+        let protectedFile = protectedDirectory.appendingPathComponent("health-context.json")
+
+        try ProtectedFileStorage.createProtectedDirectory(at: protectedDirectory)
+        try Data("sensibel".utf8).write(to: protectedFile, options: .atomic)
+        try ProtectedFileStorage.applyProtection(to: protectedFile)
+
+        try expectCompleteProtectionWhenAvailable(at: protectedDirectory)
+        try expectCompleteProtectionWhenAvailable(at: protectedFile)
+    }
+
+    @Test
+    func temporaryExportFilesAreProtectedExcludedFromBackupAndExpire() throws {
+        let fileManager = FileManager.default
+        let activeURL = fileManager.temporaryDirectory.appendingPathComponent("schmerztagebuch-export-\(UUID().uuidString).json5")
+        let expiredURL = fileManager.temporaryDirectory.appendingPathComponent("Symi-Bericht-\(UUID().uuidString).pdf")
+        defer {
+            try? fileManager.removeItem(at: activeURL)
+            try? fileManager.removeItem(at: expiredURL)
+        }
+
+        try TemporaryExportFileLifecycle.prepareProtectedTemporaryFile(at: activeURL)
+        try Data("aktiv".utf8).write(to: activeURL, options: .atomic)
+        try TemporaryExportFileLifecycle.finalizeProtectedTemporaryFile(at: activeURL)
+
+        try Data("abgelaufen".utf8).write(to: expiredURL, options: .atomic)
+        let expiredDate = Date(timeIntervalSinceNow: -(TemporaryExportFileLifecycle.expirationInterval + 60))
+        try fileManager.setAttributes([.modificationDate: expiredDate], ofItemAtPath: expiredURL.path)
+
+        try TemporaryExportFileLifecycle.cleanupExpiredFiles(now: .now)
+
+        try expectCompleteProtectionWhenAvailable(at: activeURL)
+        #expect(try activeURL.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup == true)
+        #expect(fileManager.fileExists(atPath: activeURL.path))
+        #expect(!fileManager.fileExists(atPath: expiredURL.path))
+    }
+
+    @Test
+    @MainActor
+    func healthContextSidecarsAreProtected() throws {
+        let baseURL = try makeTemporaryDirectory()
+        let episodeID = UUID()
+        let store = HealthContextStore(baseURL: baseURL)
+
+        try store.save(
+            HealthContextSnapshotData(
+                recordedAt: Date(timeIntervalSince1970: 1_000),
+                source: "Test",
+                sleepMinutes: 420,
+                stepCount: 1_200,
+                averageHeartRate: nil,
+                restingHeartRate: 62,
+                heartRateVariability: nil,
+                menstrualFlow: nil,
+                symptoms: []
+            ),
+            for: episodeID
+        )
+
+        let sidecarURL = baseURL
+            .appendingPathComponent("Symi", isDirectory: true)
+            .appendingPathComponent("HealthContext", isDirectory: true)
+            .appendingPathComponent("\(episodeID.uuidString).json")
+        try expectCompleteProtectionWhenAvailable(at: sidecarURL)
+    }
+}
+
+private func expectCompleteProtectionWhenAvailable(at url: URL, fileManager: FileManager = .default) throws {
+    let protection = try fileManager.attributesOfItem(atPath: url.path)[.protectionKey] as? FileProtectionType
+    if let protection {
+        #expect(protection == ProtectedFileStorage.fileProtectionType)
+    }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}


### PR DESCRIPTION
## Änderungen
- setzt eine zentrale File-Protection-Policy für lokale Store-Dateien, HealthContext-Sidecars, Sync-State, App-Logs und temporäre Exporte
- markiert temporäre Export-/Recovery-Dateien als vom Backup ausgeschlossen und räumt alte verwaltete Exportdateien nach 24 Stunden auf
- ergänzt UI-Hinweise, dass geteilte PDF- und Backup-Dateien außerhalb der App-Sandbox liegen können
- ergänzt Tests für Schutz-/Backup-Attribute, HealthContext-Sidecars und Export-Ablauf-Cleanup

## Validierung
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #224
