### PR TITLE
[codex] Refine Health cycle data handling

### DIFF
--- a/Symi/Sources/Core/Health/HealthCore.swift
+++ b/Symi/Sources/Core/Health/HealthCore.swift
@@ -81,6 +81,10 @@ enum HealthDataCatalog {
     static var allDefinitions: [HealthDataTypeDefinition] {
         readDefinitions + writeDefinitions
     }
+
+    static func canWriteMenstrualFlowSample(from status: MenstruationStatus) -> Bool {
+        status.canWriteMenstrualFlowSample
+    }
 }
 
 public struct HealthSymptomSampleData: @preconcurrency Codable, Equatable, Sendable {
@@ -113,6 +117,76 @@ public struct HealthSymptomSampleData: @preconcurrency Codable, Equatable, Senda
     }
 }
 
+public enum MenstrualFlowSamplePrecision: String, Codable, Sendable {
+    case specified
+    case unspecified
+    case unknown
+
+    nonisolated var displayName: String {
+        switch self {
+        case .specified:
+            "Exakter Health-Flow"
+        case .unspecified:
+            "Health-Flow ohne Stärke"
+        case .unknown:
+            "Unklare Genauigkeit"
+        }
+    }
+}
+
+public struct HealthMenstrualFlowSampleData: @preconcurrency Codable, Equatable, Sendable {
+    public let flow: String
+    public let precision: MenstrualFlowSamplePrecision
+    public let startDate: Date
+    public let endDate: Date
+    public let source: String
+    public let isUserEntered: Bool
+
+    public nonisolated init(
+        flow: String,
+        precision: MenstrualFlowSamplePrecision,
+        startDate: Date,
+        endDate: Date,
+        source: String,
+        isUserEntered: Bool
+    ) {
+        self.flow = flow
+        self.precision = precision
+        self.startDate = startDate
+        self.endDate = endDate
+        self.source = source
+        self.isUserEntered = isUserEntered
+    }
+
+    nonisolated var displayText: String {
+        switch precision {
+        case .specified:
+            "Menstruation: \(flow)"
+        case .unspecified:
+            "Menstruation: Stärke nicht angegeben"
+        case .unknown:
+            "Menstruation: erfasst, Genauigkeit unklar"
+        }
+    }
+
+    nonisolated var accuracyText: String {
+        "\(precision.displayName), Quelle: \(source)"
+    }
+
+    nonisolated var canWriteToAppleHealth: Bool {
+        isUserEntered && precision == .specified
+    }
+
+    public nonisolated static func == (lhs: HealthMenstrualFlowSampleData, rhs: HealthMenstrualFlowSampleData) -> Bool {
+        lhs.flow == rhs.flow &&
+            lhs.precision == rhs.precision &&
+            lhs.startDate == rhs.startDate &&
+            lhs.endDate == rhs.endDate &&
+            lhs.source == rhs.source &&
+            lhs.isUserEntered == rhs.isUserEntered
+    }
+}
+
 public struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sendable {
     public let recordedAt: Date
     public let source: String
@@ -122,6 +196,7 @@ public struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sen
     public let restingHeartRate: Double?
     public let heartRateVariability: Double?
     public let menstrualFlow: String?
+    public let menstrualFlowSample: HealthMenstrualFlowSampleData?
     public let symptoms: [HealthSymptomSampleData]
 
     public nonisolated init(
@@ -133,6 +208,7 @@ public struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sen
         restingHeartRate: Double?,
         heartRateVariability: Double?,
         menstrualFlow: String?,
+        menstrualFlowSample: HealthMenstrualFlowSampleData? = nil,
         symptoms: [HealthSymptomSampleData]
     ) {
         self.recordedAt = recordedAt
@@ -143,6 +219,7 @@ public struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sen
         self.restingHeartRate = restingHeartRate
         self.heartRateVariability = heartRateVariability
         self.menstrualFlow = menstrualFlow
+        self.menstrualFlowSample = menstrualFlowSample
         self.symptoms = symptoms
     }
 
@@ -153,6 +230,7 @@ public struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sen
         restingHeartRate != nil ||
         heartRateVariability != nil ||
         menstrualFlow != nil ||
+        menstrualFlowSample != nil ||
             !symptoms.isEmpty
     }
 
