### PR TITLE
[codex] Implement Apple Health type configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16
 
 - [docs/MVP-Konzept.md](/Users/mat/code/Symi/docs/MVP-Konzept.md)
 - [docs/Insight-Engine.md](/Users/mat/code/Symi/docs/Insight-Engine.md)
+- [docs/Apple-Health-Datentypen.md](/Users/mat/code/Symi/docs/Apple-Health-Datentypen.md)
 - [docs/App-Store-Metadaten.md](/Users/mat/code/Symi/docs/App-Store-Metadaten.md)
 - [docs/Historische-Identifier.md](/Users/mat/code/Symi/docs/Historische-Identifier.md)
 - [docs/Teststrategie-und-Release-Checkliste.md](/Users/mat/code/Symi/docs/Teststrategie-und-Release-Checkliste.md)

--- a/Symi/Sources/Core/Health/HealthCore.swift
+++ b/Symi/Sources/Core/Health/HealthCore.swift
@@ -37,10 +37,23 @@ public enum HealthDataTypeID: String, Codable, CaseIterable, Identifiable, Senda
     }
 }
 
+enum HealthDataTypeCategory: String, Codable, CaseIterable, Identifiable, Sendable {
+    case sleep = "Schlaf"
+    case activity = "Aktivität"
+    case heart = "Herzwerte"
+    case cycle = "Zyklus"
+    case symptom = "Symptome"
+
+    var id: String { rawValue }
+}
+
 struct HealthDataTypeDefinition: Identifiable, Equatable, Sendable {
     let id: HealthDataTypeID
     let direction: HealthDataDirection
+    let category: HealthDataTypeCategory
     let defaultEnabled: Bool
+    let healthKitIdentifier: String
+    let availabilityNote: String?
     let rationale: String
 
     var displayName: String { id.displayName }
@@ -48,21 +61,21 @@ struct HealthDataTypeDefinition: Identifiable, Equatable, Sendable {
 
 enum HealthDataCatalog {
     static let readDefinitions: [HealthDataTypeDefinition] = [
-        .init(id: .sleep, direction: .read, defaultEnabled: true, rationale: "Schlafmangel und Schlafqualität sind häufige Kontextfaktoren bei Kopfschmerzen und Migräne."),
-        .init(id: .steps, direction: .read, defaultEnabled: true, rationale: "Aktivität am Episodentag kann helfen, Belastung und Schonung im Verlauf einzuordnen."),
-        .init(id: .heartRate, direction: .read, defaultEnabled: true, rationale: "Herzfrequenz im Umfeld einer Episode kann körperlichen Stress als Kontext sichtbar machen."),
-        .init(id: .restingHeartRate, direction: .read, defaultEnabled: true, rationale: "Der Ruhepuls ergänzt den Tageskontext, ohne eine medizinische Bewertung vorzunehmen."),
-        .init(id: .heartRateVariability, direction: .read, defaultEnabled: true, rationale: "HRV kann als neutraler Kontextwert für Stress und Erholung angezeigt werden."),
-        .init(id: .menstrualFlow, direction: .read, defaultEnabled: true, rationale: "Zyklusdaten können bei migränebezogenen Mustern relevant sein, bleiben aber reine Kontextdaten."),
-        .init(id: .headache, direction: .read, defaultEnabled: true, rationale: "Vorhandene Health-Kopfschmerzsymptome werden als externe Quelle kenntlich gemacht."),
-        .init(id: .nausea, direction: .read, defaultEnabled: true, rationale: "Übelkeit ist ein häufiges Begleitsymptom von Migräne."),
-        .init(id: .dizziness, direction: .read, defaultEnabled: true, rationale: "Schwindel kann als Begleitsymptom den Episodenkontext ergänzen."),
-        .init(id: .fatigue, direction: .read, defaultEnabled: true, rationale: "Müdigkeit kann als neutraler Kontext vor oder während Schmerzepisoden relevant sein.")
+        .init(id: .sleep, direction: .read, category: .sleep, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierSleepAnalysis", availabilityNote: nil, rationale: "Schlafmangel und Schlafqualität sind häufige Kontextfaktoren bei Kopfschmerzen und Migräne."),
+        .init(id: .steps, direction: .read, category: .activity, defaultEnabled: true, healthKitIdentifier: "HKQuantityTypeIdentifierStepCount", availabilityNote: nil, rationale: "Aktivität am Episodentag kann helfen, Belastung und Schonung im Verlauf einzuordnen."),
+        .init(id: .heartRate, direction: .read, category: .heart, defaultEnabled: true, healthKitIdentifier: "HKQuantityTypeIdentifierHeartRate", availabilityNote: nil, rationale: "Herzfrequenz im Umfeld einer Episode kann körperlichen Stress als Kontext sichtbar machen."),
+        .init(id: .restingHeartRate, direction: .read, category: .heart, defaultEnabled: true, healthKitIdentifier: "HKQuantityTypeIdentifierRestingHeartRate", availabilityNote: nil, rationale: "Der Ruhepuls ergänzt den Tageskontext, ohne eine medizinische Bewertung vorzunehmen."),
+        .init(id: .heartRateVariability, direction: .read, category: .heart, defaultEnabled: true, healthKitIdentifier: "HKQuantityTypeIdentifierHeartRateVariabilitySDNN", availabilityNote: nil, rationale: "HRV kann als neutraler Kontextwert für Stress und Erholung angezeigt werden."),
+        .init(id: .menstrualFlow, direction: .read, category: .cycle, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierMenstrualFlow", availabilityNote: "Ab iOS 18 verfügbar; auf älteren Systemen wird der Typ ausgelassen.", rationale: "Zyklusdaten können bei migränebezogenen Mustern relevant sein, bleiben aber reine Kontextdaten."),
+        .init(id: .headache, direction: .read, category: .symptom, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierHeadache", availabilityNote: nil, rationale: "Vorhandene Health-Kopfschmerzsymptome werden als externe Quelle kenntlich gemacht."),
+        .init(id: .nausea, direction: .read, category: .symptom, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierNausea", availabilityNote: nil, rationale: "Übelkeit ist ein häufiges Begleitsymptom von Migräne."),
+        .init(id: .dizziness, direction: .read, category: .symptom, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierDizziness", availabilityNote: nil, rationale: "Schwindel kann als Begleitsymptom den Episodenkontext ergänzen."),
+        .init(id: .fatigue, direction: .read, category: .symptom, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierFatigue", availabilityNote: nil, rationale: "Müdigkeit kann als neutraler Kontext vor oder während Schmerzepisoden relevant sein.")
     ]
 
     static let writeDefinitions: [HealthDataTypeDefinition] = [
-        .init(id: .headache, direction: .write, defaultEnabled: true, rationale: "Die App kann die dokumentierte Schmerzepisode als Kopfschmerz-Symptom nach Apple Health schreiben."),
-        .init(id: .nausea, direction: .write, defaultEnabled: true, rationale: "Übelkeit wird nur geschrieben, wenn sie in der Episode ausdrücklich ausgewählt wurde.")
+        .init(id: .headache, direction: .write, category: .symptom, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierHeadache", availabilityNote: nil, rationale: "Die App kann die dokumentierte Schmerzepisode als Kopfschmerz-Symptom nach Apple Health schreiben."),
+        .init(id: .nausea, direction: .write, category: .symptom, defaultEnabled: true, healthKitIdentifier: "HKCategoryTypeIdentifierNausea", availabilityNote: nil, rationale: "Übelkeit wird nur geschrieben, wenn sie in der Episode ausdrücklich ausgewählt wurde.")
     ]
 
     static var allDefinitions: [HealthDataTypeDefinition] {
@@ -177,6 +190,16 @@ struct HealthContextRecord: Equatable, Sendable {
         self.heartRateVariability = snapshot.heartRateVariability
         self.menstrualFlow = snapshot.menstrualFlow
         self.symptoms = snapshot.symptoms
+    }
+
+    var hasVisibleData: Bool {
+        sleepMinutes != nil ||
+        stepCount != nil ||
+        averageHeartRate != nil ||
+        restingHeartRate != nil ||
+        heartRateVariability != nil ||
+        menstrualFlow != nil ||
+            !symptoms.isEmpty
     }
 }
 

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -553,9 +553,17 @@ private struct HealthDataTypeSection: View {
                 )) {
                     VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                         Text(definition.displayName)
+                        Text("\(definition.category.rawValue) · \(definition.healthKitIdentifier)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
                         Text(definition.rationale)
                             .font(.caption)
                             .foregroundStyle(.secondary)
+                        if let availabilityNote = definition.availabilityNote {
+                            Text(availabilityNote)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
                 .tint(AppTheme.ocean)

--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -44,6 +44,10 @@ struct EpisodeDetailView: View {
                             EntryDetailTriggerSection(triggers: episode.triggers)
                         }
 
+                        if let healthContext = episode.healthContext, healthContext.hasVisibleData {
+                            EntryDetailHealthContextCard(healthContext: healthContext)
+                        }
+
                         EntryDetailMedicationCard(episode: episode)
 
                         EntryDetailDeleteAction(onDelete: { isShowingDeleteConfirmation = true })
@@ -570,6 +574,73 @@ private struct EntryDetailMedicationCard: View {
 
     private var medicationText: String {
         JournalEntryContext.medicationDetail(for: episode) ?? "Keine Medikation"
+    }
+}
+
+private struct EntryDetailHealthContextCard: View {
+    let healthContext: HealthContextRecord
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
+            Label("Apple Health", systemImage: "heart.text.square")
+                .font(.system(.headline, design: .rounded).weight(.semibold))
+                .foregroundStyle(ColorToken.Brand.primary)
+
+            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+                ForEach(lines, id: \.self) { line in
+                    Text(line)
+                        .font(.system(.subheadline, design: .rounded).weight(.medium))
+                        .foregroundStyle(ColorToken.Text.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Text("Quelle: \(healthContext.source)")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(ColorToken.Text.tertiary)
+        }
+        .padding(SymiSpacing.entryDetailMedicationCardPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(EntryDetailSurface.cardFill, in: RoundedRectangle(cornerRadius: EntryDetailSurface.cornerRadius, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: EntryDetailSurface.cornerRadius, style: .continuous)
+                .stroke(EntryDetailSurface.highlight, lineWidth: SymiStroke.hairline)
+        )
+        .shadow(
+            color: EntryDetailSurface.shadowColor,
+            radius: EntryDetailSurface.shadowRadius,
+            x: SymiShadow.cardXOffset,
+            y: EntryDetailSurface.shadowYOffset
+        )
+    }
+
+    private var lines: [String] {
+        var values: [String] = []
+        if let sleepMinutes = healthContext.sleepMinutes {
+            values.append("Schlaf: \(Int(sleepMinutes.rounded()).formatted()) min")
+        }
+        if let stepCount = healthContext.stepCount {
+            values.append("Schritte: \(stepCount.formatted())")
+        }
+        if let averageHeartRate = healthContext.averageHeartRate {
+            values.append("Herzfrequenz: \(averageHeartRate.formatted(.number.precision(.fractionLength(0)))) bpm")
+        }
+        if let restingHeartRate = healthContext.restingHeartRate {
+            values.append("Ruhepuls: \(restingHeartRate.formatted(.number.precision(.fractionLength(0)))) bpm")
+        }
+        if let heartRateVariability = healthContext.heartRateVariability {
+            values.append("HRV: \(heartRateVariability.formatted(.number.precision(.fractionLength(0)))) ms")
+        }
+        if let menstrualFlow = healthContext.menstrualFlow {
+            values.append("Menstruation: \(menstrualFlow)")
+        }
+        if !healthContext.symptoms.isEmpty {
+            let symptoms = healthContext.symptoms.map { "\($0.type.displayName): \($0.severity)" }
+            values.append("Symptome: \(symptoms.joined(separator: ", "))")
+        }
+
+        values.append("Erfasst: \(healthContext.recordedAt.formatted(date: .abbreviated, time: .shortened))")
+        return values
     }
 }
 

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -158,6 +158,27 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func healthDataCatalogDocumentsSeparateReadableAndWritableTypes() {
+        let readDefinitions = HealthDataCatalog.readDefinitions
+        let writeDefinitions = HealthDataCatalog.writeDefinitions
+
+        #expect(!readDefinitions.isEmpty)
+        #expect(!writeDefinitions.isEmpty)
+        #expect(readDefinitions.allSatisfy { $0.direction == .read })
+        #expect(writeDefinitions.allSatisfy { $0.direction == .write })
+        #expect(Set(readDefinitions.map(\.id)).count == readDefinitions.count)
+        #expect(Set(writeDefinitions.map(\.id)).count == writeDefinitions.count)
+        #expect(readDefinitions.contains { $0.category == .sleep })
+        #expect(readDefinitions.contains { $0.category == .activity })
+        #expect(readDefinitions.contains { $0.category == .heart })
+        #expect(readDefinitions.contains { $0.category == .cycle })
+        #expect(readDefinitions.contains { $0.category == .symptom })
+        #expect(writeDefinitions.allSatisfy { $0.category == .symptom })
+        #expect(HealthDataCatalog.allDefinitions.allSatisfy { !$0.rationale.trimmed.isEmpty })
+        #expect(HealthDataCatalog.allDefinitions.allSatisfy { !$0.healthKitIdentifier.trimmed.isEmpty })
+    }
+
+    @Test
     func usageDataConsentStorePersistsExplicitDecisions() {
         let suiteName = "UsageDataConsentStoreTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/docs/Apple-Health-Datentypen.md
+++ b/docs/Apple-Health-Datentypen.md
@@ -1,0 +1,38 @@
+# Apple-Health-Datentypen
+
+Dieses Dokument beschreibt die Apple-Health-Datentypen, die Symi als schmerzrelevanten Kontext nutzt. Lesen und Schreiben sind bewusst getrennt, damit Nutzer jeden Typ einzeln aktivieren oder deaktivieren können und spätere HealthKit-Typen über den zentralen Katalog ergänzt werden.
+
+## Lesen aus Apple Health
+
+| Bereich | Symi-Typ | HealthKit-Identifier | Standard | Fachliche Begründung |
+| --- | --- | --- | --- | --- |
+| Schlaf | Schlaf | `HKCategoryTypeIdentifierSleepAnalysis` | aktiv | Schlafmangel, Schlafdauer und Schlafqualität sind häufige Kontextfaktoren bei Kopfschmerzen und Migräne. |
+| Aktivität | Schritte | `HKQuantityTypeIdentifierStepCount` | aktiv | Aktivität am Episodentag hilft, Belastung, Schonung und Tagesroutine im Verlauf einzuordnen. |
+| Herzwerte | Herzfrequenz | `HKQuantityTypeIdentifierHeartRate` | aktiv | Herzfrequenz rund um eine Episode kann körperlichen Stress als neutralen Kontext sichtbar machen. |
+| Herzwerte | Ruhepuls | `HKQuantityTypeIdentifierRestingHeartRate` | aktiv | Ruhepuls ergänzt den Tageskontext, ohne daraus eine medizinische Bewertung abzuleiten. |
+| Herzwerte | Herzfrequenzvariabilität | `HKQuantityTypeIdentifierHeartRateVariabilitySDNN` | aktiv | HRV kann Hinweise auf Stress und Erholung liefern und bleibt in Symi reine Kontextinformation. |
+| Zyklus | Menstruation | `HKCategoryTypeIdentifierMenstrualFlow` | aktiv | Zyklusdaten können bei migränebezogenen Mustern relevant sein. Der Typ wird erst ab iOS 18 abgefragt. |
+| Symptome | Kopfschmerz | `HKCategoryTypeIdentifierHeadache` | aktiv | Vorhandene Kopfschmerzsymptome aus Apple Health werden als externe Quelle kenntlich gemacht. |
+| Symptome | Übelkeit | `HKCategoryTypeIdentifierNausea` | aktiv | Übelkeit ist ein häufiges Begleitsymptom von Migräne. |
+| Symptome | Schwindel | `HKCategoryTypeIdentifierDizziness` | aktiv | Schwindel kann Episoden fachlich ergänzen, ohne Diagnose oder Interpretation. |
+| Symptome | Müdigkeit | `HKCategoryTypeIdentifierFatigue` | aktiv | Müdigkeit kann vor oder während Schmerzepisoden relevant sein. |
+
+## Schreiben nach Apple Health
+
+| Bereich | Symi-Typ | HealthKit-Identifier | Standard | Fachliche Begründung |
+| --- | --- | --- | --- | --- |
+| Symptome | Kopfschmerz | `HKCategoryTypeIdentifierHeadache` | aktiv | Symi kann die dokumentierte Episode als Kopfschmerz-Symptom schreiben. Notizen und Medikamente werden nicht übertragen. |
+| Symptome | Übelkeit | `HKCategoryTypeIdentifierNausea` | aktiv | Übelkeit wird nur geschrieben, wenn sie im Eintrag ausdrücklich ausgewählt wurde. |
+
+## Nutzersteuerung
+
+- Die Einstellungen zeigen Lesen und Schreiben getrennt unter `Apple Health`.
+- Jeder Datentyp hat einen eigenen Schalter. Die Auswahl wird unabhängig von der iOS-Berechtigung gespeichert.
+- Die eigentliche HealthKit-Autorisierung wird erst über `Leserechte anfragen` oder `Schreibrechte anfragen` gestartet.
+- Gelesene Episodenkontexte werden in der UI und im PDF-Export als `Apple Health` mit Quelle ausgewiesen.
+
+## Erweiterung
+
+Neue Typen werden über `HealthDataTypeID`, `HealthDataCatalog` und die HealthKit-Zuordnung in `AppleHealthKitService` ergänzt. Die Einstellungen und Präferenzen lesen den Katalog dynamisch, sodass zusätzliche Datentypen ohne neue Einstellungslogik sichtbar werden.
+
+Nicht Bestandteil dieser Strategie sind komplexe Konfliktlogik zwischen Symi und Apple Health, medizinische Interpretation der Werte und nicht-Apple-basierte Gesundheitsplattformen.


### PR DESCRIPTION
## Änderungen

- Apple-Health-Datentypen nach Lesen und Schreiben fachlich dokumentiert.

- Health-Katalog mit Kategorie, HealthKit-Identifier und Availability-Hinweis erweitert; Einstellungen zeigen diese Metadaten pro Toggle an.

- Episodendetails zeigen gespeicherten Apple-Health-Kontext inklusive Quelle; Export kennzeichnet ihn weiterhin als Apple Health.


## Prüfung

- `xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SymiTests/CoreArchitectureTests`


Closes #102






