### PR TITLE
Add usage data consent sheet

### DIFF
--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -301,6 +301,16 @@
     "Ab" : {
 
     },
+    "Abstürze & Performance" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crashes & Performance"
+          }
+        }
+      }
+    },
     "Abbrechen" : {
       "localizations" : {
         "en" : {
@@ -480,12 +490,52 @@
         }
       }
     },
+    "Anonym teilen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share Anonymously"
+          }
+        }
+      }
+    },
+    "Anonyme Nutzungsdaten teilen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share Anonymous Usage Data"
+          }
+        }
+      }
+    },
+    "App verbessern" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Improve the App"
+          }
+        }
+      }
+    },
     "App herunterladen" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Download the app"
+          }
+        }
+      }
+    },
+    "App-Nutzung" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App Usage"
           }
         }
       }
@@ -908,6 +958,16 @@
         }
       }
     },
+    "Deine Einträge" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your Entries"
+          }
+        }
+      }
+    },
     "Deine Einträge bleiben lokal auf diesem Gerät und helfen dir, Muster, Auslöser und wirksame Routinen besser im Blick zu behalten." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1135,6 +1195,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "You can change location permission in this app's settings under \"Location\" to \"While Using the App\"."
+          }
+        }
+      }
+    },
+    "Du kannst das jederzeit in den Einstellungen ändern." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can change this anytime in Settings."
           }
         }
       }
@@ -1678,6 +1748,16 @@
         }
       }
     },
+    "Gesundheitsdaten" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Health Data"
+          }
+        }
+      }
+    },
     "GitHub-Issues öffnen" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1800,6 +1880,16 @@
         }
       }
     },
+    "Hilf uns, Symi besser zu machen." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Help us make Symi better."
+          }
+        }
+      }
+    },
     "iOS verwaltet Health-Berechtigungen pro Datentyp. Verweigerte Leserechte erscheinen in der App wie fehlende Daten." : {
       "localizations" : {
         "en" : {
@@ -1827,6 +1917,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sync Now"
+          }
+        }
+      }
+    },
+    "Jetzt nicht" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Now"
           }
         }
       }
@@ -2374,6 +2474,16 @@
         }
       }
     },
+    "Nutzungsdaten anonym teilen?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share Anonymous Usage Data?"
+          }
+        }
+      }
+    },
     "Noch kein Eintrag für diesen Tag." : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2596,6 +2706,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Adjust the period so a report can be created from your diary."
+          }
+        }
+      }
+    },
+    "Persönliche Informationen" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personal Information"
           }
         }
       }
