### PR TITLE
[codex] Sharpen CI gating coverage

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -27,6 +27,8 @@ on:
       - "fastlane/Fastfile"
       - "fastlane/Snapfile"
       - ".github/workflows/ios-ci.yml"
+  schedule:
+    - cron: "30 2 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -63,7 +65,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "schedule" ]]; then
             echo "iphone_tests=true" >> "$GITHUB_OUTPUT"
             echo "ui_smoke=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -75,13 +77,13 @@ jobs:
 
           printf 'Geänderte Dateien:\n%s\n' "${changed_files}"
 
-          if printf '%s\n' "${changed_files}" | grep -Eq '^(Symi/Sources/(Models|Infrastructure/Persistence|Infrastructure/Health|Core/Export|Features/Export|App/(SymiApp|StoreRecovery|StartupMaintenanceService)\.swift)|SymiTests/(SwiftDataMigrationTests|DataTransferHealthContextTests|PersistentStoreRecoveryTests)\.swift|Symi\.xcodeproj/|\.github/workflows/ios-ci\.yml$)'; then
+          if printf '%s\n' "${changed_files}" | grep -Eq '^(Symi/Sources/(App|Shared|Models|Core|Infrastructure/(Persistence|Health|Sync)|Features/(Export|Sync|History|Home|Capture|InputFlow))|Symi/Resources/(Data|Localizable\.xcstrings|PrivacyInfo\.xcprivacy)|SymiTests/(SwiftDataMigrationTests|DataTransferHealthContextTests|PersistentStoreRecoveryTests|SyncMergeEngineTests|CoreArchitectureTests|DomainValidatorTests|ExportSummaryMetricsTests|FileProtectionPolicyTests)\.swift|Symi\.xcodeproj/|\.github/workflows/ios-ci\.yml$)'; then
             echo "iphone_tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "iphone_tests=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if printf '%s\n' "${changed_files}" | grep -Eq '^(SymiUITests/|Symi/Sources/Features/(Home|Capture)/|Symi/Sources/App/ScreenshotSupport\.swift|Symi\.xcodeproj/|fastlane/(Fastfile|Snapfile)$|\.github/workflows/ios-ci\.yml$)'; then
+          if printf '%s\n' "${changed_files}" | grep -Eq '^(SymiUITests/|Symi/Sources/(App/(AppShellView|ScreenshotSupport)\.swift|Features/(Home|Capture|InputFlow|History|Export)|Core/(Episodes|History|Export)|Shared/(AppTheme|ProductBranding|LiquidGlassStyle)\.swift)|Symi/Resources/(Assets\.xcassets|Localizable\.xcstrings)|Symi\.xcodeproj/|fastlane/(Fastfile|Snapfile)$|\.github/workflows/ios-ci\.yml$)'; then
             echo "ui_smoke=true" >> "$GITHUB_OUTPUT"
           else
             echo "ui_smoke=false" >> "$GITHUB_OUTPUT"
@@ -337,7 +339,7 @@ jobs:
           xcrun simctl boot "${TEST_DEVICE_NAME}" || true
           xcrun simctl bootstatus "${TEST_DEVICE_NAME}" -b
 
-      - name: Home-zu-Speichern-Smoke ausführen
+      - name: Zentrale UI-Smokes ausführen
         run: |
           xcodebuild test \
             -project Symi.xcodeproj \
@@ -346,7 +348,11 @@ jobs:
             -destination "${TEST_DESTINATION}" \
             -derivedDataPath "${RUNNER_TEMP}/DerivedData-UI" \
             -resultBundlePath "${RESULT_BUNDLE_PATH}" \
+            -only-testing:SymiUITests/HomeRedesignUITests/testAppShellUsesRequestedTabs \
             -only-testing:SymiUITests/HomeRedesignUITests/testHomeQuickEntryCanSaveHeadacheOnlyEntry \
+            -only-testing:SymiUITests/EntryFlowUITests/testCompleteFiveStepFlowSavesEntry \
+            -only-testing:SymiUITests/EntryFlowUITests/testOptionalStepsCanBeSkippedAndStillSavedWithoutWeather \
+            -only-testing:SymiUITests/SymiScreenshotTests/testDefaultSeedShowsScaleFirstNewEntryFlow \
             CODE_SIGNING_ALLOWED=NO
 
       - name: xcresult bei Fehler hochladen

