### PR TITLE
Document historical Apple identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Die App bleibt klar migränefokussiert, fühlt sich aber bewusst nicht wie ein m
 - PDF-Erzeugung lokal auf dem Gerät
 - optionale, manuell ausgelöste iCloud-Synchronisation getrennt von der lokalen Kernnutzung
 
-Interne technische Kennungen wie `Symi`, Bundle-ID, Scheme und iCloud-Container bestehen derzeit aus Migrations- und Release-Gründen weiter, obwohl die sichtbare Produktmarke auf `Symi` umgestellt ist.
+Interne Apple-Developer-Identifier wie Bundle ID und iCloud-Container bestehen aus Migrations- und Release-Gründen weiterhin unter `MigraineTracker`, obwohl die sichtbare Produktmarke auf `Symi` umgestellt ist. Diese historischen Kennungen sind in [docs/Historische-Identifier.md](/Users/mat/code/Symi/docs/Historische-Identifier.md) dokumentiert.
 
 ## Datenschutz und medizinische Einordnung
 
@@ -133,5 +133,6 @@ xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16
 - [docs/MVP-Konzept.md](/Users/mat/code/Symi/docs/MVP-Konzept.md)
 - [docs/Insight-Engine.md](/Users/mat/code/Symi/docs/Insight-Engine.md)
 - [docs/App-Store-Metadaten.md](/Users/mat/code/Symi/docs/App-Store-Metadaten.md)