@@ -3453,6 +3573,26 @@
     },
     "Wenn aktiviert, enthält das PDF zusätzlich die detaillierten Einträge mit Medikamenten, Triggern, Wetterdaten, Apple-Health-Kontext und Notizen." : {
 
+    },
+    "Was wird geteilt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What Is Shared"
+          }
+        }
+      }
+    },
+    "Was wird NICHT geteilt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "What Is NOT Shared"
+          }
+        }
+      }
     },
     "Wetter" : {
       "localizations" : {

--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -14,7 +14,8 @@ final class AppContainer {
         weatherService: any WeatherService = AppleWeatherKitWeatherService(),
         locationService: any LocationService = SystemLocationService(),
         healthService: any HealthService = AppleHealthKitService(),
-        healthContextStore: HealthContextStore = HealthContextStore()
+        healthContextStore: HealthContextStore = HealthContextStore(),
+        usageDataConsentService: UsageDataConsentService = AppTelemetryService.shared
     ) {
         let episodeWeatherContextService = EpisodeWeatherContextService(
             weatherService: weatherService,
@@ -92,7 +93,8 @@ final class AppContainer {
                     continuousMedicationRepository: continuousMedicationRepository,
                     syncService: syncService,
                     appLogService: appLogStore,
-                    healthService: healthService
+                    healthService: healthService,
+                    usageDataConsentService: usageDataConsentService
                 )
             },
             dataExport: dataExport

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -1,7 +1,4 @@
 import SwiftUI
-import Sentry
-import TelemetryDeck
-
 import SwiftData
 import OSLog
 
@@ -10,12 +7,12 @@ struct SymiApp: App {
     private static let logger = Logger(subsystem: "Symi", category: "Persistence")
     private let launchConfiguration: AppLaunchConfiguration
     private let initialStartupState: AppStartupState
+    @State private var telemetryService = AppTelemetryService.shared
 
     init() {
         let launchConfiguration = AppLaunchConfiguration.current
         self.launchConfiguration = launchConfiguration
 
-        Self.configureTelemetry(for: launchConfiguration)
         self.initialStartupState = Self.makeInitialStartupState(launchConfiguration: launchConfiguration)
     }
 
@@ -23,7 +20,8 @@ struct SymiApp: App {
         WindowGroup {
             AppRootView(
                 launchConfiguration: launchConfiguration,
-                initialStartupState: initialStartupState
+                initialStartupState: initialStartupState,
+                telemetryService: telemetryService
             )
         }
         #if targetEnvironment(macCatalyst)
@@ -169,33 +167,6 @@ struct SymiApp: App {
         return try ModelContainer(for: schema, configurations: [configuration])
     }
 
-    private static func configureTelemetry(for launchConfiguration: AppLaunchConfiguration) {
-        if !launchConfiguration.isScreenshotMode, !launchConfiguration.isRunningTests, let sentryDSN = Self.sentryDSN {
-            SentrySDK.start { options in
-                options.dsn = sentryDSN
-
-                options.sendDefaultPii = false
-                options.tracesSampleRate = 0.2
-
-                options.configureProfiling = {
-                    $0.sessionSampleRate = 0.05
-                    $0.lifecycle = .trace
-                }
-
-                options.attachScreenshot = false
-                options.attachViewHierarchy = false
-                options.debug = false
-                options.enableLogs = false
-            }
-        } else {
-            Self.logger.notice("Sentry ist deaktiviert, weil keine gültige DSN in der App-Konfiguration gefunden wurde.")
-        }
-
-        if !launchConfiguration.isScreenshotMode, !launchConfiguration.isRunningTests, let telemetryAppID = Self.telemetryAppID {
-            TelemetryDeck.initialize(config: .init(appID: telemetryAppID))
-        }
-    }
-
     static func defaultStoreURL(
         applicationSupportDirectoryURL: URL? = nil,
         fileManager: FileManager = .default
@@ -238,31 +209,6 @@ struct SymiApp: App {
 
     private static func unitTestStoreURL() -> URL {
         FileManager.default.temporaryDirectory.appending(path: "Symi-UnitTests-\(UUID().uuidString).store")
-    }
-
-    private static var sentryDSN: String? {
-        normalize(Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String)
-    }
-
-    private static var telemetryAppID: String? {
-        normalize(Bundle.main.object(forInfoDictionaryKey: "TELEMETRY_APP_ID") as? String)
-    }
-
-    private static func normalize(_ value: String?) -> String? {
-        guard let value else {
-            return nil
-        }
-
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            return nil
-        }
-
-        if trimmed.hasPrefix("$("), trimmed.hasSuffix(")") {
-            return nil
-        }
-
-        return trimmed
     }
 
     static func sanitizedSummary(for error: Error) -> String {
@@ -309,14 +255,41 @@ struct StoreRecoveryEnvironment {
 
 private struct AppRootView: View {
     let launchConfiguration: AppLaunchConfiguration
+    @Bindable var telemetryService: AppTelemetryService
     @State private var startupState: AppStartupState
+    @State private var isUsageDataConsentPromptPresented = false
 
-    init(launchConfiguration: AppLaunchConfiguration, initialStartupState: AppStartupState) {
+    init(
+        launchConfiguration: AppLaunchConfiguration,
+        initialStartupState: AppStartupState,
+        telemetryService: AppTelemetryService
+    ) {
         self.launchConfiguration = launchConfiguration
+        self.telemetryService = telemetryService
         _startupState = State(initialValue: initialStartupState)
     }
 
     var body: some View {
+        rootContent
+            .task {
+                telemetryService.configureIfPermitted(launchConfiguration: launchConfiguration)
+                presentUsageDataConsentPromptIfNeeded()
+            }
+            .sheet(isPresented: $isUsageDataConsentPromptPresented, onDismiss: {
+                if telemetryService.shouldAskForUsageDataConsent {
+                    telemetryService.setUsageDataCollectionAllowed(false)
+                }
+            }) {
+                DataSharingSheet {
+                    telemetryService.setUsageDataCollectionAllowed(true)
+                }
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+            }
+    }
+
+    @ViewBuilder
+    private var rootContent: some View {
         switch startupState {
         case .app(let environment):
             appContent(environment: environment)
@@ -336,6 +309,7 @@ private struct AppRootView: View {
                 },
                 didRecover: { recoveredEnvironment in
                     startupState = .app(recoveredEnvironment)
+                    presentUsageDataConsentPromptIfNeeded()
                 }
             )
             .modelContainer(environment.fallbackContainer)
@@ -362,6 +336,7 @@ private struct AppRootView: View {
                 },
                 didRecover: { recoveredEnvironment in
                     startupState = .app(recoveredEnvironment)
+                    presentUsageDataConsentPromptIfNeeded()
                 }
             )
         }
@@ -378,5 +353,17 @@ private struct AppRootView: View {
         } else {
             AppShellView(appContainer: environment.appContainer)
         }
+    }
+
+    private func presentUsageDataConsentPromptIfNeeded() {
+        guard !launchConfiguration.isScreenshotMode, !launchConfiguration.isRunningTests else {
+            return
+        }
+
+        guard case .app = startupState, telemetryService.shouldAskForUsageDataConsent else {
+            return
+        }
+
+        isUsageDataConsentPromptPresented = true
     }
 }

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import SwiftData
 import OSLog
+import Sentry
+import TelemetryDeck
 
 @main
 struct SymiApp: App {
@@ -275,17 +277,21 @@ private struct AppRootView: View {
                 telemetryService.configureIfPermitted(launchConfiguration: launchConfiguration)
                 presentUsageDataConsentPromptIfNeeded()
             }
-            .sheet(isPresented: $isUsageDataConsentPromptPresented, onDismiss: {
-                if telemetryService.shouldAskForUsageDataConsent {
-                    telemetryService.setUsageDataCollectionAllowed(false)
-                }
-            }) {
+            .sheet(
+                isPresented: $isUsageDataConsentPromptPresented,
+                onDismiss: {
+                    if telemetryService.shouldAskForUsageDataConsent {
+                        telemetryService.setUsageDataCollectionAllowed(false)
+                    }
+                },
+                content: {
                 DataSharingSheet {
                     telemetryService.setUsageDataCollectionAllowed(true)
                 }
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
-            }
+                }
+            )
     }
 
     @ViewBuilder
@@ -365,5 +371,39 @@ private struct AppRootView: View {
         }
 
         isUsageDataConsentPromptPresented = true
+    }
+}
+
+@MainActor
+enum AppTelemetryGateway {
+    static func startSentry(dsn: String) {
+        SentrySDK.start { options in
+            options.dsn = dsn
+
+            options.sendDefaultPii = false
+            options.tracesSampleRate = 0.2
+
+            options.configureProfiling = {
+                $0.sessionSampleRate = 0.05
+                $0.lifecycle = .trace
+            }
+
+            options.attachScreenshot = false
+            options.attachViewHierarchy = false
+            options.debug = false
+            options.enableLogs = false
+        }
+    }
+
+    static func stopSentry() {
+        SentrySDK.close()
+    }
+
+    static func startTelemetryDeck(appID: String) {
+        TelemetryDeck.initialize(config: .init(appID: appID))
+    }
+
+    static func stopTelemetryDeck() {
+        TelemetryDeck.terminate()
     }
 }

--- a/Symi/Sources/Core/Settings/SettingsCore.swift
+++ b/Symi/Sources/Core/Settings/SettingsCore.swift
@@ -103,6 +103,7 @@ final class SettingsController {
     private let syncService: SyncService
     private let appLogService: AppLogService
     private let healthService: HealthService
+    private let usageDataConsentService: UsageDataConsentService
     @ObservationIgnored private var loadTask: Task<Void, Never>?
     @ObservationIgnored private var restoreTask: Task<Void, Never>?
     @ObservationIgnored private var logRefreshTask: Task<Void, Never>?
@@ -114,7 +115,8 @@ final class SettingsController {
         continuousMedicationRepository: ContinuousMedicationRepository,
         syncService: SyncService,
         appLogService: AppLogService,
-        healthService: HealthService
+        healthService: HealthService,
+        usageDataConsentService: UsageDataConsentService
     ) {
         self.episodeRepository = episodeRepository
         self.medicationRepository = medicationRepository
@@ -122,6 +124,7 @@ final class SettingsController {
         self.syncService = syncService
         self.appLogService = appLogService
         self.healthService = healthService
+        self.usageDataConsentService = usageDataConsentService
         self.loadSettingsUseCase = LoadSettingsUseCase(
             episodeRepository: episodeRepository,
             medicationRepository: medicationRepository,
@@ -155,6 +158,10 @@ final class SettingsController {
 
     var healthWriteDefinitions: [HealthDataTypeDefinition] {
         healthService.writeDefinitions
+    }
+
+    var isUsageDataCollectionAllowed: Bool {
+        usageDataConsentService.usageDataConsent == .allowed
     }
 
     func load() {
@@ -334,5 +341,9 @@ final class SettingsController {
     func requestHealthWriteAuthorization() async {
         try? await healthService.requestWriteAuthorization()
         healthSettingsRevision += 1
+    }
+
+    func setUsageDataCollectionAllowed(_ allowed: Bool) {
+        usageDataConsentService.setUsageDataCollectionAllowed(allowed)
     }
 }

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -117,6 +117,18 @@ struct SettingsView: View {
                 }
             }
 
+            Section {
+                Toggle("Anonyme Nutzungsdaten teilen", isOn: Binding(
+                    get: { controller.isUsageDataCollectionAllowed },
+                    set: { controller.setUsageDataCollectionAllowed($0) }
+                ))
+                .tint(AppTheme.ocean)
+            } header: {
+                Text("App verbessern")
+            } footer: {
+                Text("Symi verwendet nur anonyme Nutzungs- und Diagnosedaten. Tagebuchinhalte, Gesundheitsdaten und personenbezogene Daten werden nicht übertragen. Du kannst diese Einstellung jederzeit ändern.")
+            }
+
             Section("Übersicht") {
                 LabeledContent("Aktive Episoden", value: "\(controller.summary.activeEpisodeCount)")
                 LabeledContent("Papierkorb", value: "\(controller.summary.trashCount)")

--- a/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/SymiSpacing.swift
@@ -60,6 +60,8 @@ nonisolated enum SymiSpacing {
     static let entryDetailTriggerChipVerticalPadding: CGFloat = 9
     static let entryDetailMedicationCardPadding: CGFloat = 22
     static let entryDetailDeleteBottomPadding: CGFloat = 38
+    static let dataSharingContentBottomPadding: CGFloat = 132
+    static let dataSharingBulletIndent: CGFloat = 30
 }
 
 nonisolated enum SymiRadius {
@@ -197,6 +199,8 @@ nonisolated enum SymiSize {
     static let weatherFooterLogoMaxWidth: CGFloat = 220
     static let weatherFooterLogoMinHeight: CGFloat = 32
     static let weatherFooterLogoMaxHeight: CGFloat = 56
+    static let dataSharingPrimaryButtonHeight: CGFloat = 52
+    static let dataSharingBulletSize: CGFloat = 6
     static let journalAccentBarWidth: CGFloat = 4
     static let journalActiveFilterChipMinHeight: CGFloat = 34
     static let journalEntryCardMinHeight: CGFloat = 76

--- a/Symi/Sources/Models/DomainValidator.swift
+++ b/Symi/Sources/Models/DomainValidator.swift
@@ -36,7 +36,16 @@ nonisolated enum DomainValidator {
     static func episodeIssues(for episode: Episode, path: String = "episode") -> [String] {
         var issues: [String] = []
 
-        appendDateRangeIssue(start: episode.startedAt, end: episode.endedAt, path: path, startField: "startedAt", endField: "endedAt", into: &issues)
+        appendDateRangeIssue(
+            DateRangeValidation(
+                start: episode.startedAt,
+                end: episode.endedAt,
+                path: path,
+                startField: "startedAt",
+                endField: "endedAt"
+            ),
+            into: &issues
+        )
 
         if !intensityRange.contains(episode.intensity) {
             issues.append("\(path).intensity muss zwischen \(intensityRange.lowerBound) und \(intensityRange.upperBound) liegen")
@@ -78,7 +87,16 @@ nonisolated enum DomainValidator {
             issues.append("\(path).name darf nicht leer sein")
         }
 
-        appendDateRangeIssue(start: medication.startDate, end: medication.endDate, path: path, startField: "startDate", endField: "endDate", into: &issues)
+        appendDateRangeIssue(
+            DateRangeValidation(
+                start: medication.startDate,
+                end: medication.endDate,
+                path: path,
+                startField: "startDate",
+                endField: "endDate"
+            ),
+            into: &issues
+        )
         return issues
     }
 
@@ -101,13 +119,30 @@ nonisolated enum DomainValidator {
             issues.append("\(path).source darf nicht leer sein")
         }
 
-        appendDateRangeIssue(start: snapshot.dayRangeStart, end: snapshot.dayRangeEnd, path: path, startField: "dayRangeStart", endField: "dayRangeEnd", into: &issues)
-        appendDateRangeIssue(start: snapshot.contextRangeStart, end: snapshot.contextRangeEnd, path: path, startField: "contextRangeStart", endField: "contextRangeEnd", into: &issues)
+        appendDateRangeIssue(
+            DateRangeValidation(
+                start: snapshot.dayRangeStart,
+                end: snapshot.dayRangeEnd,
+                path: path,
+                startField: "dayRangeStart",
+                endField: "dayRangeEnd"
+            ),
+            into: &issues
+        )
+        appendDateRangeIssue(
+            DateRangeValidation(
+                start: snapshot.contextRangeStart,
+                end: snapshot.contextRangeEnd,
+                path: path,
+                startField: "contextRangeStart",
+                endField: "contextRangeEnd"
+            ),
+            into: &issues
+        )
 
-        for (index, point) in snapshot.contextPoints.enumerated() {
-            if point.condition.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                issues.append("\(path).contextPoints[\(index)].condition darf nicht leer sein")
-            }
+        for (index, point) in snapshot.contextPoints.enumerated()
+            where point.condition.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append("\(path).contextPoints[\(index)].condition darf nicht leer sein")
         }
 
         return issues
@@ -119,18 +154,21 @@ nonisolated enum DomainValidator {
         }
     }
 
-    private static func appendDateRangeIssue(
-        start: Date?,
-        end: Date?,
-        path: String,
-        startField: String,
-        endField: String,
-        into issues: inout [String]
-    ) {
+    private static func appendDateRangeIssue(_ range: DateRangeValidation, into issues: inout [String]) {
+        let start = range.start
+        let end = range.end
         guard let start, let end, end < start else {
             return
         }
 
-        issues.append("\(path).\(endField) darf nicht vor \(path).\(startField) liegen")
+        issues.append("\(range.path).\(range.endField) darf nicht vor \(range.path).\(range.startField) liegen")
+    }
+
+    private struct DateRangeValidation {
+        let start: Date?
+        let end: Date?
+        let path: String
+        let startField: String
+        let endField: String
     }
 }

--- a/Symi/Sources/Shared/DataSharingSheet.swift
+++ b/Symi/Sources/Shared/DataSharingSheet.swift
@@ -2,15 +2,16 @@ import SwiftUI
 
 struct DataSharingSheet: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     var onAccept: () -> Void
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: SymiSpacing.xxxl) {
                 header
 
-                VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: SymiSpacing.xxxl) {
                     InfoSection(
                         icon: "checkmark.circle.fill",
                         title: "Was wird geteilt",
@@ -18,11 +19,11 @@ struct DataSharingSheet: View {
                             "App-Nutzung",
                             "Abstürze & Performance"
                         ],
-                        tint: SymiSheetColors.sage
+                        tint: AppTheme.sage(for: colorScheme)
                     )
 
                     Divider()
-                        .opacity(0.2)
+                        .opacity(SymiOpacity.pressedFill)
 
                     InfoSection(
                         icon: "lock.shield.fill",
@@ -32,31 +33,31 @@ struct DataSharingSheet: View {
                             "Gesundheitsdaten",
                             "Persönliche Informationen"
                         ],
-                        tint: SymiSheetColors.coral
+                        tint: AppTheme.coral(for: colorScheme)
                     )
-                    .padding(.top, 8)
+                    .padding(.top, SymiSpacing.xs)
                 }
 
                 footer
             }
-            .padding(.horizontal, 24)
-            .padding(.top, 24)
-            .padding(.bottom, 132)
+            .padding(.horizontal, SymiSpacing.xxxl)
+            .padding(.top, SymiSpacing.xxxl)
+            .padding(.bottom, SymiSpacing.dataSharingContentBottomPadding)
         }
-        .background(SymiSheetColors.background)
+        .background(AppTheme.warmBackground(for: colorScheme))
         .safeAreaInset(edge: .bottom) {
             actions
-                .padding(.horizontal, 24)
-                .padding(.top, 12)
-                .padding(.bottom, 16)
+                .padding(.horizontal, SymiSpacing.xxxl)
+                .padding(.top, SymiSpacing.md)
+                .padding(.bottom, SymiSpacing.lg)
         }
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
             Text("Nutzungsdaten anonym teilen?")
                 .font(.title2.weight(.semibold))
-                .foregroundStyle(SymiSheetColors.primaryText)
+                .foregroundStyle(AppTheme.textPrimary(for: colorScheme))
                 .fixedSize(horizontal: false, vertical: true)
 
             Text("Hilf uns, Symi besser zu machen.")
@@ -67,7 +68,7 @@ struct DataSharingSheet: View {
     }
 
     private var footer: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
+        HStack(alignment: .firstTextBaseline, spacing: SymiSpacing.xs) {
             Image(systemName: "gearshape.fill")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -81,7 +82,7 @@ struct DataSharingSheet: View {
     }
 
     private var actions: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: SymiSpacing.md) {
             Button {
                 onAccept()
                 dismiss()
@@ -89,11 +90,11 @@ struct DataSharingSheet: View {
                 Text("Anonym teilen")
                     .font(.headline)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 52)
+                    .frame(height: SymiSize.dataSharingPrimaryButtonHeight)
             }
             .buttonStyle(.plain)
-            .foregroundStyle(.white)
-            .background(SymiSheetColors.petrol, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .foregroundStyle(AppTheme.symiOnAccent)
+            .background(AppTheme.petrol(for: colorScheme), in: RoundedRectangle(cornerRadius: SymiRadius.flowBanner, style: .continuous))
 
             Button {
                 dismiss()
@@ -101,10 +102,10 @@ struct DataSharingSheet: View {
                 Text("Jetzt nicht")
                     .font(.subheadline.weight(.semibold))
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, SymiSpacing.xs)
             }
             .buttonStyle(.plain)
-            .foregroundStyle(SymiSheetColors.petrol)
+            .foregroundStyle(AppTheme.petrol(for: colorScheme))
         }
     }
 }
@@ -116,8 +117,8 @@ private struct InfoSection: View {
     let tint: Color
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .firstTextBaseline, spacing: 10) {
+        VStack(alignment: .leading, spacing: SymiSpacing.md) {
+            HStack(alignment: .firstTextBaseline, spacing: SymiSpacing.sm) {
                 Image(systemName: icon)
                     .font(.headline)
                     .foregroundStyle(tint)
@@ -126,16 +127,16 @@ private struct InfoSection: View {
                 Text(title)
                     .font(.body)
                     .fontWeight(.semibold)
-                    .foregroundStyle(SymiSheetColors.primaryText)
+                    .foregroundStyle(AppTheme.symiTextPrimary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: SymiSpacing.xs) {
                 ForEach(items, id: \.self) { item in
                     DataSharingBulletRow(text: item, tint: tint)
                 }
             }
-            .padding(.leading, 30)
+            .padding(.leading, SymiSpacing.dataSharingBulletIndent)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -146,26 +147,18 @@ private struct DataSharingBulletRow: View {
     let tint: Color
 
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: SymiSpacing.xs) {
             Circle()
                 .fill(tint)
-                .frame(width: 6, height: 6)
-                .padding(.top, 6)
+                .frame(width: SymiSize.dataSharingBulletSize, height: SymiSize.dataSharingBulletSize)
+                .padding(.top, SymiSpacing.compact)
 
             Text(text)
                 .font(.body)
-                .foregroundStyle(SymiSheetColors.primaryText)
+                .foregroundStyle(AppTheme.symiTextPrimary)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
-}
-
-private enum SymiSheetColors {
-    static let petrol = Color(red: 15 / 255, green: 61 / 255, blue: 62 / 255)
-    static let sage = Color(red: 142 / 255, green: 205 / 255, blue: 184 / 255)
-    static let coral = Color(red: 255 / 255, green: 138 / 255, blue: 122 / 255)
-    static let background = Color(red: 246 / 255, green: 244 / 255, blue: 239 / 255)
-    static let primaryText = Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255)
 }
 
 #Preview {

--- a/Symi/Sources/Shared/DataSharingSheet.swift
+++ b/Symi/Sources/Shared/DataSharingSheet.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+struct DataSharingSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var onAccept: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+
+                VStack(alignment: .leading, spacing: 24) {
+                    InfoSection(
+                        icon: "checkmark.circle.fill",
+                        title: "Was wird geteilt",
+                        items: [
+                            "App-Nutzung",
+                            "Abstürze & Performance"
+                        ],
+                        tint: SymiSheetColors.sage
+                    )
+
+                    Divider()
+                        .opacity(0.2)
+
+                    InfoSection(
+                        icon: "lock.shield.fill",
+                        title: "Was wird NICHT geteilt",
+                        items: [
+                            "Deine Einträge",
+                            "Gesundheitsdaten",
+                            "Persönliche Informationen"
+                        ],
+                        tint: SymiSheetColors.coral
+                    )
+                    .padding(.top, 8)
+                }
+
+                footer
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+            .padding(.bottom, 132)
+        }
+        .background(SymiSheetColors.background)
+        .safeAreaInset(edge: .bottom) {
+            actions
+                .padding(.horizontal, 24)
+                .padding(.top, 12)
+                .padding(.bottom, 16)
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Nutzungsdaten anonym teilen?")
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(SymiSheetColors.primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Hilf uns, Symi besser zu machen.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var footer: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: "gearshape.fill")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            Text("Du kannst das jederzeit in den Einstellungen ändern.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var actions: some View {
+        VStack(spacing: 12) {
+            Button {
+                onAccept()
+                dismiss()
+            } label: {
+                Text("Anonym teilen")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.white)
+            .background(SymiSheetColors.petrol, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
+            Button {
+                dismiss()
+            } label: {
+                Text("Jetzt nicht")
+                    .font(.subheadline.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(SymiSheetColors.petrol)
+        }
+    }
+}
+
+private struct InfoSection: View {
+    let icon: String
+    let title: String
+    let items: [String]
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Image(systemName: icon)
+                    .font(.headline)
+                    .foregroundStyle(tint)
+                    .accessibilityHidden(true)
+
+                Text(title)
+                    .font(.body)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(SymiSheetColors.primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(items, id: \.self) { item in
+                    DataSharingBulletRow(text: item, tint: tint)
+                }
+            }
+            .padding(.leading, 30)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct DataSharingBulletRow: View {
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Circle()
+                .fill(tint)
+                .frame(width: 6, height: 6)
+                .padding(.top, 6)
+
+            Text(text)
+                .font(.body)
+                .foregroundStyle(SymiSheetColors.primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private enum SymiSheetColors {
+    static let petrol = Color(red: 15 / 255, green: 61 / 255, blue: 62 / 255)
+    static let sage = Color(red: 142 / 255, green: 205 / 255, blue: 184 / 255)
+    static let coral = Color(red: 255 / 255, green: 138 / 255, blue: 122 / 255)
+    static let background = Color(red: 246 / 255, green: 244 / 255, blue: 239 / 255)
+    static let primaryText = Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255)
+}
+
+#Preview {
+    DataSharingSheet {}
+}

--- a/Symi/Sources/Shared/UsageDataConsent.swift
+++ b/Symi/Sources/Shared/UsageDataConsent.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Observation
+import OSLog
+import Sentry
+import TelemetryDeck
+
+enum UsageDataConsent: Equatable {
+    case undecided
+    case allowed
+    case denied
+}
+
+protocol UsageDataConsentService: AnyObject {
+    var usageDataConsent: UsageDataConsent { get }
+
+    func setUsageDataCollectionAllowed(_ allowed: Bool)
+}
+
+final class UsageDataConsentStore {
+    private let defaults: UserDefaults
+    private let consentKey = "usageDataCollectionAllowed"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    var consent: UsageDataConsent {
+        guard defaults.object(forKey: consentKey) != nil else {
+            return .undecided
+        }
+
+        return defaults.bool(forKey: consentKey) ? .allowed : .denied
+    }
+
+    func setConsent(_ consent: UsageDataConsent) {
+        switch consent {
+        case .undecided:
+            defaults.removeObject(forKey: consentKey)
+        case .allowed:
+            defaults.set(true, forKey: consentKey)
+        case .denied:
+            defaults.set(false, forKey: consentKey)
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class AppTelemetryService: UsageDataConsentService {
+    static let shared = AppTelemetryService()
+
+    private static let logger = Logger(subsystem: "Symi", category: "Telemetry")
+    private let store: UsageDataConsentStore
+    private var launchConfiguration: AppLaunchConfiguration?
+    private var isSentryStarted = false
+    private var isTelemetryDeckStarted = false
+
+    init(store: UsageDataConsentStore = UsageDataConsentStore()) {
+        self.store = store
+    }
+
+    var usageDataConsent: UsageDataConsent {
+        store.consent
+    }
+
+    var isUsageDataCollectionAllowed: Bool {
+        usageDataConsent == .allowed
+    }
+
+    var shouldAskForUsageDataConsent: Bool {
+        usageDataConsent == .undecided
+    }
+
+    func configureIfPermitted(launchConfiguration: AppLaunchConfiguration) {
+        self.launchConfiguration = launchConfiguration
+        guard usageDataConsent == .allowed else {
+            stopTelemetry()
+            return
+        }
+
+        startTelemetry(launchConfiguration: launchConfiguration)
+    }
+
+    func setUsageDataCollectionAllowed(_ allowed: Bool) {
+        store.setConsent(allowed ? .allowed : .denied)
+
+        if allowed, let launchConfiguration {
+            startTelemetry(launchConfiguration: launchConfiguration)
+        } else {
+            stopTelemetry()
+        }
+    }
+
+    private func startTelemetry(launchConfiguration: AppLaunchConfiguration) {
+        guard !launchConfiguration.isScreenshotMode, !launchConfiguration.isRunningTests else {
+            return
+        }
+
+        if !isSentryStarted, let sentryDSN = Self.sentryDSN {
+            SentrySDK.start { options in
+                options.dsn = sentryDSN
+
+                options.sendDefaultPii = false
+                options.tracesSampleRate = 0.2
+
+                options.configureProfiling = {
+                    $0.sessionSampleRate = 0.05
+                    $0.lifecycle = .trace
+                }
+
+                options.attachScreenshot = false
+                options.attachViewHierarchy = false
+                options.debug = false
+                options.enableLogs = false
+            }
+            isSentryStarted = true
+        } else if Self.sentryDSN == nil {
+            Self.logger.notice("Sentry ist deaktiviert, weil keine gültige DSN in der App-Konfiguration gefunden wurde.")
+        }
+
+        if !isTelemetryDeckStarted, let telemetryAppID = Self.telemetryAppID {
+            TelemetryDeck.initialize(config: .init(appID: telemetryAppID))
+            isTelemetryDeckStarted = true
+        }
+    }
+
+    private func stopTelemetry() {
+        if isSentryStarted {
+            SentrySDK.close()
+            isSentryStarted = false
+        }
+
+        if isTelemetryDeckStarted {
+            TelemetryDeck.terminate()
+            isTelemetryDeckStarted = false
+        }
+    }
+
+    private static var sentryDSN: String? {
+        normalize(Bundle.main.object(forInfoDictionaryKey: "SENTRY_DSN") as? String)
+    }
+
+    private static var telemetryAppID: String? {
+        normalize(Bundle.main.object(forInfoDictionaryKey: "TELEMETRY_APP_ID") as? String)
+    }
+
+    private static func normalize(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return nil
+        }
+
+        if trimmed.hasPrefix("$("), trimmed.hasSuffix(")") {
+            return nil
+        }
+
+        return trimmed
+    }
+}

--- a/Symi/Sources/Shared/UsageDataConsent.swift
+++ b/Symi/Sources/Shared/UsageDataConsent.swift
@@ -1,8 +1,6 @@
 import Foundation
 import Observation
 import OSLog
-import Sentry
-import TelemetryDeck
 
 enum UsageDataConsent: Equatable {
     case undecided
@@ -97,41 +95,26 @@ final class AppTelemetryService: UsageDataConsentService {
         }
 
         if !isSentryStarted, let sentryDSN = Self.sentryDSN {
-            SentrySDK.start { options in
-                options.dsn = sentryDSN
-
-                options.sendDefaultPii = false
-                options.tracesSampleRate = 0.2
-
-                options.configureProfiling = {
-                    $0.sessionSampleRate = 0.05
-                    $0.lifecycle = .trace
-                }
-
-                options.attachScreenshot = false
-                options.attachViewHierarchy = false
-                options.debug = false
-                options.enableLogs = false
-            }
+            AppTelemetryGateway.startSentry(dsn: sentryDSN)
             isSentryStarted = true
         } else if Self.sentryDSN == nil {
             Self.logger.notice("Sentry ist deaktiviert, weil keine gültige DSN in der App-Konfiguration gefunden wurde.")
         }
 
         if !isTelemetryDeckStarted, let telemetryAppID = Self.telemetryAppID {
-            TelemetryDeck.initialize(config: .init(appID: telemetryAppID))
+            AppTelemetryGateway.startTelemetryDeck(appID: telemetryAppID)
             isTelemetryDeckStarted = true
         }
     }
 
     private func stopTelemetry() {
         if isSentryStarted {
-            SentrySDK.close()
+            AppTelemetryGateway.stopSentry()
             isSentryStarted = false
         }
 
         if isTelemetryDeckStarted {
-            TelemetryDeck.terminate()
+            AppTelemetryGateway.stopTelemetryDeck()
             isTelemetryDeckStarted = false
         }
     }

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -158,6 +158,25 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func usageDataConsentStorePersistsExplicitDecisions() {
+        let suiteName = "UsageDataConsentStoreTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = UsageDataConsentStore(defaults: defaults)
+
+        #expect(store.consent == .undecided)
+
+        store.setConsent(.allowed)
+        #expect(store.consent == .allowed)
+
+        store.setConsent(.denied)
+        #expect(store.consent == .denied)
+
+        store.setConsent(.undecided)
+        #expect(store.consent == .undecided)
+    }
+
+    @Test
     func featureSourcesDoNotWireAppContainerOrInfrastructureImplementations() throws {
         let featureFiles = try swiftSourceFiles(in: "Symi/Sources/Features")
         #expect(!featureFiles.isEmpty)


### PR DESCRIPTION
## Summary
- gate Sentry and TelemetryDeck behind an explicit usage-data consent preference
- replace the first-launch privacy prompt with a native SwiftUI bottom sheet
- expose the anonymous usage-data setting in Settings
- update string catalog entries for the new copy

## Validation
- xcodebuild test -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SymiTests/CoreArchitectureTests/usageDataConsentStorePersistsExplicitDecisions
- xcodebuild build -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 17'

Closes #229
