### PR TITLE
[codex] Isolate sync provider concurrency state

### DIFF
--- a/Symi/Sources/Core/Insights/InsightCore.swift
+++ b/Symi/Sources/Core/Insights/InsightCore.swift
@@ -261,12 +261,8 @@ extension InsightMetrics {
     }
 }
 
-final class InsightEngine: @unchecked Sendable {
+final class InsightEngine: Sendable {
     static let minimumQualifiedEpisodeCount = 5
-
-    private var cachedFingerprint: String?
-    private var cachedResult: InsightResult?
-    private let cacheLock = NSLock()
 
     func evaluate(
         episodes: [EpisodeRecord],
@@ -274,20 +270,6 @@ final class InsightEngine: @unchecked Sendable {
         referenceDate: Date? = nil,
         calendar: Calendar = .current
     ) -> InsightResult {
-        let fingerprint = DataAggregator.fingerprint(
-            for: episodes,
-            period: period,
-            referenceDate: referenceDate,
-            calendar: calendar
-        )
-
-        cacheLock.lock()
-        if fingerprint == cachedFingerprint, let cachedResult {
-            cacheLock.unlock()
-            return cachedResult
-        }
-        cacheLock.unlock()
-
         let aggregate = DataAggregator.aggregate(
             episodes: episodes,
             period: period,
@@ -338,11 +320,6 @@ final class InsightEngine: @unchecked Sendable {
                 insights: insights
             )
         }
-
-        cacheLock.lock()
-        cachedFingerprint = fingerprint
-        cachedResult = result
-        cacheLock.unlock()
 
         return result
     }

--- a/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
+++ b/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
@@ -15,7 +15,7 @@ struct SyncFailedRecordSave: Sendable {
     let error: CKError
 }
 
-protocol SyncProvider: AnyObject {
+protocol SyncProvider: AnyObject, Sendable {
     var queuedChangeCount: Int { get async }
     var accountAvailability: SyncServiceState { get async }
 
@@ -26,15 +26,88 @@ protocol SyncProvider: AnyObject {
     func send() async throws
 }
 
-final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
+actor CloudKitSyncProviderState {
+    private var syncEngine: CKSyncEngine?
+    private var pendingRecordNames = Set<String>()
+
+    var queuedChangeCount: Int {
+        if let syncEngine {
+            return syncEngine.state.pendingRecordZoneChanges.count + syncEngine.state.pendingDatabaseChanges.count
+        }
+
+        return pendingRecordNames.count
+    }
+
+    func hasSyncEngine() -> Bool {
+        syncEngine != nil
+    }
+
+    func installSyncEngine(_ engine: CKSyncEngine) {
+        syncEngine = engine
+    }
+
+    func stopSyncEngine() async {
+        await syncEngine?.cancelOperations()
+        syncEngine = nil
+    }
+
+    func queue(recordNames: [String], zoneID: CKRecordZone.ID) -> Bool {
+        pendingRecordNames.formUnion(recordNames)
+
+        guard let syncEngine else {
+            return false
+        }
+
+        syncEngine.state.add(pendingRecordZoneChanges: pendingRecordZoneChanges(for: recordNames, zoneID: zoneID))
+        return true
+    }
+
+    func removeSentRecordNames(_ recordNames: [String]) {
+        pendingRecordNames.subtract(recordNames)
+    }
+
+    func fetchChanges(zoneID: CKRecordZone.ID) async throws -> Bool {
+        guard let syncEngine else {
+            return false
+        }
+
+        try await syncEngine.fetchChanges(
+            .init(scope: .zoneIDs([zoneID]))
+        )
+        return true
+    }
+
+    func sendChanges(zoneID: CKRecordZone.ID) async throws -> Bool {
+        guard let syncEngine else {
+            return false
+        }
+
+        try await syncEngine.sendChanges(
+            .init(scope: .zoneIDs([zoneID]))
+        )
+        return true
+    }
+
+    private func pendingRecordZoneChanges(
+        for recordNames: [String],
+        zoneID: CKRecordZone.ID
+    ) -> [CKSyncEngine.PendingRecordZoneChange] {
+        recordNames.map {
+            CKSyncEngine.PendingRecordZoneChange.saveRecord(
+                CKRecord.ID(recordName: $0, zoneID: zoneID)
+            )
+        }
+    }
+}
+
+final class CloudKitSyncProvider: NSObject, SyncProvider {
     private let stateStore: SyncStateStore
     private let zoneID: CKRecordZone.ID
     private let recordProvider: @Sendable (CKRecord.ID) async -> CKRecord?
     private let eventHandler: @Sendable (SyncProviderEvent) async -> Void
     private let appLogStore: AppLogStore
-    private var syncEngine: CKSyncEngine?
+    private let providerState = CloudKitSyncProviderState()
     private let container = CKContainer(identifier: SyncConfiguration.containerIdentifier)
-    private var pendingRecordNames = Set<String>()
 
     init(
         stateStore: SyncStateStore,
@@ -52,11 +125,7 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
 
     var queuedChangeCount: Int {
         get async {
-            if let syncEngine {
-                return syncEngine.state.pendingRecordZoneChanges.count + syncEngine.state.pendingDatabaseChanges.count
-            }
-
-            return pendingRecordNames.count
+            await providerState.queuedChangeCount
         }
     }
 
@@ -78,7 +147,7 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
     }
 
     func start() async throws {
-        guard syncEngine == nil else {
+        guard await !providerState.hasSyncEngine() else {
             await log(level: .debug, operation: "provider.start.skip", message: "Sync-Engine läuft bereits.")
             return
         }
@@ -96,63 +165,52 @@ final class CloudKitSyncProvider: NSObject, @unchecked Sendable, SyncProvider {
                 .saveZone(CKRecordZone(zoneID: zoneID))
             ]
         )
-        syncEngine = engine
+        await providerState.installSyncEngine(engine)
         await log(level: .info, operation: "provider.start", message: "CloudKit-Sync-Engine gestartet.", metadata: [
             "zone": zoneID.zoneName
         ])
     }
 
     func stop() async {
-        await syncEngine?.cancelOperations()
-        syncEngine = nil
+        await providerState.stopSyncEngine()
         await log(level: .info, operation: "provider.stop", message: "CloudKit-Sync-Engine gestoppt.")
     }
 
     func queue(recordNames: [String]) async {
-        pendingRecordNames.formUnion(recordNames)
         await log(level: .debug, operation: "provider.queue", message: "Records für Upload markiert.", metadata: [
             "count": "\(recordNames.count)",
             "recordNames": recordNames.sorted().joined(separator: ",")
         ])
 
-        guard let syncEngine else {
+        let wasQueuedInEngine = await providerState.queue(recordNames: recordNames, zoneID: zoneID)
+        guard wasQueuedInEngine else {
             await log(level: .warning, operation: "provider.queue.deferred", message: "Queue wurde vorgemerkt, Engine ist aber noch nicht aktiv.")
             return
         }
-
-        let changes = recordNames.map {
-            CKSyncEngine.PendingRecordZoneChange.saveRecord(
-                CKRecord.ID(recordName: $0, zoneID: zoneID)
-            )
-        }
-        syncEngine.state.add(pendingRecordZoneChanges: changes)
     }
 
     func fetch() async throws {
-        guard let syncEngine else {
+        guard await providerState.hasSyncEngine() else {
             await log(level: .warning, operation: "provider.fetch.skip", message: "Fetch übersprungen, da keine Sync-Engine aktiv ist.")
             return
         }
 
         await log(level: .info, operation: "provider.fetch.start", message: "CloudKit-Änderungen werden geladen.")
-        try await syncEngine.fetchChanges(
-            .init(scope: .zoneIDs([zoneID]))
-        )
+        _ = try await providerState.fetchChanges(zoneID: zoneID)
         await log(level: .info, operation: "provider.fetch.finish", message: "CloudKit-Änderungen wurden geladen.")
     }
 
     func send() async throws {
-        guard let syncEngine else {
+        guard await providerState.hasSyncEngine() else {
             await log(level: .warning, operation: "provider.send.skip", message: "Upload übersprungen, da keine Sync-Engine aktiv ist.")
             return
         }
 
+        let pendingRecordCount = await queuedChangeCount
         await log(level: .info, operation: "provider.send.start", message: "CloudKit-Änderungen werden gesendet.", metadata: [
-            "pendingRecords": "\(await queuedChangeCount)"
+            "pendingRecords": "\(pendingRecordCount)"
         ])
-        try await syncEngine.sendChanges(
-            .init(scope: .zoneIDs([zoneID]))
-        )
+        _ = try await providerState.sendChanges(zoneID: zoneID)
         await log(level: .info, operation: "provider.send.finish", message: "CloudKit-Änderungen wurden gesendet.")
     }
 }
@@ -174,7 +232,7 @@ extension CloudKitSyncProvider: CKSyncEngineDelegate {
             let failures = changes.failedRecordSaves.map {
                 SyncFailedRecordSave(recordID: $0.record.recordID, error: $0.error)
             }
-            pendingRecordNames.subtract(changes.savedRecords.map { $0.recordID.recordName })
+            await providerState.removeSentRecordNames(changes.savedRecords.map { $0.recordID.recordName })
             await log(level: failures.isEmpty ? .info : .warning, operation: "provider.event.sentRecordZoneChanges", message: "Upload-Ergebnis erhalten.", metadata: [
                 "savedRecords": "\(changes.savedRecords.count)",
                 "failedRecords": "\(failures.count)"

--- a/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
+++ b/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
@@ -1,17 +1,13 @@
 import Foundation
 
-final class HealthContextStore: @unchecked Sendable {
+final class HealthContextStore: Sendable {
     private let directoryURL: URL
-    private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
 
     init(baseURL: URL? = nil) {
         let root = baseURL ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ?? FileManager.default.temporaryDirectory
         self.directoryURL = root
             .appendingPathComponent("Symi", isDirectory: true)
             .appendingPathComponent("HealthContext", isDirectory: true)
-        encoder.dateEncodingStrategy = .iso8601
-        decoder.dateDecodingStrategy = .iso8601
     }
 
     nonisolated func save(_ snapshot: HealthContextSnapshotData?, for episodeID: UUID) throws {
@@ -25,6 +21,8 @@ final class HealthContextStore: @unchecked Sendable {
         }
 
         try ProtectedFileStorage.createProtectedDirectory(at: directoryURL)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(snapshot)
         try data.write(to: url, options: .atomic)
         try ProtectedFileStorage.applyProtection(to: url)
@@ -32,6 +30,8 @@ final class HealthContextStore: @unchecked Sendable {
 
     nonisolated func load(for episodeID: UUID) -> HealthContextRecord? {
         let url = fileURL(for: episodeID)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
         guard let data = try? Data(contentsOf: url), let snapshot = try? decoder.decode(HealthContextSnapshotData.self, from: data) else {
             return nil
         }

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftData
 
-final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
+final class SwiftDataEpisodeRepository: EpisodeRepository, Sendable {
     private let modelContainer: ModelContainer
     private let healthContextStore: HealthContextStore
 
@@ -175,7 +175,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, @unchecked Sendable {
     }
 }
 
-final class SwiftDataContinuousMedicationRepository: ContinuousMedicationRepository, @unchecked Sendable {
+final class SwiftDataContinuousMedicationRepository: ContinuousMedicationRepository, Sendable {
     private let modelContainer: ModelContainer
 
     init(modelContainer: ModelContainer) {
@@ -258,7 +258,7 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
     }
 }
 
-final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository, @unchecked Sendable {
+final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository, Sendable {
     private let modelContainer: ModelContainer
 
     init(modelContainer: ModelContainer) {
@@ -353,7 +353,7 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository, @
     }
 }
 
-final class SwiftDataExportRepository: ExportRepository, @unchecked Sendable {
+final class SwiftDataExportRepository: ExportRepository, Sendable {
     private let modelContainer: ModelContainer
     private let healthContextStore: HealthContextStore
 

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreLocation
+import os
 import Testing
 import WeatherKit
 @testable import Symi
@@ -667,41 +668,97 @@ struct CoreArchitectureTests {
 
 }
 
-private final class EpisodeRepositoryMock: EpisodeRepository, @unchecked Sendable {
-    var recentRecords: [EpisodeRecord] = []
-    var monthRecords: [EpisodeRecord] = []
-    var dayRecords: [EpisodeRecord] = []
-    var loadedRecord: EpisodeRecord?
-    var deletedRecords: [EpisodeRecord] = []
-    var lastSavedDraft: EpisodeDraft?
-    var lastWeatherSnapshot: WeatherSnapshotData?
-    var lastHealthContext: HealthContextSnapshotData?
+private final class EpisodeRepositoryMock: EpisodeRepository, Sendable {
+    private struct State: Sendable {
+        var recentRecords: [EpisodeRecord] = []
+        var monthRecords: [EpisodeRecord] = []
+        var dayRecords: [EpisodeRecord] = []
+        var loadedRecord: EpisodeRecord?
+        var deletedRecords: [EpisodeRecord] = []
+        var lastSavedDraft: EpisodeDraft?
+        var lastWeatherSnapshot: WeatherSnapshotData?
+        var lastHealthContext: HealthContextSnapshotData?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
     let savedDraftID = UUID()
 
-    func fetchRecent() throws -> [EpisodeRecord] { recentRecords }
-    func fetchByDay(_ day: Date) throws -> [EpisodeRecord] { dayRecords }
-    func fetchByMonth(_ month: Date) throws -> [EpisodeRecord] { monthRecords }
-    func load(id: UUID) throws -> EpisodeRecord? { loadedRecord }
+    var recentRecords: [EpisodeRecord] {
+        get { state.withLock(\.recentRecords) }
+        set { state.withLock { $0.recentRecords = newValue } }
+    }
+    var monthRecords: [EpisodeRecord] {
+        get { state.withLock(\.monthRecords) }
+        set { state.withLock { $0.monthRecords = newValue } }
+    }
+    var dayRecords: [EpisodeRecord] {
+        get { state.withLock(\.dayRecords) }
+        set { state.withLock { $0.dayRecords = newValue } }
+    }
+    var loadedRecord: EpisodeRecord? {
+        get { state.withLock(\.loadedRecord) }
+        set { state.withLock { $0.loadedRecord = newValue } }
+    }
+    var deletedRecords: [EpisodeRecord] {
+        get { state.withLock(\.deletedRecords) }
+        set { state.withLock { $0.deletedRecords = newValue } }
+    }
+    var lastSavedDraft: EpisodeDraft? {
+        state.withLock(\.lastSavedDraft)
+    }
+    var lastWeatherSnapshot: WeatherSnapshotData? {
+        state.withLock(\.lastWeatherSnapshot)
+    }
+    var lastHealthContext: HealthContextSnapshotData? {
+        state.withLock(\.lastHealthContext)
+    }
+
+    func fetchRecent() throws -> [EpisodeRecord] { state.withLock(\.recentRecords) }
+    func fetchByDay(_ day: Date) throws -> [EpisodeRecord] { state.withLock(\.dayRecords) }
+    func fetchByMonth(_ month: Date) throws -> [EpisodeRecord] { state.withLock(\.monthRecords) }
+    func load(id: UUID) throws -> EpisodeRecord? { state.withLock(\.loadedRecord) }
     func save(draft: EpisodeDraft, weatherSnapshot: WeatherSnapshotData?, healthContext: HealthContextSnapshotData?) throws -> UUID {
-        lastSavedDraft = draft
-        lastWeatherSnapshot = weatherSnapshot
-        lastHealthContext = healthContext
+        state.withLock {
+            $0.lastSavedDraft = draft
+            $0.lastWeatherSnapshot = weatherSnapshot
+            $0.lastHealthContext = healthContext
+        }
         return savedDraftID
     }
     func softDelete(id: UUID) throws {}
     func restore(id: UUID) throws {}
-    func fetchDeleted() throws -> [EpisodeRecord] { deletedRecords }
+    func fetchDeleted() throws -> [EpisodeRecord] { state.withLock(\.deletedRecords) }
 }
 
-private final class MedicationCatalogRepositoryMock: MedicationCatalogRepository, @unchecked Sendable {
-    var definitions: [MedicationDefinitionRecord] = []
-    var deletedDefinitions: [MedicationDefinitionRecord] = []
-    var savedDrafts: [CustomMedicationDefinitionDraft] = []
-    var deletedCatalogKeys: [String] = []
+private final class MedicationCatalogRepositoryMock: MedicationCatalogRepository, Sendable {
+    private struct State: Sendable {
+        var definitions: [MedicationDefinitionRecord] = []
+        var deletedDefinitions: [MedicationDefinitionRecord] = []
+        var savedDrafts: [CustomMedicationDefinitionDraft] = []
+        var deletedCatalogKeys: [String] = []
+    }
 
-    func fetchDefinitions(searchText: String?) throws -> [MedicationDefinitionRecord] { definitions }
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var definitions: [MedicationDefinitionRecord] {
+        get { state.withLock(\.definitions) }
+        set { state.withLock { $0.definitions = newValue } }
+    }
+    var deletedDefinitions: [MedicationDefinitionRecord] {
+        get { state.withLock(\.deletedDefinitions) }
+        set { state.withLock { $0.deletedDefinitions = newValue } }
+    }
+    var savedDrafts: [CustomMedicationDefinitionDraft] {
+        state.withLock(\.savedDrafts)
+    }
+    var deletedCatalogKeys: [String] {
+        state.withLock(\.deletedCatalogKeys)
+    }
+
+    func fetchDefinitions(searchText: String?) throws -> [MedicationDefinitionRecord] {
+        state.withLock(\.definitions)
+    }
     func saveCustomDefinition(_ draft: CustomMedicationDefinitionDraft) throws -> MedicationDefinitionRecord {
-        savedDrafts.append(draft)
         let record = MedicationDefinitionRecord(
             catalogKey: draft.id,
             groupID: "custom-medications",
@@ -714,13 +771,20 @@ private final class MedicationCatalogRepositoryMock: MedicationCatalogRepository
             isCustom: true,
             isDeleted: false
         )
-        definitions.append(record)
+        state.withLock {
+            $0.savedDrafts.append(draft)
+            $0.definitions.append(record)
+        }
         return record
     }
     func softDeleteCustomDefinition(catalogKey: String) throws {
-        deletedCatalogKeys.append(catalogKey)
+        state.withLock {
+            $0.deletedCatalogKeys.append(catalogKey)
+        }
     }
-    func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord] { deletedDefinitions }
+    func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord] {
+        state.withLock(\.deletedDefinitions)
+    }
 }
 
 private enum UnexpectedServiceCallError: Error {

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 @testable import Symi
 
@@ -251,12 +252,29 @@ private enum EntryFlowTestError: Error {
     case timedOut
 }
 
-private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, @unchecked Sendable {
+private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, Sendable {
+    private struct State: Sendable {
+        var lastSavedDraft: EpisodeDraft?
+        var lastWeatherSnapshot: WeatherSnapshotData?
+        var lastHealthContext: HealthContextSnapshotData?
+        var saveCount = 0
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
     let savedID = UUID()
-    var lastSavedDraft: EpisodeDraft?
-    var lastWeatherSnapshot: WeatherSnapshotData?
-    var lastHealthContext: HealthContextSnapshotData?
-    var saveCount = 0
+
+    var lastSavedDraft: EpisodeDraft? {
+        state.withLock(\.lastSavedDraft)
+    }
+    var lastWeatherSnapshot: WeatherSnapshotData? {
+        state.withLock(\.lastWeatherSnapshot)
+    }
+    var lastHealthContext: HealthContextSnapshotData? {
+        state.withLock(\.lastHealthContext)
+    }
+    var saveCount: Int {
+        state.withLock(\.saveCount)
+    }
 
     func fetchRecent() throws -> [EpisodeRecord] { [] }
     func fetchByDay(_ day: Date) throws -> [EpisodeRecord] { [] }
@@ -264,10 +282,12 @@ private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, @unchecke
     func load(id: UUID) throws -> EpisodeRecord? { nil }
 
     func save(draft: EpisodeDraft, weatherSnapshot: WeatherSnapshotData?, healthContext: HealthContextSnapshotData?) throws -> UUID {
-        saveCount += 1
-        lastSavedDraft = draft
-        lastWeatherSnapshot = weatherSnapshot
-        lastHealthContext = healthContext
+        state.withLock {
+            $0.saveCount += 1
+            $0.lastSavedDraft = draft
+            $0.lastWeatherSnapshot = weatherSnapshot
+            $0.lastHealthContext = healthContext
+        }
         return savedID
     }
 
@@ -276,7 +296,7 @@ private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, @unchecke
     func fetchDeleted() throws -> [EpisodeRecord] { [] }
 }
 
-private final class EntryFlowMedicationRepositoryMock: MedicationCatalogRepository, @unchecked Sendable {
+private final class EntryFlowMedicationRepositoryMock: MedicationCatalogRepository, Sendable {
     func fetchDefinitions(searchText: String?) throws -> [MedicationDefinitionRecord] { [] }
 
     func saveCustomDefinition(_ draft: CustomMedicationDefinitionDraft) throws -> MedicationDefinitionRecord {
@@ -298,7 +318,7 @@ private final class EntryFlowMedicationRepositoryMock: MedicationCatalogReposito
     func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord] { [] }
 }
 
-private final class EntryFlowContinuousMedicationRepositoryMock: ContinuousMedicationRepository, @unchecked Sendable {
+private final class EntryFlowContinuousMedicationRepositoryMock: ContinuousMedicationRepository, Sendable {
     let activeMedications: [ContinuousMedicationRecord]
 
     init(activeMedications: [ContinuousMedicationRecord] = []) {

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -125,6 +125,39 @@ struct SyncMergeEngineTests {
     }
 
     @Test
+    func cloudKitProviderStateSerializesConcurrentQueueAccess() async {
+        let state = CloudKitSyncProviderState()
+        let recordNames = (0..<80).map { "record-\($0)" }
+
+        await withTaskGroup(of: Void.self) { group in
+            for recordName in recordNames {
+                group.addTask {
+                    _ = await state.queue(recordNames: [recordName], zoneID: syncTestZoneID)
+                }
+            }
+        }
+
+        #expect(await state.queuedChangeCount == recordNames.count)
+    }
+
+    @Test
+    func cloudKitProviderStateRemovesSentRecordsAcrossConcurrentCallbacks() async {
+        let state = CloudKitSyncProviderState()
+        let recordNames = (0..<60).map { "record-\($0)" }
+        _ = await state.queue(recordNames: recordNames, zoneID: syncTestZoneID)
+
+        await withTaskGroup(of: Void.self) { group in
+            for chunk in recordNames.chunked(into: 5) {
+                group.addTask {
+                    await state.removeSentRecordNames(chunk)
+                }
+            }
+        }
+
+        #expect(await state.queuedChangeCount == 0)
+    }
+
+    @Test
     @MainActor
     func cloudKitRecordCodecRejectsEnvelopeMetadataMismatch() throws {
         let envelope = definitionEnvelope(name: "Sumatriptan", deletedAt: nil)
@@ -666,6 +699,14 @@ private func fuzzedEpisodeEnvelope(seed: Int) -> SyncDocumentEnvelope {
 
 private let syncTestDeviceID = "device-local"
 private let syncTestZoneID = CKRecordZone.ID(zoneName: "SyncTests", ownerName: CKCurrentUserDefaultName)
+
+private extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map { startIndex in
+            Array(self[startIndex..<Swift.min(startIndex + size, count)])
+        }
+    }
+}
 
 @MainActor
 private func makeSyncTestStack() throws -> (


### PR DESCRIPTION
## Summary
- Isolate mutable CloudKit sync engine and pending record state behind an actor.
- Remove all remaining @unchecked Sendable conformances from app and tests.
- Make SwiftData repositories, HealthContextStore, InsightEngine, and test spies checked Sendable.
- Add concurrent provider-state tests for queue and sent-record callback handling.

## Validation
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination "platform=iOS Simulator,name=iPhone 17"
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination "platform=macOS,variant=Mac Catalyst,name=My Mac"
- rg -n "@unchecked|@uncheckedSendable" Symi SymiTests

Closes #226