### PR TITLE
[codex] Remove nightly CI schedule

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -27,8 +27,6 @@ on:
       - "fastlane/Fastfile"
       - "fastlane/Snapfile"
       - ".github/workflows/ios-ci.yml"
-  schedule:
-    - cron: "30 2 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -65,7 +63,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "schedule" ]]; then
+          if [[ "${{ github.event_name }}" == "push" ]]; then
             echo "iphone_tests=true" >> "$GITHUB_OUTPUT"
             echo "ui_smoke=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/docs/Teststrategie-und-Release-Checkliste.md
+++ b/docs/Teststrategie-und-Release-Checkliste.md
@@ -15,16 +15,15 @@ Automatisierte Gates im Projekt:
 
 1. Workflow `iOS CI` bei jedem `pull_request` auf `main`
 2. Workflow `iOS CI` bei jedem `push` auf `main`
-3. Workflow `iOS CI` jede Nacht um `02:30 UTC`
-4. Swift-Builds, Tests und Release-Archive laufen in GitHub Actions mit Xcode 26.4
-5. schnelles PR-Gate aus SwiftLint/Design-Token-Regeln und `SymiTests` auf `Mac Catalyst`
-6. Ausführung von `SymiTests` auf einem `iPhone 17`-Simulator bei Änderungen an App-, Shared-, Core-, Sync-, Persistence-, Health-, Export-, History-, Home-, Capture-, InputFlow-, Ressourcen- oder kritischen Testdateien sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
-7. UI-Smoke auf einem `iPhone 17`-Simulator bei Änderungen an App-Shell, Home, Capture, InputFlow, History, Export, UI-Tests, App-Ressourcen, Fastlane-Screenshot-Konfiguration oder Projektdateien sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
-8. Upload der `xcresult`-Bundles nur bei Fehlern für nachvollziehbare Fehlerdiagnose in GitHub
-9. Workflow `TestFlight Release` per manuellem GitHub-Actions-Start für Distribution-Signing via `match`, Build via `build_app` und Verteilung via `pilot`
-10. optionaler `TestFlight Release`-Input `build_number`; leer bedeutet automatische fastlane-Buildnummer
-11. Workflow `App Store Release` bei Git-Tags `vX.Y.Z` für Screenshot-Erstellung, Distribution-Signing via `match` und Upload via `deliver`
-12. Die finale Einreichung erfolgt manuell in App Store Connect über `Submit`
+3. Swift-Builds, Tests und Release-Archive laufen in GitHub Actions mit Xcode 26.4
+4. schnelles PR-Gate aus SwiftLint/Design-Token-Regeln und `SymiTests` auf `Mac Catalyst`
+5. Ausführung von `SymiTests` auf einem `iPhone 17`-Simulator bei Änderungen an App-, Shared-, Core-, Sync-, Persistence-, Health-, Export-, History-, Home-, Capture-, InputFlow-, Ressourcen- oder kritischen Testdateien sowie immer auf `main` und bei manuellem Start
+6. UI-Smoke auf einem `iPhone 17`-Simulator bei Änderungen an App-Shell, Home, Capture, InputFlow, History, Export, UI-Tests, App-Ressourcen, Fastlane-Screenshot-Konfiguration oder Projektdateien sowie immer auf `main` und bei manuellem Start
+7. Upload der `xcresult`-Bundles nur bei Fehlern für nachvollziehbare Fehlerdiagnose in GitHub
+8. Workflow `TestFlight Release` per manuellem GitHub-Actions-Start für Distribution-Signing via `match`, Build via `build_app` und Verteilung via `pilot`
+9. optionaler `TestFlight Release`-Input `build_number`; leer bedeutet automatische fastlane-Buildnummer
+10. Workflow `App Store Release` bei Git-Tags `vX.Y.Z` für Screenshot-Erstellung, Distribution-Signing via `match` und Upload via `deliver`
+11. Die finale Einreichung erfolgt manuell in App Store Connect über `Submit`
 
 Lokale Vorab-Prüfung vor einem Tag-Release:
 
@@ -101,7 +100,7 @@ Der UI-Smoke-Job läuft bei Änderungen an:
 - `fastlane/Snapfile`
 - `.github/workflows/ios-ci.yml`
 
-Auf `main`, bei manuellem Start und im nächtlichen Lauf werden iPhone-Unit-Tests und UI-Smokes immer ausgeführt. Damit laufen die kritischen Journeys regelmäßig unabhängig davon, ob ein Pull Request von der Pfadliste erfasst wurde.
+Auf `main` und bei manuellem Start werden iPhone-Unit-Tests und UI-Smokes immer ausgeführt. Damit können die kritischen Journeys vor Release vollständig validiert werden, auch wenn ein Pull Request nicht von der Pfadliste erfasst wurde.
 
 Damit sind die fehleranfälligen Regeln des MVP reproduzierbar abgesichert, während die schwere App-Store-Screenshot-Erzeugung getrennt vom schnellen PR-Gate bleibt.
 

