### PR TITLE
[codex] Reduce full-table fetches

### DIFF
--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -51,6 +51,7 @@ struct BackupImportResult: Sendable {
 
 struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
     nonisolated static let maximumImportFileSizeInBytes = 10 * 1_024 * 1_024
+    private nonisolated static let importLookupBatchSize = 250
 
     let formatVersion: Int
     let exportedAt: Date
@@ -155,16 +156,15 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
     nonisolated func previewImport(into context: ModelContext) throws -> BackupImportPreview {
         try validateDomainInvariants()
 
-        let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
-        let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
-        let existingDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
-        let customDefinitionsByKey = Dictionary(
-            uniqueKeysWithValues: existingDefinitions
-                .filter(\.isCustom)
-                .map { ($0.catalogKey, $0) }
+        let episodesByID = try context.episodesByID(Array(Set(episodes.map(\.id))), batchSize: Self.importLookupBatchSize)
+        let customDefinitionsByKey = try context.customMedicationDefinitionsByKey(
+            Array(Set(customMedicationDefinitions.map(\.catalogKey))),
+            batchSize: Self.importLookupBatchSize
         )
-        let existingContinuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
-        let continuousMedicationsByID = Dictionary(uniqueKeysWithValues: existingContinuousMedications.map { ($0.id, $0) })
+        let continuousMedicationsByID = try context.continuousMedicationsByID(
+            Array(Set(continuousMedications.map(\.id))),
+            batchSize: Self.importLookupBatchSize
+        )
 
         var newEpisodes = 0
         var changedEpisodes = 0
@@ -222,17 +222,15 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
     nonisolated func merge(into context: ModelContext, healthContextStore: HealthContextStore) throws {
         try validateDomainInvariants()
 
-        let existingEpisodes = try context.fetch(FetchDescriptor<Episode>())
-        let episodesByID = Dictionary(uniqueKeysWithValues: existingEpisodes.map { ($0.id, $0) })
-
-        let existingDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
-        let customDefinitionsByKey = Dictionary(
-            uniqueKeysWithValues: existingDefinitions
-                .filter(\.isCustom)
-                .map { ($0.catalogKey, $0) }
+        let episodesByID = try context.episodesByID(Array(Set(episodes.map(\.id))), batchSize: Self.importLookupBatchSize)
+        let customDefinitionsByKey = try context.customMedicationDefinitionsByKey(
+            Array(Set(customMedicationDefinitions.map(\.catalogKey))),
+            batchSize: Self.importLookupBatchSize
         )
-        let existingContinuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
-        let continuousMedicationsByID = Dictionary(uniqueKeysWithValues: existingContinuousMedications.map { ($0.id, $0) })
+        let continuousMedicationsByID = try context.continuousMedicationsByID(
+            Array(Set(continuousMedications.map(\.id))),
+            batchSize: Self.importLookupBatchSize
+        )
 
         for payload in customMedicationDefinitions {
             if let definition = customDefinitionsByKey[payload.catalogKey] {
@@ -291,6 +289,56 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
         formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd-HHmmss"
         return formatter.string(from: date)
+    }
+}
+
+private extension ModelContext {
+    nonisolated func episodesByID(_ ids: [UUID], batchSize: Int) throws -> [UUID: Episode] {
+        try fetchModelsByKey(ids, batchSize: batchSize) { batchIDs in
+            let descriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> { batchIDs.contains($0.id) }
+            )
+            return try fetch(descriptor).map { ($0.id, $0) }
+        }
+    }
+
+    nonisolated func customMedicationDefinitionsByKey(_ keys: [String], batchSize: Int) throws -> [String: MedicationDefinition] {
+        try fetchModelsByKey(keys, batchSize: batchSize) { batchKeys in
+            let descriptor = FetchDescriptor<MedicationDefinition>(
+                predicate: #Predicate<MedicationDefinition> { definition in
+                    definition.isCustom && batchKeys.contains(definition.catalogKey)
+                }
+            )
+            return try fetch(descriptor).map { ($0.catalogKey, $0) }
+        }
+    }
+
+    nonisolated func continuousMedicationsByID(_ ids: [UUID], batchSize: Int) throws -> [UUID: ContinuousMedication] {
+        try fetchModelsByKey(ids, batchSize: batchSize) { batchIDs in
+            let descriptor = FetchDescriptor<ContinuousMedication>(
+                predicate: #Predicate<ContinuousMedication> { batchIDs.contains($0.id) }
+            )
+            return try fetch(descriptor).map { ($0.id, $0) }
+        }
+    }
+
+    nonisolated func fetchModelsByKey<Key: Hashable, Value>(
+        _ keys: [Key],
+        batchSize: Int,
+        fetchBatch: ([Key]) throws -> [(Key, Value)]
+    ) throws -> [Key: Value] {
+        guard !keys.isEmpty else {
+            return [:]
+        }
+
+        var modelsByKey: [Key: Value] = [:]
+        for startIndex in stride(from: 0, to: keys.count, by: batchSize) {
+            let endIndex = Swift.min(startIndex + batchSize, keys.count)
+            for (key, value) in try fetchBatch(Array(keys[startIndex..<endIndex])) {
+                modelsByKey[key] = value
+            }
+        }
+        return modelsByKey
     }
 }
 

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -192,13 +192,12 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
     nonisolated func fetchActive(on date: Date) throws -> [ContinuousMedicationRecord] {
         let dayStart = Calendar.current.startOfDay(for: date)
         let descriptor = FetchDescriptor<ContinuousMedication>(
+            predicate: #Predicate<ContinuousMedication> { medication in
+                medication.startDate <= dayStart && (medication.endDate == nil || medication.endDate! >= dayStart)
+            },
             sortBy: [SortDescriptor(\ContinuousMedication.name)]
         )
-        return try readContext().fetch(descriptor)
-            .filter { medication in
-                medication.startDate <= dayStart && (medication.endDate == nil || (medication.endDate ?? .distantPast) >= dayStart)
-            }
-            .map(ContinuousMedicationRecord.init)
+        return try readContext().fetch(descriptor).map(ContinuousMedicationRecord.init)
     }
 
     @discardableResult
@@ -355,6 +354,8 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository, S
 }
 
 final class SwiftDataExportRepository: ExportRepository, Sendable {
+    private nonisolated static let fetchBatchSize = 250
+
     private let modelContainer: ModelContainer
     private let healthContextStore: HealthContextStore
 
@@ -383,23 +384,40 @@ final class SwiftDataExportRepository: ExportRepository, Sendable {
 
     nonisolated func createBackup() throws -> URL {
         let readContext = readContext()
-        let episodes = try readContext.fetch(FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]))
-        let definitions = try readContext.fetch(
+        var episodes: [EpisodePayload] = []
+        var definitions: [MedicationDefinitionPayload] = []
+        var continuousMedications: [ContinuousMedicationPayload] = []
+
+        try readContext.fetchBatches(
+            FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]),
+            batchSize: Self.fetchBatchSize
+        ) { batch in
+            episodes += batch.map { EpisodePayload(episode: $0, healthContext: healthContextStore.load(for: $0.id)) }
+        }
+
+        try readContext.fetchBatches(
             FetchDescriptor<MedicationDefinition>(
                 predicate: #Predicate<MedicationDefinition> { $0.isCustom },
                 sortBy: [SortDescriptor(\MedicationDefinition.sortOrder)]
-            )
-        )
-        let continuousMedications = try readContext.fetch(
+            ),
+            batchSize: Self.fetchBatchSize
+        ) { batch in
+            definitions += batch.map(MedicationDefinitionPayload.init)
+        }
+
+        try readContext.fetchBatches(
             FetchDescriptor<ContinuousMedication>(
                 sortBy: [SortDescriptor(\ContinuousMedication.startDate, order: .reverse), SortDescriptor(\ContinuousMedication.name)]
-            )
-        )
+            ),
+            batchSize: Self.fetchBatchSize
+        ) { batch in
+            continuousMedications += batch.map(ContinuousMedicationPayload.init)
+        }
+
         let snapshot = DataTransferSnapshot(
             episodes: episodes,
             customMedicationDefinitions: definitions,
-            continuousMedications: continuousMedications,
-            healthContextStore: healthContextStore
+            continuousMedications: continuousMedications
         )
         return try snapshot.writeToTemporaryFile()
     }