--- a/docs/Teststrategie-und-Release-Checkliste.md
+++ b/docs/Teststrategie-und-Release-Checkliste.md
@@ -15,15 +15,16 @@ Automatisierte Gates im Projekt:
 
 1. Workflow `iOS CI` bei jedem `pull_request` auf `main`
 2. Workflow `iOS CI` bei jedem `push` auf `main`
-3. Swift-Builds, Tests und Release-Archive laufen in GitHub Actions mit Xcode 26.4
-4. schnelles PR-Gate aus SwiftLint/Design-Token-Regeln und `SymiTests` auf `Mac Catalyst`
-5. Ausführung von `SymiTests` auf einem `iPhone 17`-Simulator bei Persistence-, Migration-, Backup- oder Import-Änderungen sowie auf `main`
-6. fokussierter UI-Smoke auf einem `iPhone 17`-Simulator für `Home → Neuer Eintrag → Speichern` bei Home-, Capture- oder UI-Test-Änderungen sowie auf `main`
-7. Upload der `xcresult`-Bundles nur bei Fehlern für nachvollziehbare Fehlerdiagnose in GitHub
-8. Workflow `TestFlight Release` per manuellem GitHub-Actions-Start für Distribution-Signing via `match`, Build via `build_app` und Verteilung via `pilot`
-9. optionaler `TestFlight Release`-Input `build_number`; leer bedeutet automatische fastlane-Buildnummer
-10. Workflow `App Store Release` bei Git-Tags `vX.Y.Z` für Screenshot-Erstellung, Distribution-Signing via `match` und Upload via `deliver`
-11. Die finale Einreichung erfolgt manuell in App Store Connect über `Submit`
+3. Workflow `iOS CI` jede Nacht um `02:30 UTC`
+4. Swift-Builds, Tests und Release-Archive laufen in GitHub Actions mit Xcode 26.4
+5. schnelles PR-Gate aus SwiftLint/Design-Token-Regeln und `SymiTests` auf `Mac Catalyst`
+6. Ausführung von `SymiTests` auf einem `iPhone 17`-Simulator bei Änderungen an App-, Shared-, Core-, Sync-, Persistence-, Health-, Export-, History-, Home-, Capture-, InputFlow-, Ressourcen- oder kritischen Testdateien sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
+7. UI-Smoke auf einem `iPhone 17`-Simulator bei Änderungen an App-Shell, Home, Capture, InputFlow, History, Export, UI-Tests, App-Ressourcen, Fastlane-Screenshot-Konfiguration oder Projektdateien sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
+8. Upload der `xcresult`-Bundles nur bei Fehlern für nachvollziehbare Fehlerdiagnose in GitHub
+9. Workflow `TestFlight Release` per manuellem GitHub-Actions-Start für Distribution-Signing via `match`, Build via `build_app` und Verteilung via `pilot`
+10. optionaler `TestFlight Release`-Input `build_number`; leer bedeutet automatische fastlane-Buildnummer
+11. Workflow `App Store Release` bei Git-Tags `vX.Y.Z` für Screenshot-Erstellung, Distribution-Signing via `match` und Upload via `deliver`
+12. Die finale Einreichung erfolgt manuell in App Store Connect über `Submit`
 
 Lokale Vorab-Prüfung vor einem Tag-Release:
 
@@ -32,7 +33,7 @@ Lokale Vorab-Prüfung vor einem Tag-Release:
 2. Unit-Tests auf dem iPhone-Simulator ausführen:
    `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`
 3. UI-Smoke lokal ausführen:
-   `xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SymiUITests/HomeRedesignUITests/testHomeQuickEntryCanSaveHeadacheOnlyEntry`
+   `xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SymiUITests/HomeRedesignUITests/testAppShellUsesRequestedTabs -only-testing:SymiUITests/HomeRedesignUITests/testHomeQuickEntryCanSaveHeadacheOnlyEntry -only-testing:SymiUITests/EntryFlowUITests/testCompleteFiveStepFlowSavesEntry -only-testing:SymiUITests/EntryFlowUITests/testOptionalStepsCanBeSkippedAndStillSavedWithoutWeather -only-testing:SymiUITests/SymiScreenshotTests/testDefaultSeedShowsScaleFirstNewEntryFlow`
 4. Screenshot-Seed ohne vollständige Screenshot-Erzeugung validieren:
    `bundle exec fastlane ios validate_screenshot_seed`
 5. App im `Release`-Build in Xcode archivieren oder per `xcodebuild archive` bauen
@@ -40,14 +41,67 @@ Lokale Vorab-Prüfung vor einem Tag-Release:
 
 ## Automatisierte Testabdeckung
 