+- [docs/Historische-Identifier.md](/Users/mat/code/Symi/docs/Historische-Identifier.md)
 - [docs/Teststrategie-und-Release-Checkliste.md](/Users/mat/code/Symi/docs/Teststrategie-und-Release-Checkliste.md)
 - [Symi Support](https://symiapp.com)

--- a/docs/Historische-Identifier.md
+++ b/docs/Historische-Identifier.md
@@ -1,0 +1,58 @@
+# Historische Identifier
+
+## Grundsatz
+
+Die sichtbare Produktmarke, das Xcode-Projekt, die App-Schemes und die Dokumentation verwenden den Namen `Symi`. Einige Apple-Developer-Identifier stammen jedoch aus der früheren Projektphase als `MigraineTracker` und bleiben absichtlich unverändert.
+
+Diese Kennungen sind Teil der veröffentlichten App-, Signing- und iCloud-Historie. Sie dürfen nicht im Rahmen normaler Branding- oder Release-Arbeiten umbenannt werden.
+
+## Nicht ändern
+
+Folgende Identifier sind historisch und bleiben stabil:
+
+- App Store Connect Bundle ID: `eu.mpwg.MigraineTracker`
+- iOS-App-`PRODUCT_BUNDLE_IDENTIFIER`: `eu.mpwg.MigraineTracker`
+- fastlane `APP_IDENTIFIER`: `eu.mpwg.MigraineTracker`
+- Distribution-Provisioning-Profile: `match AppStore eu.mpwg.MigraineTracker`
+- iCloud-/CloudKit-Container: `iCloud.eu.mpwg.MigraineTracker`
+- HealthKit-Sync-Metadaten-Präfix: `eu.mpwg.MigraineTracker.episode`
+
+Diese Werte sind bewusst keine Produkttexte. Sie erscheinen in Developer-Portal, App Store Connect, Provisioning Profiles, Entitlements, CloudKit und technischen Metadaten.
+
+## Aktuelle Symi-Identifier
+
+Diese Kennungen dürfen weiterhin `Symi` verwenden, weil sie keine veröffentlichte Apple-App-Identität ersetzen:
+
+- Xcode-Projekt: `Symi.xcodeproj`
+- Shared App Scheme: `Symi`
+- Test-Scheme: `SymiTests`
+- Screenshot-Scheme: `SymiScreenshots`
+- Test-Bundle-Identifier: `eu.mpwg.SymiTests` und `eu.mpwg.SymiUITests`
+- lokale App-Support-Verzeichnisse und Exportnamen mit sichtbarem Produktbezug
+
+## Release- und Provisioning-Regeln
+
+Für Releases wird weiterhin gegen `eu.mpwg.MigraineTracker` signiert und veröffentlicht. `fastlane match` muss deshalb Zertifikate und Profile für genau diese Bundle ID liefern. Das Provisioning Profile muss außerdem die bestehenden Push-, WeatherKit-, HealthKit- und iCloud-Entitlements abdecken.
+
+Der iCloud-Container `iCloud.eu.mpwg.MigraineTracker` bleibt der produktive CloudKit-Container. Neue Release- oder Provisioning-Arbeiten dürfen keinen parallelen `iCloud.eu.mpwg.Symi`-Container anlegen, solange keine explizite Migrationsentscheidung getroffen wurde.
+
+Vor jedem Signing- oder Capability-Change prüfen:
+
+1. App Store Connect enthält weiterhin das Bundle `eu.mpwg.MigraineTracker`.
+2. Apple Developer Portal enthält weiterhin App ID, iCloud-Container und Capabilities für `eu.mpwg.MigraineTracker`.
+3. Das `match`-Repository enthält ein gültiges `appstore`-Profil für `eu.mpwg.MigraineTracker`.
+4. `Symi/Symi.entitlements` referenziert weiterhin `iCloud.eu.mpwg.MigraineTracker`.
+5. `fastlane/Fastfile` verwendet weiterhin `APP_IDENTIFIER = "eu.mpwg.MigraineTracker"`.
+
+## Falls eine Umbenennung geplant wird
+
+Eine spätere technische Umbenennung auf `eu.mpwg.Symi` ist ein eigenes Migrationsprojekt und darf nicht als einfache Textänderung umgesetzt werden. Vor einer Änderung braucht es mindestens:
+
+- Entscheidung, ob eine neue Bundle ID überhaupt zulässig ist oder ob dadurch eine neue App-Store-App entstehen würde.
+- Apple-Developer-Plan für neue App ID, Capabilities, Push, WeatherKit, HealthKit und Provisioning Profiles.
+- CloudKit-Strategie für `iCloud.eu.mpwg.Symi`, inklusive Datenmigration oder bewusster Trennung vom bestehenden Container.
+- Fallback-Plan für Nutzerinnen und Nutzer mit vorhandenen iCloud-Daten im Container `iCloud.eu.mpwg.MigraineTracker`.
+- TestFlight-Migrationslauf mit produktionsnahen Daten und dokumentierter Rollback-Entscheidung.
+- Aktualisierung von `fastlane`, GitHub-Actions-Secrets, App Store Connect, Entitlements, HealthKit-Metadaten und Support-Dokumentation in einem abgestimmten Release.
+
+Bis diese Strategie beschlossen und getestet ist, bleiben die historischen Identifier unverändert.

--- a/docs/Teststrategie-und-Release-Checkliste.md
+++ b/docs/Teststrategie-und-Release-Checkliste.md
@@ -36,7 +36,8 @@ Lokale Vorab-Prüfung vor einem Tag-Release:
 4. Screenshot-Seed ohne vollständige Screenshot-Erzeugung validieren:
    `bundle exec fastlane ios validate_screenshot_seed`
 5. App im `Release`-Build in Xcode archivieren oder per `xcodebuild archive` bauen
-6. offene Fehler in `GitHub Actions` oder `TestFlight` vor dem Tagging beseitigen
+6. Signing und Provisioning gegen die historischen Identifier `eu.mpwg.MigraineTracker` und `iCloud.eu.mpwg.MigraineTracker` prüfen; Details stehen in [Historische Identifier](/Users/mat/code/Symi/docs/Historische-Identifier.md)
+7. offene Fehler in `GitHub Actions` oder `TestFlight` vor dem Tagging beseitigen
 
 ## Automatisierte Testabdeckung
 
@@ -158,3 +159,4 @@ Die Projektregeln für Releases sind:
 - `TestFlight` wird bewusst über den manuell gestarteten Workflow `TestFlight Release` verteilt
 - der `App Store` wird nur über Git-Tags im Format `vX.Y.Z` ausgelöst
 - `fastlane match`, `build_app`, `pilot` und `deliver` sind die Release-Werkzeuge für Distribution
+- technische Apple-Developer-Identifier bleiben für Release und Provisioning auf `eu.mpwg.MigraineTracker`; `Symi` ist die sichtbare Produktmarke

--- a/docs/Xcode-Cloud.md
+++ b/docs/Xcode-Cloud.md
@@ -18,6 +18,7 @@ Es gibt genau drei relevante Workflows:
 Vor der Einrichtung in `App Store Connect` und `GitHub` müssen diese Punkte erfüllt sein:
 
 - das Bundle `eu.mpwg.MigraineTracker` existiert bereits in `App Store Connect`
+- die Bundle ID `eu.mpwg.MigraineTracker` ist ein historischer Identifier und wird trotz sichtbarer Produktmarke `Symi` nicht umbenannt
 - in `GitHub Actions` sind diese Secrets gesetzt:
   - `APPLE_DEVELOPER_TEAM_ID`
   - `APP_STORE_CONNECT_ISSUER_ID`
@@ -32,14 +33,19 @@ Vor der Einrichtung in `App Store Connect` und `GitHub` müssen diese Punkte erf
   - `TELEMETRY_APP_ID`
 - das Shared Scheme `Symi` ist versioniert
 - das Match-Repository enthält ein gültiges `appstore`-Zertifikat und ein passendes Provisioning Profile für `eu.mpwg.MigraineTracker`
-- die vorhandenen Entitlements für Push und iCloud bleiben aktiv
+- die vorhandenen Entitlements für Push, WeatherKit, HealthKit und iCloud bleiben aktiv
+- der iCloud-Container bleibt `iCloud.eu.mpwg.MigraineTracker`; es wird kein paralleler `Symi`-Container für Releases angelegt
 - der verwendete App-Store-Connect-Schlüssel ist ein Team-Key, kein Individual Key
 
 Aus dem Projekt bestätigt:
 
 - `DEVELOPMENT_TEAM = $(APPLE_DEVELOPER_TEAM_ID)`
+- `PRODUCT_BUNDLE_IDENTIFIER = eu.mpwg.MigraineTracker` für die iOS-App
 - `Debug` verwendet `ICLOUD_CONTAINER_ENVIRONMENT = Development`
 - `Release` verwendet `ICLOUD_CONTAINER_ENVIRONMENT = Production`
+- `Symi/Symi.entitlements` referenziert `iCloud.eu.mpwg.MigraineTracker`
+
+Die historischen Apple-Developer-Identifier und die Regeln für eine mögliche spätere Migration sind in [Historische Identifier](/Users/mat/code/Symi/docs/Historische-Identifier.md) festgehalten.
 
 Die Release-Lanes erzeugen in CI ein lokales Secrets-`xcconfig`, laden über `match` Distribution-Zertifikate und Provisioning Profiles in ein temporäres Keychain und bauen anschließend reproduzierbar mit manuellem Distribution-Signing.
 Die GitHub-Workflows wählen für Swift-Builds explizit Xcode 26.4 aus.


### PR DESCRIPTION
## Änderungen

- dokumentiert die historischen Apple-Developer-Identifier für Bundle ID, iCloud-Container, Provisioning und fastlane
- ergänzt Release-/Provisioning-Regeln in der GitHub-Actions-Release-Doku
- ergänzt eine Migrationsstrategie, falls die technischen Identifier später auf Symi umgestellt werden sollen

## Validierung

- `git diff --check`
- Markdown-Dateien auf lesbaren Inhalt geprüft

Closes #233