@@ -424,6 +442,35 @@ final class SwiftDataExportRepository: ExportRepository, Sendable {
 
     nonisolated private func writeContext() -> ModelContext {
         ModelContext(modelContainer)
+    }
+}
+
+private extension ModelContext {
+    nonisolated func fetchBatches<T: PersistentModel>(
+        _ descriptor: FetchDescriptor<T>,
+        batchSize: Int,
+        handleBatch: ([T]) throws -> Void
+    ) throws {
+        var descriptor = descriptor
+        var offset = 0
+
+        while true {
+            descriptor.fetchLimit = batchSize
+            descriptor.fetchOffset = offset
+            let batch = try fetch(descriptor)
+
+            guard !batch.isEmpty else {
+                return
+            }
+
+            try handleBatch(batch)
+
+            if batch.count < batchSize {
+                return
+            }
+
+            offset += batch.count
+        }
     }
 }
 

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @MainActor
 struct LocalSyncRepository {
+    private static let fetchBatchSize = 250
+
     let modelContainer: ModelContainer
     let healthContextStore: HealthContextStore
 
@@ -13,22 +15,65 @@ struct LocalSyncRepository {
 
     func allEnvelopes(deviceID: String) throws -> [SyncDocumentEnvelope] {
         let context = ModelContext(modelContainer)
-        let episodes = try context.fetch(FetchDescriptor<Episode>())
-        let customDefinitions = try context.fetch(FetchDescriptor<MedicationDefinition>())
-            .filter(\.isCustom)
-        let continuousMedications = try context.fetch(FetchDescriptor<ContinuousMedication>())
+        var envelopes: [SyncDocumentEnvelope] = []
 
-        try episodes.forEach(DomainValidator.validate)
-        try continuousMedications.forEach(DomainValidator.validate)
+        try context.fetchBatches(
+            FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.updatedAt, order: .reverse)]),
+            batchSize: Self.fetchBatchSize
+        ) { episodes in
+            try episodes.forEach(DomainValidator.validate)
+            envelopes += episodes.map { $0.syncEnvelope(deviceID: deviceID, healthContextStore: healthContextStore) }
+        }
 
