### PR TITLE
Validate domain invariants centrally

### DIFF
--- a/Symi/Sources/App/StartupMaintenanceService.swift
+++ b/Symi/Sources/App/StartupMaintenanceService.swift
@@ -90,6 +90,8 @@ final class StartupMaintenanceService {
                     didChange = true
                 }
             }
+
+            try DomainValidator.validate(episode)
         }
 
         let definitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
@@ -99,6 +101,11 @@ final class StartupMaintenanceService {
                 definition.categoryRaw = normalizedCategory
                 didChange = true
             }
+        }
+
+        let continuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
+        for medication in continuousMedications {
+            try DomainValidator.validate(medication)
         }
 
         if didChange {

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -153,6 +153,8 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
     }
 
     nonisolated func previewImport(into context: ModelContext) throws -> BackupImportPreview {
+        try validateDomainInvariants()
+
         let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
         let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
         let existingDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
@@ -218,6 +220,8 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
     }
 
     nonisolated func merge(into context: ModelContext, healthContextStore: HealthContextStore) throws {
+        try validateDomainInvariants()
+
         let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
         let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
 
@@ -256,6 +260,22 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
 
         try context.save()
         try mergeEpisodeSidecars(into: healthContextStore)
+    }
+
+    private nonisolated func validateDomainInvariants() throws {
+        var issues: [String] = []
+
+        for (index, payload) in episodes.enumerated() {
+            issues.append(contentsOf: payload.domainValidationIssues(path: "episodes[\(index)]"))
+        }
+
+        for (index, payload) in continuousMedications.enumerated() {
+            issues.append(contentsOf: payload.domainValidationIssues(path: "continuousMedications[\(index)]"))
+        }
+
+        guard issues.isEmpty else {
+            throw DomainValidationError.invalid(issues: issues)
+        }
     }
 
     private nonisolated func mergeEpisodeSidecars(into healthContextStore: HealthContextStore) throws {
@@ -498,6 +518,11 @@ struct EpisodePayload: Codable, Sendable {
 
         try healthContextStore.save(healthContext, for: id)
     }
+
+    nonisolated func domainValidationIssues(path: String) -> [String] {
+        let episode = makeModel()
+        return DomainValidator.episodeIssues(for: episode, path: path)
+    }
 }
 
 struct MedicationEntryPayload: @preconcurrency Codable, Sendable {
@@ -738,6 +763,10 @@ struct ContinuousMedicationPayload: Codable, Sendable {
         medication.endDate = endDate
         medication.createdAt = createdAt
         medication.updatedAt = updatedAt
+    }
+
+    nonisolated func domainValidationIssues(path: String) -> [String] {
+        DomainValidator.continuousMedicationIssues(for: makeModel(), path: path)
     }
 }
 

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -124,6 +124,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, Sendable {
             target.weatherSnapshot = WeatherSnapshot(snapshot: weatherSnapshot, episode: target)
         }
 
+        try DomainValidator.validate(target)
         try context.save()
         try healthContextStore.save(healthContext, for: target.id)
         return target.id
@@ -227,6 +228,7 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
             context.insert(medication)
         }
 
+        try DomainValidator.validate(medication)
         try context.save()
         return ContinuousMedicationRecord(medication: medication)
     }

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -18,6 +18,9 @@ struct LocalSyncRepository {
             .filter(\.isCustom)
         let continuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
 
+        try episodes.forEach(DomainValidator.validate)
+        try continuousMedications.forEach(DomainValidator.validate)
+
         return episodes.map { $0.syncEnvelope(deviceID: deviceID, healthContextStore: healthContextStore) } +
             customDefinitions.map { $0.syncEnvelope(deviceID: deviceID) } +
             continuousMedications.map { $0.syncEnvelope(deviceID: deviceID) }
@@ -144,6 +147,8 @@ struct LocalSyncRepository {
             context.insert(target)
         }
 
+        try DomainValidator.validate(target)
+
         if payload.includesHealthContext {
             try healthContextStore.save(payload.healthContext, for: episodeID)
         }
@@ -216,6 +221,8 @@ struct LocalSyncRepository {
         if existing == nil {
             context.insert(target)
         }
+
+        try DomainValidator.validate(target)
     }
 }
 
