### PR TITLE
Improve manual sync stale-state UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Die App bleibt klar migränefokussiert, fühlt sich aber bewusst nicht wie ein m
 ### 4. Optionale Synchronisation
 
 - iCloud-Sync aktivieren oder deaktivieren
-- Sync bewusst manuell über `Jetzt synchronisieren` auslösen; CloudKit-Subscriptions werden derzeit nicht angelegt
+- Sync-Vertrag: halbautomatisch beim Aktivieren, danach bewusst manuell über `Jetzt synchronisieren`; beim App-Start wird der gespeicherte Sync-Status geladen und der Provider vorbereitet, CloudKit-Subscriptions werden derzeit nicht angelegt
+- letzter Upload/Download, ungesyncte Records, stale Hinweise und offene Konflikte prüfen
 - Konflikte einsehen und auflösen
 - Cloud-Daten und Sync-Protokoll prüfen
 

--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -55,6 +55,7 @@ final class AppContainer {
                     initialStartedAt: initialStartedAt,
                     episodeRepository: episodeRepository,
                     medicationRepository: medicationCatalogRepository,
+                    syncService: syncService,
                     weatherContextService: episodeWeatherContextService,
                     healthService: healthService
                 )

--- a/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
@@ -385,6 +385,7 @@ final class EpisodeEditorController {
     private var saveValidationMessage: String?
     private let saveEpisodeUseCase: SaveEpisodeUseCase
     private let episodeRepository: EpisodeRepository
+    private let syncService: SyncService
     private let weatherContextService: any EpisodeWeatherContextProviding
     private let healthService: any HealthService
     private var originalStartedAt: Date?
@@ -395,10 +396,12 @@ final class EpisodeEditorController {
         initialStartedAt: Date?,
         episodeRepository: EpisodeRepository,
         medicationRepository: MedicationCatalogRepository,
+        syncService: SyncService,
         weatherContextService: any EpisodeWeatherContextProviding,
         healthService: any HealthService
     ) {
         self.episodeRepository = episodeRepository
+        self.syncService = syncService
         self.weatherContextService = weatherContextService
         self.healthService = healthService
         self.medicationController = EpisodeMedicationSelectionController(medicationRepository: medicationRepository)
@@ -426,6 +429,17 @@ final class EpisodeEditorController {
 
     var validationMessage: String? {
         saveValidationMessage ?? medicationController.validationMessage
+    }
+
+    var syncStalenessWarning: String? {
+        syncService.status.staleDataWarning(
+            isSyncEnabled: syncService.isEnabled,
+            openConflictCount: syncService.conflicts.count
+        )
+    }
+
+    func refreshSyncStatus() {
+        syncService.refreshStatus()
     }
 
     func save(onSaved: (() -> Void)?, onDismiss: @escaping () -> Void) {

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -27,6 +27,10 @@ struct EpisodeEditorView: View {
                 EpisodeValidationMessageSection(message: validationMessage)
             }
 
+            if let syncStalenessWarning = controller.syncStalenessWarning {
+                EpisodeSyncWarningSection(message: syncStalenessWarning)
+            }
+
             EpisodeScaleSection(draft: $controller.draft)
             EpisodeTimingSection(draft: $controller.draft)
             EpisodeTagSection(
@@ -105,6 +109,9 @@ struct EpisodeEditorView: View {
         .task(id: controller.draft.startedAt) {
             await controller.refreshWeather()
         }
+        .task {
+            controller.refreshSyncStatus()
+        }
     }
 
     private func save() {
@@ -147,6 +154,20 @@ private struct EpisodeValidationMessageSection: View {
                 .font(.subheadline)
                 .foregroundStyle(AppTheme.symiCoral)
                 .accessibilityLabel("Hinweis: \(message)")
+                .formAlignedRow()
+        }
+    }
+}
+
+private struct EpisodeSyncWarningSection: View {
+    let message: String
+
+    var body: some View {
+        Section {
+            Label(message, systemImage: "arrow.triangle.2.circlepath.circle.fill")
+                .font(.subheadline)
+                .foregroundStyle(AppTheme.symiCoral)
+                .accessibilityLabel("Sync-Hinweis: \(message)")
                 .formAlignedRow()
         }
     }

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -29,11 +29,24 @@ struct SettingsView: View {
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
 
+                        if let syncStalenessWarning {
+                            Label(syncStalenessWarning, systemImage: "exclamationmark.triangle.fill")
+                                .font(.subheadline)
+                                .foregroundStyle(AppTheme.symiCoral)
+                        }
+
                         HStack(spacing: SymiSpacing.lg) {
                             statValue(title: "Ausstehend", value: "\(controller.syncStatus.queuedUpdates)")
                             statValue(title: "Ungesynct", value: "\(controller.syncStatus.unsyncedRecords)")
                             statValue(title: "Konflikte", value: "\(controller.conflicts.count)")
                         }
+
+                        VStack(alignment: .leading, spacing: SymiSpacing.micro) {
+                            Text("Upload: \(formatted(controller.syncStatus.lastUploadedAt))")
+                            Text("Download: \(formatted(controller.syncStatus.lastDownloadedAt))")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     }
                     .padding(.vertical, SymiSpacing.compact)
                     .brandGroupedRow()
@@ -65,7 +78,7 @@ struct SettingsView: View {
             } header: {
                 Text("Synchronisation")
             } footer: {
-                Text("Die App bleibt lokal vollständig nutzbar. iCloud-Sync ist optional, arbeitet getrennt von SwiftData und kann jederzeit wieder deaktiviert werden.")
+                Text(syncContractSummary)
             }
 
             Section {
@@ -176,17 +189,20 @@ struct SettingsView: View {
             return lastError
         }
 
-        if let lastUploadedAt = controller.syncStatus.lastUploadedAt {
-            return "Letzter Upload: \(formatted(lastUploadedAt))"
-        }
-
-        if let lastDownloadedAt = controller.syncStatus.lastDownloadedAt {
-            return "Letzter Download: \(formatted(lastDownloadedAt))"
-        }
-
         return controller.isSyncEnabled
             ? "Synchronisation ist bereit. Lokale Änderungen bleiben bis zum nächsten Lauf sicher auf dem Gerät."
             : "Synchronisation ist deaktiviert. Alle Daten bleiben lokal auf diesem Gerät erhalten."
+    }
+
+    private var syncStalenessWarning: String? {
+        controller.syncStatus.staleDataWarning(
+            isSyncEnabled: controller.isSyncEnabled,
+            openConflictCount: controller.conflicts.count
+        )
+    }
+
+    private var syncContractSummary: String {
+        "Sync ist halbautomatisch: Aktivieren startet sofort einen Abgleich; App-Start lädt den gespeicherten Sync-Status und startet den Provider. Danach löst du den Cloud-Abgleich bewusst mit `Jetzt synchronisieren` aus. CloudKit-Subscriptions werden nicht angelegt; stale Stände, ungesyncte Records und Konflikte bleiben sichtbar."
     }
 
     private var statusBadge: some View {
@@ -212,6 +228,14 @@ struct SettingsView: View {
 
     private func formatted(_ date: Date) -> String {
         date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    private func formatted(_ date: Date?) -> String {
+        guard let date else {
+            return "Noch nie"
+        }
+
+        return formatted(date)
     }
 
     private var logSubtitle: String {
@@ -550,8 +574,17 @@ private struct SyncStatusView: View {
                 statusRow("Dienst", controller.syncStatus.service)
                 statusRow("Ausstehende Uploads", "\(controller.syncStatus.queuedUpdates)")
                 statusRow("Ungesyncte Einträge", "\(controller.syncStatus.unsyncedRecords)")
+                statusRow("Offene Konflikte", "\(controller.conflicts.count)")
                 statusRow("Letzter Download", formatted(controller.syncStatus.lastDownloadedAt))
                 statusRow("Letzter Upload", formatted(controller.syncStatus.lastUploadedAt))
+
+                if let syncStalenessWarning {
+                    Label(syncStalenessWarning, systemImage: "exclamationmark.triangle.fill")
+                        .font(.subheadline)
+                        .foregroundStyle(AppTheme.symiCoral)
+                        .padding(.vertical, SymiSpacing.xxs)
+                        .brandGroupedRow()
+                }
 
                 if let lastError = controller.syncStatus.lastError {
                     VStack(alignment: .leading, spacing: SymiSpacing.compact) {
@@ -567,6 +600,13 @@ private struct SyncStatusView: View {
                 Text("Status")
             } footer: {
                 Text(statusFooter)
+            }
+
+            Section("Sync-Vertrag") {
+                Text("Symi arbeitet lokal-first. Bei aktivem iCloud-Sync startet ein neuer Abgleich sofort nach dem Aktivieren und danach nur, wenn du ihn mit `Jetzt synchronisieren` auslöst. Beim App-Start wird der gespeicherte Sync-Status geladen und der Provider vorbereitet; Push- oder Subscription-gesteuerte Hintergrundabgleiche gibt es derzeit nicht.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .brandGroupedRow()
             }
         }
         .navigationTitle("Status")
@@ -611,6 +651,13 @@ private struct SyncStatusView: View {
             "Ohne Netzwerk bleiben alle Daten lokal erhalten und werden später erneut versucht."
         }
     }
+
+    private var syncStalenessWarning: String? {
+        controller.syncStatus.staleDataWarning(
+            isSyncEnabled: controller.isSyncEnabled,
+            openConflictCount: controller.conflicts.count
+        )
+    }
 }
 
 private struct ManageCloudDataView: View {
@@ -623,12 +670,23 @@ private struct ManageCloudDataView: View {
         List {
             Section {
                 statusRow("Sync", controller.isSyncEnabled ? "Aktiviert" : "Deaktiviert")
+                statusRow("Letzter Upload", formatted(controller.syncStatus.lastUploadedAt))
+                statusRow("Letzter Download", formatted(controller.syncStatus.lastDownloadedAt))
+                statusRow("Ungesyncte Records", "\(controller.syncStatus.unsyncedRecords)")
                 statusRow("Offene Konflikte", "\(controller.conflicts.count)")
                 statusRow("Papierkorb", "\(controller.summary.trashCount)")
+
+                if let syncStalenessWarning {
+                    Label(syncStalenessWarning, systemImage: "exclamationmark.triangle.fill")
+                        .font(.subheadline)
+                        .foregroundStyle(AppTheme.symiCoral)
+                        .padding(.vertical, SymiSpacing.xxs)
+                        .brandGroupedRow()
+                }
             } header: {
                 Text("Übersicht")
             } footer: {
-                Text("Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst.")
+                Text("Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst. Sync läuft halbautomatisch: Aktivierung startet einen Abgleich, danach nutzt du `Jetzt synchronisieren`.")
             }
 
             Section {
@@ -780,6 +838,21 @@ private struct ManageCloudDataView: View {
             Text(value)
                 .foregroundStyle(.secondary)
         }
+    }
+
+    private func formatted(_ date: Date?) -> String {
+        guard let date else {
+            return "Noch nie"
+        }
+
+        return date.formatted(date: .numeric, time: .shortened)
+    }
+
+    private var syncStalenessWarning: String? {
+        controller.syncStatus.staleDataWarning(
+            isSyncEnabled: controller.isSyncEnabled,
+            openConflictCount: controller.conflicts.count
+        )
     }
 
     private var selectedConflictPresented: Binding<Bool> {

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -59,6 +59,8 @@ public enum SyncPayloadSchema {
 }
 
 public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
+    public nonisolated static let staleDataWarningInterval: TimeInterval = 24 * 60 * 60
+
     public nonisolated var state: SyncServiceState
     public nonisolated var service: String
     public nonisolated var queuedUpdates: Int
@@ -83,6 +85,45 @@ public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
         self.lastDownloadedAt = lastDownloadedAt
         self.lastUploadedAt = lastUploadedAt
         self.lastError = lastError
+    }
+
+    public nonisolated func staleDataWarning(
+        now: Date = .now,
+        isSyncEnabled: Bool,
+        openConflictCount: Int
+    ) -> String? {
+        guard isSyncEnabled else {
+            return nil
+        }
+
+        if openConflictCount > 0 {
+            return "\(openConflictCount) Sync-Konflikt\(openConflictCount == 1 ? "" : "e") warten auf eine Entscheidung. Bearbeite erst weiter, wenn klar ist, welcher Stand gelten soll."
+        }
+
+        if unsyncedRecords > 0 {
+            return "\(unsyncedRecords) lokale Änderung\(unsyncedRecords == 1 ? "" : "en") sind noch nicht in iCloud bestätigt. Synchronisiere vor dem Bearbeiten auf anderen Geräten."
+        }
+
+        guard let lastDownloadedAt else {
+            return "Dieses Gerät hat noch keinen iCloud-Download abgeschlossen. Synchronisiere vor dem Bearbeiten, wenn du Symi auf mehreren Geräten nutzt."
+        }
+
+        let age = now.timeIntervalSince(lastDownloadedAt)
+        guard age >= Self.staleDataWarningInterval else {
+            return nil
+        }
+
+        return "Der letzte iCloud-Download liegt \(Self.relativeDurationDescription(for: age)) zurück. Synchronisiere vor dem Bearbeiten, damit du nicht auf einem alten Stand arbeitest."
+    }
+
+    private nonisolated static func relativeDurationDescription(for interval: TimeInterval) -> String {
+        let hours = max(1, Int(interval / 3_600))
+        guard hours >= 48 else {
+            return "\(hours) Stunde\(hours == 1 ? "" : "n")"
+        }
+
+        let days = max(1, hours / 24)
+        return "\(days) Tag\(days == 1 ? "" : "e")"
     }
 }
 

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -6,6 +6,58 @@ import Testing
 
 struct SyncMergeEngineTests {
     @Test
+    func syncStatusWarnsWhenLastDownloadIsStale() {
+        let now = Date(timeIntervalSince1970: 200_000)
+        let status = SyncStatusSnapshot(
+            state: .ready,
+            unsyncedRecords: 0,
+            lastDownloadedAt: now.addingTimeInterval(-SyncStatusSnapshot.staleDataWarningInterval - 60),
+            lastUploadedAt: now.addingTimeInterval(-300)
+        )
+
+        let warning = status.staleDataWarning(now: now, isSyncEnabled: true, openConflictCount: 0)
+
+        #expect(warning?.contains("letzte iCloud-Download") == true)
+    }
+
+    @Test
+    func syncStatusPrioritizesConflictsAndUnsyncedRecords() {
+        let status = SyncStatusSnapshot(
+            state: .conflict,
+            unsyncedRecords: 3,
+            lastDownloadedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let conflictWarning = status.staleDataWarning(
+            now: Date(timeIntervalSince1970: 2_000),
+            isSyncEnabled: true,
+            openConflictCount: 2
+        )
+        let unsyncedWarning = status.staleDataWarning(
+            now: Date(timeIntervalSince1970: 2_000),
+            isSyncEnabled: true,
+            openConflictCount: 0
+        )
+
+        #expect(conflictWarning?.contains("2 Sync-Konflikte") == true)
+        #expect(unsyncedWarning?.contains("3 lokale Änderungen") == true)
+    }
+
+    @Test
+    func syncStatusDoesNotWarnWhenDisabledOrFresh() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let status = SyncStatusSnapshot(
+            state: .ready,
+            unsyncedRecords: 0,
+            lastDownloadedAt: now.addingTimeInterval(-300),
+            lastUploadedAt: now.addingTimeInterval(-120)
+        )
+
+        #expect(status.staleDataWarning(now: now, isSyncEnabled: false, openConflictCount: 0) == nil)
+        #expect(status.staleDataWarning(now: now, isSyncEnabled: true, openConflictCount: 0) == nil)
+    }
+
+    @Test
     func corruptSyncStateFileStartsWithCleanStateAndCanPersistAgain() async throws {
         let baseDirectory = try makeTemporaryDirectory()
         let syncDirectory = baseDirectory.appendingPathComponent("Symi", isDirectory: true)

--- a/docs/Sync-Abdeckung.md
+++ b/docs/Sync-Abdeckung.md
@@ -14,6 +14,12 @@ CloudKit-Sync nutzt `SyncDocumentEnvelope` als fachliche Dokumentgrenze. Die fol
 
 Konfliktbehandlung läuft weiterhin über den dreiseitigen Merge aus Shadow, lokalem Dokument und Remote-Dokument. Konflikte bei Episoden-Sidecars werden mit Feldpfaden wie `continuousMedicationChecks.<id>.wasTaken` oder `healthContext` sichtbar gemacht; Konflikte bei Dauermedikationen werden auf den jeweiligen Feldern wie `dosage`, `frequency` oder `endDate` gemeldet.
 
+## Sync-Vertrag und UX-Signale
+
+Der iCloud-Sync ist halbautomatisch. Beim Aktivieren wird der Provider gestartet und sofort ein Abgleich ausgelöst. Beim App-Start lädt Symi den gespeicherten Sync-Status und startet den Provider, löst aber keinen stillen vollständigen Cloud-Abgleich per Subscription aus. Danach bleibt `Jetzt synchronisieren` die bewusste Nutzeraktion für Fetch und Upload; CloudKit-Subscriptions werden derzeit nicht angelegt.
+
+Die App zeigt deshalb bewusst sichtbare Frische-Signale: letzter Upload, letzter Download, ausstehende Uploads, ungesyncte Records und offene Konflikte. Wenn ein Gerät noch nie geladen hat, der letzte Download älter als 24 Stunden ist, lokale Änderungen noch nicht bestätigt sind oder Konflikte offen sind, erscheint vor dem Bearbeiten ein Sync-Hinweis. So ist erkennbar, wenn Gerät B möglicherweise auf einem älteren Stand arbeitet, weil Gerät A länger nicht synchronisiert wurde.
+
 ## CloudKit-Record-Design
 
 Symi speichert pro fachlichem Sync-Dokument weiterhin einen vollständigen `SyncDocumentEnvelope` als JSON in `payloadJSON`. Die CloudKit-Felder `documentID`, `entityType`, `schemaVersion`, `modifiedAt`, `authorDeviceID` und `deletedAt` bleiben zusätzlich als Record-Metadaten erhalten. Diese Entscheidung ist bewusst: Der Envelope hält die fachliche Dokumentgrenze stabil, vermeidet fragmentierte Teil-Records für Episoden-Sidecars und erlaubt den bestehenden dreiseitigen Merge gegen lokale Shadows ohne CloudKit-spezifische Feldlogik.


### PR DESCRIPTION
## Summary
- show upload/download freshness, unsynced records, conflicts, and stale warnings more prominently in sync settings
- warn in the episode editor when the local sync state is stale, conflicted, or has unconfirmed local changes
- document the current half-automatic/manual iCloud sync contract

## Tests
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'

Closes #232