-        return episodes.map { $0.syncEnvelope(deviceID: deviceID, healthContextStore: healthContextStore) } +
-            customDefinitions.map { $0.syncEnvelope(deviceID: deviceID) } +
-            continuousMedications.map { $0.syncEnvelope(deviceID: deviceID) }
+        try context.fetchBatches(
+            FetchDescriptor<MedicationDefinition>(
+                predicate: #Predicate<MedicationDefinition> { $0.isCustom },
+                sortBy: [SortDescriptor(\MedicationDefinition.updatedAt, order: .reverse)]
+            ),
+            batchSize: Self.fetchBatchSize
+        ) { definitions in
+            envelopes += definitions.map { $0.syncEnvelope(deviceID: deviceID) }
+        }
+
+        try context.fetchBatches(
+            FetchDescriptor<ContinuousMedication>(
+                sortBy: [SortDescriptor(\ContinuousMedication.updatedAt, order: .reverse)]
+            ),
+            batchSize: Self.fetchBatchSize
+        ) { medications in
+            try medications.forEach(DomainValidator.validate)
+            envelopes += medications.map { $0.syncEnvelope(deviceID: deviceID) }
+        }
+
+        return envelopes
     }
 
     func envelope(documentID: String, deviceID: String) throws -> SyncDocumentEnvelope? {
-        let envelopes = try allEnvelopes(deviceID: deviceID)
-        return envelopes.first { $0.documentID == documentID }
+        let context = ModelContext(modelContainer)
+        guard let key = SyncDocumentKey(documentID: documentID) else {
+            return nil
+        }
+
+        switch key.entityType {
+        case .episode:
+            let episodeID = key.id
+            let descriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> { $0.id == episodeID }
+            )
+            return try context.fetch(descriptor).first?.syncEnvelope(deviceID: deviceID, healthContextStore: healthContextStore)
+        case .medicationDefinition:
+            let catalogKey = key.rawID
+            let descriptor = FetchDescriptor<MedicationDefinition>(
+                predicate: #Predicate<MedicationDefinition> { $0.catalogKey == catalogKey && $0.isCustom }
+            )
+            return try context.fetch(descriptor).first?.syncEnvelope(deviceID: deviceID)
+        case .continuousMedication:
+            let medicationID = key.id
+            let descriptor = FetchDescriptor<ContinuousMedication>(
+                predicate: #Predicate<ContinuousMedication> { $0.id == medicationID }
+            )
+            return try context.fetch(descriptor).first?.syncEnvelope(deviceID: deviceID)
+        }
     }
 
     func validate(remote envelope: SyncDocumentEnvelope) throws {
@@ -58,7 +103,10 @@ struct LocalSyncRepository {
         in context: ModelContext
     ) throws {
         let episodeID = try RemoteSyncPayloadValidator.uuid(payload.id, field: "episode.id")
-        let existing = try context.fetch(FetchDescriptor<Episode>()).first { $0.id == episodeID }
+        let existingDescriptor = FetchDescriptor<Episode>(
+            predicate: #Predicate<Episode> { $0.id == episodeID }
+        )
+        let existing = try context.fetch(existingDescriptor).first
         let target = existing ?? Episode(
             id: episodeID,
             startedAt: payload.startedAt,
@@ -159,7 +207,11 @@ struct LocalSyncRepository {
         from envelope: SyncDocumentEnvelope,
         in context: ModelContext
     ) throws {
-        let existing = try context.fetch(FetchDescriptor<MedicationDefinition>()).first { $0.catalogKey == payload.catalogKey }
+        let catalogKey = payload.catalogKey
+        let existingDescriptor = FetchDescriptor<MedicationDefinition>(
+            predicate: #Predicate<MedicationDefinition> { $0.catalogKey == catalogKey }
+        )
+        let existing = try context.fetch(existingDescriptor).first
         let target = existing ?? MedicationDefinition(
             catalogKey: payload.catalogKey,
             groupID: payload.groupID,
@@ -198,7 +250,10 @@ struct LocalSyncRepository {
         in context: ModelContext
     ) throws {
         let medicationID = try RemoteSyncPayloadValidator.uuid(payload.id, field: "continuousMedication.id")
-        let existing = try context.fetch(FetchDescriptor<ContinuousMedication>()).first { $0.id == medicationID }
+        let existingDescriptor = FetchDescriptor<ContinuousMedication>(
+            predicate: #Predicate<ContinuousMedication> { $0.id == medicationID }
+        )
+        let existing = try context.fetch(existingDescriptor).first
         let target = existing ?? ContinuousMedication(
             id: medicationID,
             name: payload.name,
@@ -223,6 +278,64 @@ struct LocalSyncRepository {
         }
 
         try DomainValidator.validate(target)
+    }
+}
+
+private struct SyncDocumentKey {
+    let entityType: SyncEntityType
+    let rawID: String
+    let id: UUID
+
+    init?(documentID: String) {
+        let parts = documentID.split(separator: ":", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else {
+            return nil
+        }
+
+        let entityType: SyncEntityType
+        switch parts[0] {
+        case "episode":
+            entityType = .episode
+        case "medicationDefinition":
+            entityType = .medicationDefinition
+        case "continuousMedication":
+            entityType = .continuousMedication
+        default:
+            return nil
+        }
+
+        self.entityType = entityType
+        self.rawID = parts[1]
+        self.id = UUID(uuidString: parts[1]) ?? UUID()
+    }
+}
+
+private extension ModelContext {
+    nonisolated func fetchBatches<T: PersistentModel>(
+        _ descriptor: FetchDescriptor<T>,
+        batchSize: Int,
+        handleBatch: ([T]) throws -> Void
+    ) throws {
+        var descriptor = descriptor
+        var offset = 0
+
+        while true {
+            descriptor.fetchLimit = batchSize
+            descriptor.fetchOffset = offset
+            let batch = try fetch(descriptor)
+
+            guard !batch.isEmpty else {
+                return
+            }
+
+            try handleBatch(batch)
+
+            if batch.count < batchSize {
+                return
+            }
+
+            offset += batch.count
+        }
     }
 }
 

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -230,6 +230,49 @@ struct DataTransferHealthContextTests {
 
         #expect(didThrow)
     }
+
+    @Test
+    func backupImportAndSyncHandleSeveralThousandRecords() throws {
+        let sourceContainer = try makeInMemoryContainer()
+        let sourceHealthStore = HealthContextStore(baseURL: try makeTemporaryDirectory())
+        let seedCounts = try seedLargeDataSet(in: sourceContainer)
+        let sourceRepository = SwiftDataExportRepository(
+            modelContainer: sourceContainer,
+            healthContextStore: sourceHealthStore
+        )
+
+        let backupURL = try sourceRepository.createBackup()
+        let targetContainer = try makeInMemoryContainer()
+        let targetRepository = SwiftDataExportRepository(
+            modelContainer: targetContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        )
+
+        let preview = try targetRepository.previewBackupImport(from: backupURL)
+        _ = try targetRepository.importBackup(from: backupURL)
+        let importedContext = ModelContext(targetContainer)
+        let importedEpisodes = try importedContext.fetch(FetchDescriptor<Episode>())
+        let importedDefinitions = try importedContext.fetch(
+            FetchDescriptor<MedicationDefinition>(
+                predicate: #Predicate<MedicationDefinition> { $0.isCustom }
+            )
+        )
+        let importedContinuousMedications = try importedContext.fetch(FetchDescriptor<ContinuousMedication>())
+        let syncEnvelopes = try LocalSyncRepository(
+            modelContainer: targetContainer,
+            healthContextStore: HealthContextStore(baseURL: try makeTemporaryDirectory())
+        ).allEnvelopes(deviceID: "large-test-device")
+
+        #expect(preview.newEpisodes == seedCounts.episodes)
+        #expect(preview.newMedicationDefinitions == seedCounts.customDefinitions)
+        #expect(preview.newContinuousMedications == seedCounts.continuousMedications)
+        #expect(importedEpisodes.count == seedCounts.episodes)
+        #expect(importedDefinitions.count == seedCounts.customDefinitions)
+        #expect(importedContinuousMedications.count == seedCounts.continuousMedications)
+        #expect(importedEpisodes.compactMap(\.weatherSnapshot).count == seedCounts.episodes)
+        #expect(importedEpisodes.flatMap(\.medications).count == seedCounts.episodes)
+        #expect(syncEnvelopes.count == seedCounts.episodes + seedCounts.customDefinitions + seedCounts.continuousMedications)
+    }
 }
 
 private func makeInMemoryContainer() throws -> ModelContainer {
@@ -420,4 +463,130 @@ private func makeTemporaryDirectory() throws -> URL {
     let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     return directory
+}
+
+private func seedLargeDataSet(in container: ModelContainer) throws -> (
+    episodes: Int,
+    customDefinitions: Int,
+    continuousMedications: Int
+) {
+    let context = ModelContext(container)
+    let episodeCount = 2_100
+    let customDefinitionCount = 32
+    let continuousMedicationCount = 48
+    let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+    var continuousMedicationIDs: [UUID] = []
+
+    for index in 0..<customDefinitionCount {
+        context.insert(
+            MedicationDefinition(
+                catalogKey: "custom:large-\(index)",
+                groupID: "custom-medications",
+                groupTitle: "Eigene Medikamente",
+                name: "Eigenes Medikament \(index)",
+                category: .other,
+                suggestedDosage: "\(index + 1) mg",
+                sortOrder: index,
+                isCustom: true,
+                createdAt: baseDate,
+                updatedAt: baseDate.addingTimeInterval(TimeInterval(index))
+            )
+        )
+    }
+
+    for index in 0..<continuousMedicationCount {
+        let medicationID = deterministicUUID(offset: 10_000 + index)
+        continuousMedicationIDs.append(medicationID)
+        context.insert(
+            ContinuousMedication(
+                id: medicationID,
+                name: "Prophylaxe \(index)",
+                dosage: "\(index + 1) mg",
+                frequency: "täglich",
+                startDate: baseDate.addingTimeInterval(TimeInterval(-index * 86_400)),
+                updatedAt: baseDate.addingTimeInterval(TimeInterval(index))
+            )
+        )
+    }
+
+    for index in 0..<episodeCount {
+        let startedAt = baseDate.addingTimeInterval(TimeInterval(index * 3_600))
+        let episode = Episode(
+            id: deterministicUUID(offset: 20_000 + index),
+            startedAt: startedAt,
+            endedAt: startedAt.addingTimeInterval(3_600),
+            updatedAt: startedAt.addingTimeInterval(60),
+            type: index.isMultiple(of: 2) ? .migraine : .headache,
+            intensity: (index % 10) + 1,
+            painLocation: "Stirn",
+            painCharacter: "Pulsierend",
+            notes: "Großer Datensatz \(index)",
+            symptoms: ["Übelkeit"],
+            triggers: ["Stress"],
+            functionalImpact: "Eingeschränkt",
+            menstruationStatus: .none
+        )
+        episode.medications = [
+            MedicationEntry(
+                id: deterministicUUID(offset: 30_000 + index),
+                name: "Sumatriptan",
+                category: .triptan,
+                dosage: "50 mg",
+                quantity: 1,
+                takenAt: startedAt.addingTimeInterval(900),
+                effectiveness: .good,
+                episode: episode
+            )
+        ]
+        episode.continuousMedicationChecks = [
+            ContinuousMedicationCheck(
+                id: deterministicUUID(offset: 40_000 + index),
+                continuousMedicationID: continuousMedicationIDs[index % continuousMedicationIDs.count],
+                name: "Prophylaxe \(index % continuousMedicationIDs.count)",
+                dosage: "1 mg",
+                frequency: "täglich",
+                wasTaken: !index.isMultiple(of: 3),
+                episode: episode
+            )
+        ]
+        episode.weatherSnapshot = WeatherSnapshot(
+            id: deterministicUUID(offset: 50_000 + index),
+            recordedAt: startedAt,
+            temperature: Double(index % 30),
+            condition: "Bewölkt",
+            humidity: Double(50 + (index % 40)),
+            pressure: Double(990 + (index % 30)),
+            precipitation: Double(index % 3),
+            weatherCode: 3,
+            source: "Test",
+            dayRangeStart: Calendar.current.startOfDay(for: startedAt),
+            dayRangeEnd: Calendar.current.startOfDay(for: startedAt).addingTimeInterval(86_400),
+            contextRangeStart: Calendar.current.startOfDay(for: startedAt).addingTimeInterval(-43_200),
+            contextRangeEnd: Calendar.current.startOfDay(for: startedAt).addingTimeInterval(129_600),
+            contextPointsStorage: WeatherSnapshot.encodeContextPoints([
+                WeatherContextPointData(
+                    recordedAt: startedAt,
+                    condition: "Bewölkt",
+                    temperature: Double(index % 30),
+                    humidity: Double(50 + (index % 40)),
+                    pressure: Double(990 + (index % 30)),
+                    precipitation: Double(index % 3),
+                    weatherCode: 3
+                )
+            ]),
+            episode: episode
+        )
+        context.insert(episode)
+
+        if index.isMultiple(of: 250) {
+            try context.save()
+        }
+    }
+
+    try context.save()
+    return (episodeCount, customDefinitionCount, continuousMedicationCount)
+}
+
+private func deterministicUUID(offset: Int) -> UUID {
+    UUID(uuidString: "00000000-0000-0000-0000-\(String(format: "%012d", offset))")!
 }


### PR DESCRIPTION
## Änderungen
- Sync-Repository nutzt Predicates für einzelne Dokumente und batcht vollständige Envelope-Exports.
- Backup-Export und Import-Vorschau/-Merge nutzen Batch- bzw. chunked Predicate-Lookups statt kompletter Tabellen plus In-Memory-Filter.
- Aktive Dauermedikamente werden direkt per SwiftData-Predicate gefiltert.
- Großer Datensatz-Test deckt Export, Import und Sync mit mehreren tausend Episoden inklusive Medikamenten und WeatherSnapshots ab.

## Tests
- xcodebuild test -scheme SymiTests -project Symi.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17'

Closes #227