@@ -297,15 +304,119 @@ enum RemoteSyncPayloadValidator {
             if let weatherSnapshot = payload.weatherSnapshot {
                 validateUUID(weatherSnapshot.id, field: "episode.weatherSnapshot.id", into: &issues)
             }
+
+            issues.append(contentsOf: domainIssues(for: payload, path: "episode"))
         case .medicationDefinition(let payload):
             validateDocumentID(envelope.documentID, expectedPrefix: "medicationDefinition", payloadID: payload.catalogKey, into: &issues)
             validateKnownValue(payload.category, field: "medicationDefinition.category", allowedValues: medicationCategoryValues, into: &issues)
         case .continuousMedication(let payload):
             validateUUID(payload.id, field: "continuousMedication.id", into: &issues)
             validateDocumentID(envelope.documentID, expectedPrefix: "continuousMedication", payloadID: payload.id, into: &issues)
+            issues.append(contentsOf: domainIssues(for: payload, path: "continuousMedication"))
         }
 
         return issues
+    }
+
+    private static func domainIssues(for payload: SyncEpisodePayload, path: String) -> [String] {
+        guard let episodeID = UUID(uuidString: payload.id) else {
+            return []
+        }
+
+        let episode = Episode(
+            id: episodeID,
+            startedAt: payload.startedAt,
+            endedAt: payload.endedAt,
+            type: EpisodeType(storageValue: payload.type),
+            intensity: payload.intensity,
+            painLocation: payload.painLocation,
+            painCharacter: payload.painCharacter,
+            notes: payload.notes,
+            symptoms: payload.symptoms,
+            triggers: payload.triggers,
+            functionalImpact: payload.functionalImpact,
+            menstruationStatus: MenstruationStatus(storageValue: payload.menstruationStatus)
+        )
+
+        episode.medications = payload.medications.compactMap { medication in
+            guard let medicationID = UUID(uuidString: medication.id) else {
+                return nil
+            }
+
+            return MedicationEntry(
+                id: medicationID,
+                name: medication.name,
+                category: MedicationCategory(storageValue: medication.category),
+                dosage: medication.dosage,
+                quantity: medication.quantity,
+                takenAt: medication.takenAt,
+                effectiveness: MedicationEffectiveness(storageValue: medication.effectiveness),
+                reliefStartedAt: medication.reliefStartedAt,
+                isRepeatDose: medication.isRepeatDose,
+                episode: episode
+            )
+        }
+
+        episode.continuousMedicationChecks = payload.continuousMedicationChecks.compactMap { check in
+            guard
+                let checkID = UUID(uuidString: check.id),
+                let medicationID = UUID(uuidString: check.continuousMedicationID)
+            else {
+                return nil
+            }
+
+            return ContinuousMedicationCheck(
+                id: checkID,
+                continuousMedicationID: medicationID,
+                name: check.name,
+                dosage: check.dosage,
+                frequency: check.frequency,
+                wasTaken: check.wasTaken,
+                episode: episode
+            )
+        }
+
+        if
+            let weather = payload.weatherSnapshot,
+            let weatherID = UUID(uuidString: weather.id) {
+            episode.weatherSnapshot = WeatherSnapshot(
+                id: weatherID,
+                recordedAt: weather.recordedAt,
+                temperature: weather.temperature,
+                condition: weather.condition,
+                humidity: weather.humidity,
+                pressure: weather.pressure,
+                precipitation: weather.precipitation,
+                weatherCode: weather.weatherCode,
+                source: weather.source,
+                dayRangeStart: weather.dayRangeStart,
+                dayRangeEnd: weather.dayRangeEnd,
+                contextRangeStart: weather.contextRangeStart,
+                contextRangeEnd: weather.contextRangeEnd,
+                contextPointsStorage: WeatherSnapshot.encodeContextPoints(weather.contextPoints),
+                episode: episode
+            )
+        }
+
+        return DomainValidator.episodeIssues(for: episode, path: path)
+    }
+
+    private static func domainIssues(for payload: SyncContinuousMedicationPayload, path: String) -> [String] {
+        guard let medicationID = UUID(uuidString: payload.id) else {
+            return []
+        }
+
+        let medication = ContinuousMedication(
+            id: medicationID,
+            name: payload.name,
+            dosage: payload.dosage,
+            frequency: payload.frequency,
+            startDate: payload.startDate,
+            endDate: payload.endDate,
+            createdAt: payload.createdAt
+        )
+
+        return DomainValidator.continuousMedicationIssues(for: medication, path: path)
     }
 
     private static func validateUUID(_ value: String, field: String, into issues: inout [String]) {

--- a/Symi/Sources/Models/DomainValidator.swift
+++ b/Symi/Sources/Models/DomainValidator.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+enum DomainValidationError: LocalizedError, Equatable {
+    case invalid(issues: [String])
+
+    var errorDescription: String? {
+        switch self {
+        case .invalid(let issues):
+            "Domain-Daten sind ungültig: \(issues.joined(separator: ", "))"
+        }
+    }
+
+    var issues: [String] {
+        switch self {
+        case .invalid(let issues):
+            issues
+        }
+    }
+}
+
+nonisolated enum DomainValidator {
+    static let intensityRange = 1 ... 10
+
+    static func validate(_ episode: Episode) throws {
+        try throwIfInvalid(episodeIssues(for: episode))
+    }
+
+    static func validate(_ medication: ContinuousMedication) throws {
+        try throwIfInvalid(continuousMedicationIssues(for: medication))
+    }
+
+    static func validate(_ snapshot: WeatherSnapshot) throws {
+        try throwIfInvalid(weatherSnapshotIssues(for: snapshot))
+    }
+
+    static func episodeIssues(for episode: Episode, path: String = "episode") -> [String] {
+        var issues: [String] = []
+
+        appendDateRangeIssue(start: episode.startedAt, end: episode.endedAt, path: path, startField: "startedAt", endField: "endedAt", into: &issues)
+
+        if !intensityRange.contains(episode.intensity) {
+            issues.append("\(path).intensity muss zwischen \(intensityRange.lowerBound) und \(intensityRange.upperBound) liegen")
+        }
+
+        for (index, medication) in episode.medications.enumerated() {
+            issues.append(contentsOf: medicationEntryIssues(for: medication, path: "\(path).medications[\(index)]"))
+        }
+
+        for (index, check) in episode.continuousMedicationChecks.enumerated() {
+            issues.append(contentsOf: continuousMedicationCheckIssues(for: check, path: "\(path).continuousMedicationChecks[\(index)]"))
+        }
+
+        if let weatherSnapshot = episode.weatherSnapshot {
+            issues.append(contentsOf: weatherSnapshotIssues(for: weatherSnapshot, path: "\(path).weatherSnapshot"))
+        }
+
+        return issues
+    }
+
+    static func medicationEntryIssues(for medication: MedicationEntry, path: String = "medicationEntry") -> [String] {
+        var issues: [String] = []
+
+        if medication.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append("\(path).name darf nicht leer sein")
+        }
+
+        if medication.quantity < 1 {
+            issues.append("\(path).quantity muss positiv sein")
+        }
+
+        return issues
+    }
+
+    static func continuousMedicationIssues(for medication: ContinuousMedication, path: String = "continuousMedication") -> [String] {
+        var issues: [String] = []
+
+        if medication.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append("\(path).name darf nicht leer sein")
+        }
+
+        appendDateRangeIssue(start: medication.startDate, end: medication.endDate, path: path, startField: "startDate", endField: "endDate", into: &issues)
+        return issues
+    }
+
+    static func continuousMedicationCheckIssues(for check: ContinuousMedicationCheck, path: String = "continuousMedicationCheck") -> [String] {
+        if check.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return ["\(path).name darf nicht leer sein"]
+        }
+
+        return []
+    }
+
+    static func weatherSnapshotIssues(for snapshot: WeatherSnapshot, path: String = "weatherSnapshot") -> [String] {
+        var issues: [String] = []
+
+        if snapshot.condition.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append("\(path).condition darf nicht leer sein")
+        }
+
+        if snapshot.source.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append("\(path).source darf nicht leer sein")
+        }
+
+        appendDateRangeIssue(start: snapshot.dayRangeStart, end: snapshot.dayRangeEnd, path: path, startField: "dayRangeStart", endField: "dayRangeEnd", into: &issues)
+        appendDateRangeIssue(start: snapshot.contextRangeStart, end: snapshot.contextRangeEnd, path: path, startField: "contextRangeStart", endField: "contextRangeEnd", into: &issues)
+
+        for (index, point) in snapshot.contextPoints.enumerated() {
+            if point.condition.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                issues.append("\(path).contextPoints[\(index)].condition darf nicht leer sein")
+            }
+        }
+
+        return issues
+    }
+
+    private static func throwIfInvalid(_ issues: [String]) throws {
+        guard issues.isEmpty else {
+            throw DomainValidationError.invalid(issues: issues)
+        }
+    }
+
+    private static func appendDateRangeIssue(
+        start: Date?,
+        end: Date?,
+        path: String,
+        startField: String,
+        endField: String,
+        into issues: inout [String]
+    ) {
+        guard let start, let end, end < start else {
+            return
+        }
+
+        issues.append("\(path).\(endField) darf nicht vor \(path).\(startField) liegen")
+    }
+}