@@ -165,6 +243,7 @@ public struct HealthContextSnapshotData: @preconcurrency Codable, Equatable, Sen
             lhs.restingHeartRate == rhs.restingHeartRate &&
             lhs.heartRateVariability == rhs.heartRateVariability &&
             lhs.menstrualFlow == rhs.menstrualFlow &&
+            lhs.menstrualFlowSample == rhs.menstrualFlowSample &&
             lhs.symptoms == rhs.symptoms
     }
 }
@@ -178,6 +257,7 @@ struct HealthContextRecord: Equatable, Sendable {
     let restingHeartRate: Double?
     let heartRateVariability: Double?
     let menstrualFlow: String?
+    let menstrualFlowSample: HealthMenstrualFlowSampleData?
     let symptoms: [HealthSymptomSampleData]
 
     nonisolated init(snapshot: HealthContextSnapshotData) {
@@ -189,6 +269,7 @@ struct HealthContextRecord: Equatable, Sendable {
         self.restingHeartRate = snapshot.restingHeartRate
         self.heartRateVariability = snapshot.heartRateVariability
         self.menstrualFlow = snapshot.menstrualFlow
+        self.menstrualFlowSample = snapshot.menstrualFlowSample
         self.symptoms = snapshot.symptoms
     }
 
@@ -199,6 +280,7 @@ struct HealthContextRecord: Equatable, Sendable {
         restingHeartRate != nil ||
         heartRateVariability != nil ||
         menstrualFlow != nil ||
+        menstrualFlowSample != nil ||
             !symptoms.isEmpty
     }
 }
@@ -258,6 +340,7 @@ extension HealthContextSnapshotData {
             restingHeartRate: record.restingHeartRate,
             heartRateVariability: record.heartRateVariability,
             menstrualFlow: record.menstrualFlow,
+            menstrualFlowSample: record.menstrualFlowSample,
             symptoms: record.symptoms
         )
     }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -720,7 +720,7 @@ private struct EntryReviewStepView: View {
             lines.append("Gefühl: \(feeling)")
         }
         if draft.menstruationStatus != .unknown {
-            lines.append("Regel: \(draft.menstruationStatus.displayName)")
+            lines.append("Zyklusstatus aus der App: \(draft.menstruationStatus.displayName)")
         }
 
         return lines

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -277,6 +277,9 @@ private struct EpisodeOptionalDetailsSection: View {
                         Text(status.displayName).tag(status)
                     }
                 }
+                Text(draft.menstruationStatus.accuracyDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
                 Toggle("Ende angeben", isOn: $draft.endedAtEnabled.animation())
                 if draft.endedAtEnabled {

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -529,7 +529,7 @@ private struct AppleHealthSettingsView: View {
                 }
                 .disabled(!controller.healthAuthorization.isAvailable)
             } footer: {
-                Text("V1 schreibt nur Kopfschmerz und ausgewählte Begleitsymptome. Medikamente, Zyklusdaten und Konfliktlogik sind eigene Folge-Issues.")
+                Text("Geschrieben werden nur ausreichend präzise, nutzererfasste Symptome. Zyklusangaben aus der App wie „aktuell“ oder „erwartet“ bleiben Kontext und werden nicht als exakte Health-Flow-Samples gespeichert.")
             }
         }
         .navigationTitle("Apple Health")