-Die automatisierten Tests decken aktuell folgende Kernlogik ab:
+Die automatisierten Tests decken aktuell folgende Kernlogik und kritische User Journeys ab:
 
 - Wetter-Snapshots für echte API-Daten und Zukunftsvalidierung
 - Export-Metriken für Durchschnittsintensität und Medikamentenliste
 - Insight Engine für Mindestdaten, Ausschlüsse, Durchschnitt, Trigger-/Wochentag-Thresholds, Trend und Hero-Sortierung
 - SwiftData-Migration von V4 und V5 auf das aktuelle Schema inklusive Erhalt von Episoden, Medikation und Wetter-Kontext
 - JSON5-Backup-Roundtrip inklusive Apple-Health-Kontext, Wetter-Snapshots und kontinuierlicher Medikation
-- UI-Smoke für den Skala-zuerst-Erfassungsflow von Home bis Speichern
+- App-Shell-Navigation mit Tagebuch, Insights, Teilen und Einstellungen
+- UI-Smoke für den Home-Quick-Entry von Home bis Speichern
+- UI-Smoke für den vollständigen fünfstufigen Erfassungsflow mit Medikation, Auslösern, Notiz und Review
+- UI-Smoke für optionale Erfassungsschritte ohne Wetterkontext
+- Screenshot-Seed-Smoke für den Skala-zuerst-Erfassungsflow
+
+## Risiko-basiertes iPhone- und UI-Gating
+
+Pull Requests bleiben schnell, indem Catalyst-Tests immer laufen und iPhone-/UI-Jobs über eine kritische Pfadliste zugeschaltet werden. Die Liste ist bewusst breiter als die minimal betroffenen Dateien, weil SwiftUI-, Ressourcen-, Persistenz- und Shared-Änderungen häufig plattformspezifische Fehler erst im iPhone-Simulator zeigen.
+
+Der iPhone-Unit-Job läuft bei Änderungen an:
+
+- `Symi/Sources/App`
+- `Symi/Sources/Shared`
+- `Symi/Sources/Models`
+- `Symi/Sources/Core`
+- `Symi/Sources/Infrastructure/Persistence`
+- `Symi/Sources/Infrastructure/Health`
+- `Symi/Sources/Infrastructure/Sync`
+- `Symi/Sources/Features/Export`
+- `Symi/Sources/Features/Sync`
+- `Symi/Sources/Features/History`
+- `Symi/Sources/Features/Home`
+- `Symi/Sources/Features/Capture`
+- `Symi/Sources/Features/InputFlow`
+- `Symi/Resources/Data`
+- `Symi/Resources/Localizable.xcstrings`
+- `Symi/Resources/PrivacyInfo.xcprivacy`
+- kritischen Testdateien für Migration, Transfer, Recovery, Sync, Architektur, Domain-Validierung, Export-Metriken und File Protection
+- `Symi.xcodeproj`
+- `.github/workflows/ios-ci.yml`
+
+Der UI-Smoke-Job läuft bei Änderungen an:
+
+- `SymiUITests`
+- `Symi/Sources/App/AppShellView.swift`
+- `Symi/Sources/App/ScreenshotSupport.swift`
+- `Symi/Sources/Features/Home`
+- `Symi/Sources/Features/Capture`
+- `Symi/Sources/Features/InputFlow`
+- `Symi/Sources/Features/History`
+- `Symi/Sources/Features/Export`
+- `Symi/Sources/Core/Episodes`
+- `Symi/Sources/Core/History`
+- `Symi/Sources/Core/Export`
+- zentralen Theme- und Branding-Dateien in `Symi/Sources/Shared`
+- `Symi/Resources/Assets.xcassets`
+- `Symi/Resources/Localizable.xcstrings`
+- `Symi.xcodeproj`
+- `fastlane/Fastfile`
+- `fastlane/Snapfile`
+- `.github/workflows/ios-ci.yml`
+
+Auf `main`, bei manuellem Start und im nächtlichen Lauf werden iPhone-Unit-Tests und UI-Smokes immer ausgeführt. Damit laufen die kritischen Journeys regelmäßig unabhängig davon, ob ein Pull Request von der Pfadliste erfasst wurde.
 
 Damit sind die fehleranfälligen Regeln des MVP reproduzierbar abgesichert, während die schwere App-Store-Screenshot-Erzeugung getrennt vom schnellen PR-Gate bleibt.
 