--- a/SymiTests/DomainValidatorTests.swift
+++ b/SymiTests/DomainValidatorTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Symi
+
+@MainActor
+struct DomainValidatorTests {
+    @Test
+    func domainValidatorReportsEpisodeMedicationAndWeatherInvariants() throws {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let episode = Episode(
+            startedAt: startedAt,
+            endedAt: startedAt.addingTimeInterval(-60),
+            type: .migraine,
+            intensity: 11
+        )
+        episode.medications = [
+            MedicationEntry(
+                name: " ",
+                category: .triptan,
+                dosage: "50 mg",
+                quantity: -1,
+                takenAt: startedAt,
+                effectiveness: .partial,
+                episode: episode
+            )
+        ]
+        episode.continuousMedicationChecks = [
+            ContinuousMedicationCheck(
+                continuousMedicationID: UUID(),
+                name: "",
+                wasTaken: true,
+                episode: episode
+            )
+        ]
+        episode.weatherSnapshot = WeatherSnapshot(
+            recordedAt: startedAt,
+            condition: "Regen",
+            source: "Apple Weather",
+            contextRangeStart: startedAt,
+            contextRangeEnd: startedAt.addingTimeInterval(-60),
+            episode: episode
+        )
+
+        let issues = DomainValidator.episodeIssues(for: episode)
+
+        #expect(issues.contains { $0.contains("endedAt") })
+        #expect(issues.contains { $0.contains("intensity") })
+        #expect(issues.contains { $0.contains("medications[0].name") })
+        #expect(issues.contains { $0.contains("quantity") })
+        #expect(issues.contains { $0.contains("continuousMedicationChecks[0].name") })
+        #expect(issues.contains { $0.contains("contextRangeEnd") })
+    }
+
+    @Test
+    func swiftDataEpisodeRepositoryRejectsInvalidDraftMedicationName() throws {
+        let repository = SwiftDataEpisodeRepository(
+            modelContainer: try makeInMemoryContainer(),
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        )
+        var draft = EpisodeDraft.makeNew(initialStartedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        draft.medications = [
+            MedicationSelectionDraft(
+                selectionKey: "invalid",
+                name: " ",
+                category: .triptan,
+                dosage: "50 mg",
+                quantity: 1,
+                isSelected: true
+            )
+        ]
+
+        #expect(throws: DomainValidationError.self) {
+            try repository.save(draft: draft, weatherSnapshot: nil, healthContext: nil)
+        }
+    }
+
+    @Test
+    func continuousMedicationRepositoryRejectsEmptyNameAndInvalidEndDate() throws {
+        let repository = SwiftDataContinuousMedicationRepository(modelContainer: try makeInMemoryContainer())
+        let startDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let draft = ContinuousMedicationDraft(
+            name: " ",
+            dosage: "50 mg",
+            frequency: "täglich",
+            startDate: startDate,
+            endDate: startDate.addingTimeInterval(-86_400)
+        )
+
+        #expect(throws: DomainValidationError.self) {
+            try repository.save(draft)
+        }
+    }
+
+    @Test
+    func backupImportPreviewRejectsInvalidDomainPayload() throws {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let episode = Episode(
+            startedAt: startedAt,
+            endedAt: startedAt.addingTimeInterval(-60),
+            type: .migraine,
+            intensity: 8
+        )
+        let snapshot = DataTransferSnapshot(
+            episodes: [EpisodePayload(episode: episode)],
+            customMedicationDefinitions: []
+        )
+
+        #expect(throws: DomainValidationError.self) {
+            _ = try snapshot.previewImport(into: ModelContext(try makeInMemoryContainer()))
+        }
+    }
+
+    @Test
+    func remoteSyncValidatorRejectsInvalidDomainPayload() throws {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let episodeID = UUID()
+        let envelope = SyncDocumentEnvelope(
+            documentID: "episode:\(episodeID.uuidString)",
+            entityType: .episode,
+            modifiedAt: startedAt,
+            authorDeviceID: "device",
+            payload: .episode(
+                SyncEpisodePayload(
+                    id: episodeID.uuidString,
+                    startedAt: startedAt,
+                    endedAt: startedAt.addingTimeInterval(-60),
+                    type: EpisodeType.migraine.rawValue,
+                    intensity: 0,
+                    painLocation: "",
+                    painCharacter: "",
+                    notes: "",
+                    symptoms: [],
+                    triggers: [],
+                    functionalImpact: "",
+                    menstruationStatus: MenstruationStatus.unknown.rawValue,
+                    medications: [
+                        SyncMedicationEntryPayload(
+                            id: UUID().uuidString,
+                            name: "",
+                            category: MedicationCategory.triptan.rawValue,
+                            dosage: "50 mg",
+                            quantity: -1,
+                            takenAt: startedAt,
+                            effectiveness: MedicationEffectiveness.partial.rawValue,
+                            reliefStartedAt: nil,
+                            isRepeatDose: false
+                        )
+                    ],
+                    weatherSnapshot: nil
+                )
+            )
+        )
+
+        #expect(throws: RemoteSyncPayloadValidationError.self) {
+            try RemoteSyncPayloadValidator.validate(envelope)
+        }
+    }
+
+    @Test
+    func startupMaintenanceRejectsInvalidPersistedDomainData() throws {
+        let container = try makeInMemoryContainer()
+        let context = ModelContext(container)
+        context.insert(Episode(startedAt: .now, type: .migraine, intensity: 12))
+        try context.save()
+
+        #expect(throws: DomainValidationError.self) {
+            try StartupMaintenanceService.normalizePersistentEnumValues(in: container)
+        }
+    }
+}
+
+private func makeInMemoryContainer() throws -> ModelContainer {
+    let schema = Schema(versionedSchema: SymiSchemaV6.self)
+    let configuration = ModelConfiguration(
+        "domain-validator-tests-\(UUID().uuidString)",
+        schema: schema,
+        isStoredInMemoryOnly: true,
+        cloudKitDatabase: .none
+    )
+    return try ModelContainer(for: schema, configurations: [configuration])
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let url = FileManager.default.temporaryDirectory.appending(path: "SymiDomainValidatorTests-\(UUID().uuidString)", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}


### PR DESCRIPTION
## Änderungen
- zentraler DomainValidator für Episode, MedicationEntry, ContinuousMedication und WeatherSnapshot
- Validierung in UI-Save/Persistenz, Backup-Import, Remote-Sync und Startup-Maintenance
- negative Tests für Zeitreihenfolge, Intensitätsbereich, leere Namen und negative Mengen

## Validierung
- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #225