--- a/Symi/Sources/Features/Export/PDFExportWriter.swift
+++ b/Symi/Sources/Features/Export/PDFExportWriter.swift
@@ -214,8 +214,12 @@ nonisolated enum PDFExportWriter {
             if let heartRateVariability = health.heartRateVariability {
                 parts.append("HRV \(heartRateVariability.formatted(.number.precision(.fractionLength(0)))) ms")
             }
-            if let menstrualFlow = health.menstrualFlow {
-                parts.append(formatted("Menstruation %@", menstrualFlow))
+            if let menstrualFlowSample = health.menstrualFlowSample {
+                parts.append(menstrualFlowSample.displayText)
+                parts.append(formatted("Zyklusgenauigkeit: %@", menstrualFlowSample.accuracyText))
+            } else if let menstrualFlow = health.menstrualFlow {
+                parts.append(formatted("Menstruation aus Apple Health %@", menstrualFlow))
+                parts.append("Zyklusgenauigkeit: alter Kontext ohne Sample-Details")
             }
             if !health.symptoms.isEmpty {
                 parts.append(formatted("Symptome %@", health.symptoms.joined(separator: ", ")))

--- a/Symi/Sources/Features/History/EpisodeDetailView.swift
+++ b/Symi/Sources/Features/History/EpisodeDetailView.swift
@@ -631,8 +631,12 @@ private struct EntryDetailHealthContextCard: View {
         if let heartRateVariability = healthContext.heartRateVariability {
             values.append("HRV: \(heartRateVariability.formatted(.number.precision(.fractionLength(0)))) ms")
         }
-        if let menstrualFlow = healthContext.menstrualFlow {
-            values.append("Menstruation: \(menstrualFlow)")
+        if let menstrualFlowSample = healthContext.menstrualFlowSample {
+            values.append(menstrualFlowSample.displayText)
+            values.append("Zyklusgenauigkeit: \(menstrualFlowSample.accuracyText)")
+        } else if let menstrualFlow = healthContext.menstrualFlow {
+            values.append("Menstruation aus Apple Health: \(menstrualFlow)")
+            values.append("Zyklusgenauigkeit: alter Kontext ohne Sample-Details")
         }
         if !healthContext.symptoms.isEmpty {
             let symptoms = healthContext.symptoms.map { "\($0.type.displayName): \($0.severity)" }

--- a/Symi/Sources/Infrastructure/Health/AppleHealthKitService.swift
+++ b/Symi/Sources/Infrastructure/Health/AppleHealthKitService.swift
@@ -79,8 +79,9 @@ final class AppleHealthKitService: HealthService {
         async let averageHeartRate = enabledTypes.contains(.heartRate) ? averageHeartRate(from: draft.startedAt.addingTimeInterval(-3_600), to: draft.startedAt.addingTimeInterval(3_600)) : nil
         async let restingHeartRate = enabledTypes.contains(.restingHeartRate) ? latestQuantityValue(typeID: .restingHeartRate, unit: HKUnit.count().unitDivided(by: .minute()), from: dayStart, to: dayEnd) : nil
         async let hrv = enabledTypes.contains(.heartRateVariability) ? latestQuantityValue(typeID: .heartRateVariabilitySDNN, unit: .secondUnit(with: .milli), from: dayStart, to: dayEnd) : nil
-        async let menstrualFlow = enabledTypes.contains(.menstrualFlow) ? latestMenstrualFlow(from: dayStart, to: dayEnd) : nil
+        async let menstrualFlowSample = enabledTypes.contains(.menstrualFlow) ? latestMenstrualFlow(from: dayStart, to: dayEnd) : nil
         async let symptoms = symptomSamples(enabledTypes: enabledTypes, from: dayStart, to: dayEnd)
+        let resolvedMenstrualFlowSample = try await menstrualFlowSample
 
         let snapshot = HealthContextSnapshotData(
             recordedAt: .now,
@@ -90,7 +91,8 @@ final class AppleHealthKitService: HealthService {
             averageHeartRate: try await averageHeartRate,
             restingHeartRate: try await restingHeartRate,
             heartRateVariability: try await hrv,
-            menstrualFlow: try await menstrualFlow,
+            menstrualFlow: resolvedMenstrualFlowSample?.flow,
+            menstrualFlowSample: resolvedMenstrualFlowSample,
             symptoms: try await symptoms
         )
 
@@ -234,7 +236,7 @@ final class AppleHealthKitService: HealthService {
         return samples.first?.quantity.doubleValue(for: unit)
     }
 
-    private func latestMenstrualFlow(from start: Date, to end: Date) async throws -> String? {
+    private func latestMenstrualFlow(from start: Date, to end: Date) async throws -> HealthMenstrualFlowSampleData? {
         guard #available(iOS 18.0, *) else {
             return nil
         }
@@ -244,18 +246,31 @@ final class AppleHealthKitService: HealthService {
         }
 
         return try await categorySamples(type: type, from: start, to: end).last.map { sample in
-            switch sample.value {
-            case HKCategoryValueVaginalBleeding.light.rawValue:
-                "Leicht"
-            case HKCategoryValueVaginalBleeding.medium.rawValue:
-                "Mittel"
-            case HKCategoryValueVaginalBleeding.heavy.rawValue:
-                "Stark"
-            case HKCategoryValueVaginalBleeding.unspecified.rawValue:
-                "Nicht angegeben"
-            default:
-                "Erfasst"
-            }
+            let mapped = Self.menstrualFlowValue(for: sample.value)
+            return HealthMenstrualFlowSampleData(
+                flow: mapped.flow,
+                precision: mapped.precision,
+                startDate: sample.startDate,
+                endDate: sample.endDate,
+                source: sample.sourceRevision.source.name,
+                isUserEntered: sample.metadata?[HKMetadataKeyWasUserEntered] as? Bool ?? false
+            )
+        }
+    }
+
+    @available(iOS 18.0, *)
+    private static func menstrualFlowValue(for value: Int) -> (flow: String, precision: MenstrualFlowSamplePrecision) {
+        switch value {
+        case HKCategoryValueVaginalBleeding.light.rawValue:
+            ("Leicht", .specified)
+        case HKCategoryValueVaginalBleeding.medium.rawValue:
+            ("Mittel", .specified)
+        case HKCategoryValueVaginalBleeding.heavy.rawValue:
+            ("Stark", .specified)
+        case HKCategoryValueVaginalBleeding.unspecified.rawValue:
+            ("Stärke nicht angegeben", .unspecified)
+        default:
+            ("Erfasst", .unknown)
         }
     }
 

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -59,6 +59,23 @@ enum MenstruationStatus: String, CaseIterable, Codable, Identifiable {
         }
     }
 
+    nonisolated var accuracyDescription: String {
+        switch self {
+        case .unknown:
+            String(localized: "Keine Zyklusangabe aus der App.")
+        case .none:
+            String(localized: "App-Angabe ohne Health-Flow-Sample.")
+        case .active:
+            String(localized: "Aktuelle App-Angabe ohne Stärke oder Health-Flow-Sample.")
+        case .expected:
+            String(localized: "Erwartete App-Angabe, keine echte Blutungsprobe.")
+        }
+    }
+
+    nonisolated var canWriteMenstrualFlowSample: Bool {
+        false
+    }
+
     nonisolated init(storageValue: String) {
         switch storageValue {
         case Self.unknown.rawValue, "Nicht angegeben":

--- a/Symi/Sources/Models/ExportModels.swift
+++ b/Symi/Sources/Models/ExportModels.swift
@@ -89,6 +89,7 @@ nonisolated struct EpisodeExportRecord: Identifiable, Sendable {
         let restingHeartRate: Double?
         let heartRateVariability: Double?
         let menstrualFlow: String?
+        let menstrualFlowSample: HealthMenstrualFlowSampleData?
         let symptoms: [String]
 
         nonisolated init(record: HealthContextRecord) {
@@ -100,6 +101,7 @@ nonisolated struct EpisodeExportRecord: Identifiable, Sendable {
             self.restingHeartRate = record.restingHeartRate
             self.heartRateVariability = record.heartRateVariability
             self.menstrualFlow = record.menstrualFlow
+            self.menstrualFlowSample = record.menstrualFlowSample
             self.symptoms = record.symptoms.map { "\($0.type.displayName): \($0.severity)" }
         }
     }

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -82,6 +82,47 @@ struct CoreArchitectureTests {
     }
 
     @Test
+    func appMenstruationStatusNeverQualifiesAsHealthFlowSample() {
+        for status in MenstruationStatus.allCases {
+            #expect(!HealthDataCatalog.canWriteMenstrualFlowSample(from: status))
+            #expect(!status.canWriteMenstrualFlowSample)
+            #expect(!status.accuracyDescription.isEmpty)
+        }
+
+        #expect(!HealthDataCatalog.writeDefinitions.contains { $0.id == .menstrualFlow })
+    }
+
+    @Test
+    func healthMenstrualFlowSampleKeepsSourceAndPrecisionSeparateFromAppStatus() {
+        let sample = HealthMenstrualFlowSampleData(
+            flow: "Mittel",
+            precision: .specified,
+            startDate: Date(timeIntervalSince1970: 1_000),
+            endDate: Date(timeIntervalSince1970: 2_000),
+            source: "Apple Health",
+            isUserEntered: true
+        )
+        let snapshot = HealthContextSnapshotData(
+            recordedAt: Date(timeIntervalSince1970: 3_000),
+            source: "Apple Health",
+            sleepMinutes: nil,
+            stepCount: nil,
+            averageHeartRate: nil,
+            restingHeartRate: nil,
+            heartRateVariability: nil,
+            menstrualFlow: sample.flow,
+            menstrualFlowSample: sample,
+            symptoms: []
+        )
+
+        #expect(sample.canWriteToAppleHealth)
+        #expect(snapshot.hasVisibleData)
+        #expect(snapshot.menstrualFlowSample?.precision == .specified)
+        #expect(MenstruationStatus.active.displayName == "Aktuell")
+        #expect(!MenstruationStatus.active.canWriteMenstrualFlowSample)
+    }
+
+    @Test
     func painIntensityLevelUsesCentralBoundaryBuckets() {
         let expectations: [(Int, PainIntensityLevel, String, String?)] = [
             (0, .none, "Nicht bewertet", nil),

--- a/docs/Apple-Health-Datentypen.md
+++ b/docs/Apple-Health-Datentypen.md
@@ -11,7 +11,7 @@ Dieses Dokument beschreibt die Apple-Health-Datentypen, die Symi als schmerzrele
 | Herzwerte | Herzfrequenz | `HKQuantityTypeIdentifierHeartRate` | aktiv | Herzfrequenz rund um eine Episode kann körperlichen Stress als neutralen Kontext sichtbar machen. |
 | Herzwerte | Ruhepuls | `HKQuantityTypeIdentifierRestingHeartRate` | aktiv | Ruhepuls ergänzt den Tageskontext, ohne daraus eine medizinische Bewertung abzuleiten. |
 | Herzwerte | Herzfrequenzvariabilität | `HKQuantityTypeIdentifierHeartRateVariabilitySDNN` | aktiv | HRV kann Hinweise auf Stress und Erholung liefern und bleibt in Symi reine Kontextinformation. |
-| Zyklus | Menstruation | `HKCategoryTypeIdentifierMenstrualFlow` | aktiv | Zyklusdaten können bei migränebezogenen Mustern relevant sein. Der Typ wird erst ab iOS 18 abgefragt. |
+| Zyklus | Menstruation | `HKCategoryTypeIdentifierMenstrualFlow` | aktiv | Echte Health-Flow-Samples können bei migränebezogenen Mustern relevant sein. Der Typ wird erst ab iOS 18 abgefragt und als Kontext mit Quelle, Zeitraum und Genauigkeit gespeichert. |
 | Symptome | Kopfschmerz | `HKCategoryTypeIdentifierHeadache` | aktiv | Vorhandene Kopfschmerzsymptome aus Apple Health werden als externe Quelle kenntlich gemacht. |
 | Symptome | Übelkeit | `HKCategoryTypeIdentifierNausea` | aktiv | Übelkeit ist ein häufiges Begleitsymptom von Migräne. |
 | Symptome | Schwindel | `HKCategoryTypeIdentifierDizziness` | aktiv | Schwindel kann Episoden fachlich ergänzen, ohne Diagnose oder Interpretation. |
@@ -30,6 +30,8 @@ Dieses Dokument beschreibt die Apple-Health-Datentypen, die Symi als schmerzrele
 - Jeder Datentyp hat einen eigenen Schalter. Die Auswahl wird unabhängig von der iOS-Berechtigung gespeichert.
 - Die eigentliche HealthKit-Autorisierung wird erst über `Leserechte anfragen` oder `Schreibrechte anfragen` gestartet.
 - Gelesene Episodenkontexte werden in der UI und im PDF-Export als `Apple Health` mit Quelle ausgewiesen.
+- Zyklusdaten aus Apple Health überschreiben keine App-Angaben. Der App-Status unterscheidet nur `Nicht angegeben`, `Nein`, `Aktuell` und `Erwartet`; echte Flow-Samples bleiben davon getrennte Health-Kontextdaten.
+- App-Angaben wie `Aktuell` oder `Erwartet` sind nicht präzise genug für `HKCategoryTypeIdentifierMenstrualFlow` und werden deshalb nicht nach Apple Health geschrieben.
 
 ## Erweiterung
 


### PR DESCRIPTION
## Änderungen

- trennt grobe App-Zyklusangaben von echten Apple-Health-Flow-Samples
- speichert gelesene Menstruations-Flow-Samples mit Quelle, Zeitraum, Genauigkeit und User-Entered-Metadaten als Kontext
- verhindert, dass „aktuell“/„erwartet“ als exakte Health-Flow-Samples gelten
- ergänzt UI-, PDF- und Dokumentationstexte zur Quelle und Genauigkeit

## Tests

- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'`

Closes #104