--- a/docs/Xcode-Cloud.md
+++ b/docs/Xcode-Cloud.md
@@ -52,7 +52,7 @@ Die GitHub-Workflows wählen für Swift-Builds explizit Xcode 26.4 aus.
 - `push` auf `main`
 - Xcode 26.4 für Swift-Builds, Tests und Release-Archive
 - schnelles PR-Gate aus SwiftLint und Catalyst-Unit-Tests
-- iPhone-Simulator-Tests und UI-Smoke bei risiko-relevanten Änderungen, auf `main`, per manuellem Start oder im nächtlichen Lauf
+- iPhone-Simulator-Tests und UI-Smoke bei risiko-relevanten Änderungen, auf `main` oder per manuellem Start
 - Upload von `xcresult`-Bundles nur bei Fehlern
 
 Die Release-Workflows in `GitHub Actions` übernehmen zusätzlich die Distribution:
@@ -66,13 +66,13 @@ Die Release-Workflows in `GitHub Actions` übernehmen zusätzlich die Distributi
 Dieser Workflow liefert schnelles Entwickler-Feedback.
 
 - Name: `iOS CI`
-- Startbedingung: `pull_request` auf `main`, `push` auf `main`, nächtlicher Zeitplan und manueller Start
+- Startbedingung: `pull_request` auf `main`, `push` auf `main` und manueller Start
 - Scheme: `Symi`
 - Aktionen:
   - SwiftLint/Design-Token-Regeln
   - Unit-Tests auf `Mac Catalyst`
-  - Unit-Tests auf einem `iPhone 17`-Simulator bei risiko-relevanten App-, Shared-, Core-, Sync-, Persistence-, Ressourcen- oder Teständerungen sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
-  - zentrale UI-Smokes auf einem `iPhone 17`-Simulator bei App-Shell-, Home-, Capture-, InputFlow-, History-, Export-, Ressourcen-, Fastlane- oder UI-Test-Änderungen sowie immer auf `main`, bei manuellem Start und im nächtlichen Lauf
+  - Unit-Tests auf einem `iPhone 17`-Simulator bei risiko-relevanten App-, Shared-, Core-, Sync-, Persistence-, Ressourcen- oder Teständerungen sowie immer auf `main` und bei manuellem Start
+  - zentrale UI-Smokes auf einem `iPhone 17`-Simulator bei App-Shell-, Home-, Capture-, InputFlow-, History-, Export-, Ressourcen-, Fastlane- oder UI-Test-Änderungen sowie immer auf `main` und bei manuellem Start
   - Upload der jeweiligen `xcresult`-Bundles nur bei Fehlern
 
 ## Workflow 2: TestFlight Release
@@ -156,7 +156,7 @@ Die GitHub-Actions-Einrichtung gilt als korrekt, wenn:
 
 - `GitHub Actions` bei `pull_request` und `push` auf `main` erfolgreich läuft
 - `iOS CI` das schnelle PR-Gate aus SwiftLint und Catalyst-Unit-Tests ausführt
-- `iOS CI` iPhone- und UI-Gates bei risiko-relevanten Änderungen, auf `main`, per manuellem Start und im nächtlichen Lauf ausführt
+- `iOS CI` iPhone- und UI-Gates bei risiko-relevanten Änderungen, auf `main` und per manuellem Start ausführt
 - ein manueller Start von `TestFlight Release` einen `TestFlight`-Build erzeugt
 - ein Tag wie `v1.2.0` ausschließlich den Workflow `App Store Release` startet
 - der Tag-Workflow Screenshots und ein veröffentlichbares Archiv in App Store Connect hochlädt, aber die Version nicht automatisch einreicht


### PR DESCRIPTION
## Was geändert wurde

- Entfernt den nächtlichen `schedule` aus `iOS CI`.
- Belässt vollständige iPhone-Unit-Tests und zentrale UI-Smokes für `push` auf `main` und manuelle Starts.
- Aktualisiert Teststrategie- und CI-Doku ohne Nightly-Aussagen.

## Warum

Die breitere iPhone-/UI-Abdeckung soll vor Release und bei `main`-Integration verfügbar sein, aber keinen automatischen nächtlichen Lauf auslösen.

## Validierung

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-ci.yml"); puts "YAML OK"'
- `git diff --check origin/main...HEAD`