--- a/docs/Xcode-Cloud.md
+++ b/docs/Xcode-Cloud.md
@@ -52,7 +52,7 @@ Die GitHub-Workflows wählen für Swift-Builds explizit Xcode 26.4 aus.
 - `push` auf `main`
 - Xcode 26.4 für Swift-Builds, Tests und Release-Archive
 - schnelles PR-Gate aus SwiftLint und Catalyst-Unit-Tests
-- iPhone-Simulator-Tests und UI-Smoke bei relevanten Änderungen, auf `main` oder per manuellem Start
+- iPhone-Simulator-Tests und UI-Smoke bei risiko-relevanten Änderungen, auf `main`, per manuellem Start oder im nächtlichen Lauf
 - Upload von `xcresult`-Bundles nur bei Fehlern
 
 Die Release-Workflows in `GitHub Actions` übernehmen zusätzlich die Distribution:
@@ -66,13 +66,13 @@ Die Release-Workflows in `GitHub Actions` übernehmen zusätzlich die Distributi
 Dieser Workflow liefert schnelles Entwickler-Feedback.
 
 - Name: `iOS CI`
-- Startbedingung: `pull_request` auf `main`, `push` auf `main` und manueller Start
+- Startbedingung: `pull_request` auf `main`, `push` auf `main`, nächtlicher Zeitplan und manueller Start
 - Scheme: `Symi`
 - Aktionen:
   - SwiftLint/Design-Token-Regeln
   - Unit-Tests auf `Mac Catalyst`
-  - Unit-Tests auf einem `iPhone 17`-Simulator bei Persistence-, Migration-, Backup- oder Import-Änderungen sowie auf `main`
-  - fokussierter UI-Smoke auf einem `iPhone 17`-Simulator bei Home-, Capture- oder UI-Test-Änderungen sowie auf `main`
+  - Unit-Tests auf einem `iPhone 17`-Simulator bei risiko-relevanten App-, Shared-, Core-, Sync-, Persistence-, Ressourcen- oder Teständerungen sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
+  - zentrale UI-Smokes auf einem `iPhone 17`-Simulator bei App-Shell-, Home-, Capture-, InputFlow-, History-, Export-, Ressourcen-, Fastlane- oder UI-Test-Änderungen sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
   - Upload der jeweiligen `xcresult`-Bundles nur bei Fehlern
 
 ## Workflow 2: TestFlight Release
@@ -156,7 +156,7 @@ Die GitHub-Actions-Einrichtung gilt als korrekt, wenn:
 
 - `GitHub Actions` bei `pull_request` und `push` auf `main` erfolgreich läuft
 - `iOS CI` das schnelle PR-Gate aus SwiftLint und Catalyst-Unit-Tests ausführt
-- `iOS CI` iPhone- und UI-Gates bei relevanten Änderungen oder auf `main` ausführt
+- `iOS CI` iPhone- und UI-Gates bei risiko-relevanten Änderungen, auf `main`, per manuellem Start und im nächtlichen Lauf ausführt
 - ein manueller Start von `TestFlight Release` einen `TestFlight`-Build erzeugt
 - ein Tag wie `v1.2.0` ausschließlich den Workflow `App Store Release` startet
 - der Tag-Workflow Screenshots und ein veröffentlichbares Archiv in App Store Connect hochlädt, aber die Version nicht automatisch einreicht


### PR DESCRIPTION
## Was geändert wurde

- `iOS CI` läuft zusätzlich nächtlich um `02:30 UTC`.
- iPhone-Unit-Tests und UI-Smokes laufen auf `push`, manuellem Start und nächtlichem Lauf immer.
- PR-Gating wurde auf risiko-relevante App-, Shared-, Core-, Sync-, Ressourcen- und UI-Pfade verbreitert.
- Der UI-Smoke umfasst jetzt App-Shell, Home-Quick-Entry, vollständigen Entry-Flow, optionale Schritte ohne Wetter und den Screenshot-Seed-Smoke.
- Teststrategie- und CI-Doku dokumentieren die kritische Pfadliste.

## Warum

Architektur-, Shared-, Sync-, Settings- und UI-nahe Änderungen konnten bisher durch das selektive Gating iPhone- oder UI-spezifische Fehler verpassen. Die breitere Risikologik hält PRs weiterhin fokussiert, sorgt aber dafür, dass zentrale Journeys regelmäßig und vor Release laufen.

## Validierung

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-ci.yml"); puts "YAML OK"'
- `git diff --check`
- `actionlint` lokal nicht installiert

Closes #230
