### PR TITLE
Send app logs to Sentry

### DIFF
--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -83,7 +83,7 @@ struct SymiApp: App {
         )
 
         let container = try makeContainer(schema: schema, configuration: configuration)
-        let appLogStore = AppLogStore()
+        let appLogStore = AppLogStore(remoteReporter: AppSentryLogReporter.shared)
         let healthContextStore = HealthContextStore()
         let syncCoordinator = SyncCoordinator(
             modelContainer: container,

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -83,7 +83,7 @@ struct SymiApp: App {
         )
 
         let container = try makeContainer(schema: schema, configuration: configuration)
-        let appLogStore = AppLogStore(remoteReporter: AppSentryLogReporter.shared)
+        let appLogStore = AppLogStore(remoteReporter: AppTelemetryGateway.sentryLogReporter)
         let healthContextStore = HealthContextStore()
         let syncCoordinator = SyncCoordinator(
             modelContainer: container,
@@ -376,6 +376,8 @@ private struct AppRootView: View {
 
 @MainActor
 enum AppTelemetryGateway {
+    static let sentryLogReporter = AppSentryLogReporter(client: SentrySDKLogClient())
+
     static func startSentry(dsn: String) {
         SentrySDK.start { options in
             options.dsn = dsn
@@ -399,11 +401,50 @@ enum AppTelemetryGateway {
         SentrySDK.close()
     }
 
+    static func setSentryLogReportingEnabled(_ enabled: Bool) {
+        sentryLogReporter.setEnabled(enabled)
+    }
+
     static func startTelemetryDeck(appID: String) {
         TelemetryDeck.initialize(config: .init(appID: appID))
     }
 
     static func stopTelemetryDeck() {
         TelemetryDeck.terminate()
+    }
+}
+
+private struct SentrySDKLogClient: AppSentryClient {
+    func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb) {
+        let sentryBreadcrumb = Breadcrumb(level: breadcrumb.level.sentryLevel, category: breadcrumb.category)
+        sentryBreadcrumb.message = breadcrumb.message
+        sentryBreadcrumb.type = "log"
+        sentryBreadcrumb.data = breadcrumb.data
+        SentrySDK.addBreadcrumb(sentryBreadcrumb)
+    }
+
+    func captureEvent(_ event: AppRemoteLogEvent) {
+        let sentryEvent = Event(level: event.level.sentryLevel)
+        sentryEvent.message = SentryMessage(formatted: event.message)
+        sentryEvent.logger = "Symi.AppLog"
+        sentryEvent.extra = event.extra
+        SentrySDK.capture(event: sentryEvent)
+    }
+}
+
+private extension AppRemoteLogLevel {
+    var sentryLevel: SentryLevel {
+        switch self {
+        case .debug:
+            .debug
+        case .info:
+            .info
+        case .warning:
+            .warning
+        case .error:
+            .error
+        case .fatal:
+            .fatal
+        }
     }
 }

--- a/Symi/Sources/Features/Export/SyncLogView.swift
+++ b/Symi/Sources/Features/Export/SyncLogView.swift
@@ -99,6 +99,8 @@ struct SyncLogView: View {
             "exclamationmark.triangle"
         case .error:
             "xmark.octagon"
+        case .critical:
+            "exclamationmark.octagon"
         }
     }
 
@@ -111,6 +113,8 @@ struct SyncLogView: View {
         case .warning:
             .orange
         case .error:
+            .red
+        case .critical:
             .red
         }
     }

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -170,10 +170,7 @@ struct HomeView: View {
     }
 
     private var homeState: HomeState {
-        let state = mapToHomeState(entryCount: entryCount)
-        print("Entry count:", entryCount)
-        print("Home state:", state)
-        return state
+        mapToHomeState(entryCount: entryCount)
     }
 
     private var entryCount: Int {

--- a/Symi/Sources/Shared/AppLogging.swift
+++ b/Symi/Sources/Shared/AppLogging.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Sentry
 
 public enum AppLogCategory: String, Codable, CaseIterable, Sendable {
     case sync
@@ -131,7 +130,7 @@ public actor AppLogStore {
         operation: String,
         message: String,
         metadata: [String: String] = [:]
-    ) {
+    ) async {
         let entry = AppLogEntry(
             category: category,
             level: level,
@@ -143,7 +142,7 @@ public actor AppLogStore {
         )
         entries.append(entry)
         pruneAndPersist()
-        remoteReporter?.record(entry)
+        await remoteReporter?.record(entry)
     }
 
     public func recentEntries(filter: AppLogFilter = .all, limit: Int = 200) -> [AppLogEntry] {
@@ -279,7 +278,7 @@ public actor AppLogStore {
 }
 
 public protocol AppLogRemoteReporting: Sendable {
-    nonisolated func record(_ entry: AppLogEntry)
+    func record(_ entry: AppLogEntry) async
 }
 
 public enum AppRemoteLogLevel: String, Equatable, Sendable {
@@ -304,31 +303,27 @@ public struct AppRemoteLogEvent: Equatable, Sendable {
 }
 
 public protocol AppSentryClient: Sendable {
-    nonisolated func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb)
-    nonisolated func captureEvent(_ event: AppRemoteLogEvent)
+    func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb) async
+    func captureEvent(_ event: AppRemoteLogEvent) async
 }
 
-public final class AppSentryLogReporter: AppLogRemoteReporting, @unchecked Sendable {
-    public nonisolated static let shared = AppSentryLogReporter(client: SentrySDKLogClient())
-
-    private let lock = NSLock()
+@MainActor
+public final class AppSentryLogReporter: AppLogRemoteReporting {
     private let client: AppSentryClient
     private let sanitizer: AppLogSanitizing
-    nonisolated(unsafe) private var isEnabled = false
+    private var isEnabled = false
 
-    public nonisolated init(client: AppSentryClient, sanitizer: AppLogSanitizing = AppLogSanitizer()) {
+    public init(client: AppSentryClient, sanitizer: AppLogSanitizing = AppLogSanitizer()) {
         self.client = client
         self.sanitizer = sanitizer
     }
 
-    public nonisolated func setEnabled(_ enabled: Bool) {
-        lock.withLock {
-            unsafe isEnabled = enabled
-        }
+    public func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
     }
 
-    public nonisolated func record(_ entry: AppLogEntry) {
-        guard lock.withLock({ unsafe isEnabled }) else {
+    public func record(_ entry: AppLogEntry) async {
+        guard isEnabled else {
             return
         }
 
@@ -340,13 +335,13 @@ public final class AppSentryLogReporter: AppLogRemoteReporting, @unchecked Senda
             message: sanitizedEntry.message,
             data: context
         )
-        client.addBreadcrumb(breadcrumb)
+        await client.addBreadcrumb(breadcrumb)
 
         guard sanitizedEntry.level.sendsSentryEvent else {
             return
         }
 
-        client.captureEvent(
+        await client.captureEvent(
             AppRemoteLogEvent(
                 level: sanitizedEntry.level.remoteLevel,
                 message: sanitizedEntry.message,
@@ -439,24 +434,6 @@ public struct AppLogSanitizer: AppLogSanitizing {
     }
 }
 
-private struct SentrySDKLogClient: AppSentryClient {
-    nonisolated func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb) {
-        let sentryBreadcrumb = Breadcrumb(level: breadcrumb.level.sentryLevel, category: breadcrumb.category)
-        sentryBreadcrumb.message = breadcrumb.message
-        sentryBreadcrumb.type = "log"
-        sentryBreadcrumb.data = breadcrumb.data
-        SentrySDK.addBreadcrumb(sentryBreadcrumb)
-    }
-
-    nonisolated func captureEvent(_ event: AppRemoteLogEvent) {
-        let sentryEvent = Event(level: event.level.sentryLevel)
-        sentryEvent.message = SentryMessage(formatted: event.message)
-        sentryEvent.logger = "Symi.AppLog"
-        sentryEvent.extra = event.extra
-        SentrySDK.capture(event: sentryEvent)
-    }
-}
-
 private extension AppLogLevel {
     nonisolated var remoteLevel: AppRemoteLogLevel {
         switch self {
@@ -475,22 +452,5 @@ private extension AppLogLevel {
 
     nonisolated var sendsSentryEvent: Bool {
         self == .error || self == .critical
-    }
-}
-
-private extension AppRemoteLogLevel {
-    nonisolated var sentryLevel: SentryLevel {
-        switch self {
-        case .debug:
-            .debug
-        case .info:
-            .info
-        case .warning:
-            .warning
-        case .error:
-            .error
-        case .fatal:
-            .fatal
-        }
     }
 }

--- a/Symi/Sources/Shared/AppLogging.swift
+++ b/Symi/Sources/Shared/AppLogging.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Sentry
 
 public enum AppLogCategory: String, Codable, CaseIterable, Sendable {
     case sync
@@ -10,6 +11,7 @@ public enum AppLogLevel: String, Codable, CaseIterable, Sendable {
     case info
     case warning
     case error
+    case critical
 }
 
 public enum AppLogFilter: String, Codable, CaseIterable, Sendable, Identifiable {
@@ -87,6 +89,7 @@ public actor AppLogStore {
     private let maxEntryCount: Int
     private let fileURL: URL
     private let snapshotDirectoryURL: URL
+    private let remoteReporter: AppLogRemoteReporting?
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     private var entries: [AppLogEntry]
@@ -95,10 +98,12 @@ public actor AppLogStore {
         fileManager: FileManager = .default,
         baseDirectoryURL: URL? = nil,
         retentionWindow: TimeInterval = 60 * 60 * 24 * 7,
-        maxEntryCount: Int = 3000
+        maxEntryCount: Int = 3000,
+        remoteReporter: AppLogRemoteReporting? = nil
     ) {
         self.retentionWindow = retentionWindow
         self.maxEntryCount = maxEntryCount
+        self.remoteReporter = remoteReporter
 
         let baseURL = baseDirectoryURL ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory
@@ -127,18 +132,18 @@ public actor AppLogStore {
         message: String,
         metadata: [String: String] = [:]
     ) {
-        entries.append(
-            AppLogEntry(
-                category: category,
-                level: level,
-                operation: operation,
-                message: message,
-                metadata: metadata.sorted { $0.key < $1.key }.reduce(into: [:]) { partialResult, item in
-                    partialResult[item.key] = item.value
-                }
-            )
+        let entry = AppLogEntry(
+            category: category,
+            level: level,
+            operation: operation,
+            message: message,
+            metadata: metadata.sorted { $0.key < $1.key }.reduce(into: [:]) { partialResult, item in
+                partialResult[item.key] = item.value
+            }
         )
+        entries.append(entry)
         pruneAndPersist()
+        remoteReporter?.record(entry)
     }
 
     public func recentEntries(filter: AppLogFilter = .all, limit: Int = 200) -> [AppLogEntry] {
@@ -197,7 +202,7 @@ public actor AppLogStore {
         case .all:
             entries
         case .errors:
-            entries.filter { $0.level == .error }
+            entries.filter { $0.level == .error || $0.level == .critical }
         case .sync:
             entries.filter { $0.category == .sync }
         }
@@ -269,6 +274,223 @@ public actor AppLogStore {
             }
         } catch {
             // Logging darf den App-Fluss nicht blockieren.
+        }
+    }
+}
+
+public protocol AppLogRemoteReporting: Sendable {
+    nonisolated func record(_ entry: AppLogEntry)
+}
+
+public enum AppRemoteLogLevel: String, Equatable, Sendable {
+    case debug
+    case info
+    case warning
+    case error
+    case fatal
+}
+
+public struct AppRemoteLogBreadcrumb: Equatable, Sendable {
+    public nonisolated let level: AppRemoteLogLevel
+    public nonisolated let category: String
+    public nonisolated let message: String
+    public nonisolated let data: [String: String]
+}
+
+public struct AppRemoteLogEvent: Equatable, Sendable {
+    public nonisolated let level: AppRemoteLogLevel
+    public nonisolated let message: String
+    public nonisolated let extra: [String: String]
+}
+
+public protocol AppSentryClient: Sendable {
+    nonisolated func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb)
+    nonisolated func captureEvent(_ event: AppRemoteLogEvent)
+}
+
+public final class AppSentryLogReporter: AppLogRemoteReporting, @unchecked Sendable {
+    public nonisolated static let shared = AppSentryLogReporter(client: SentrySDKLogClient())
+
+    private let lock = NSLock()
+    private let client: AppSentryClient
+    private let sanitizer: AppLogSanitizing
+    nonisolated(unsafe) private var isEnabled = false
+
+    public nonisolated init(client: AppSentryClient, sanitizer: AppLogSanitizing = AppLogSanitizer()) {
+        self.client = client
+        self.sanitizer = sanitizer
+    }
+
+    public nonisolated func setEnabled(_ enabled: Bool) {
+        lock.withLock {
+            unsafe isEnabled = enabled
+        }
+    }
+
+    public nonisolated func record(_ entry: AppLogEntry) {
+        guard lock.withLock({ unsafe isEnabled }) else {
+            return
+        }
+
+        let sanitizedEntry = sanitizer.sanitize(entry)
+        let context = Self.context(from: sanitizedEntry)
+        let breadcrumb = AppRemoteLogBreadcrumb(
+            level: sanitizedEntry.level.remoteLevel,
+            category: sanitizedEntry.category.rawValue,
+            message: sanitizedEntry.message,
+            data: context
+        )
+        client.addBreadcrumb(breadcrumb)
+
+        guard sanitizedEntry.level.sendsSentryEvent else {
+            return
+        }
+
+        client.captureEvent(
+            AppRemoteLogEvent(
+                level: sanitizedEntry.level.remoteLevel,
+                message: sanitizedEntry.message,
+                extra: context
+            )
+        )
+    }
+
+    private nonisolated static func context(from entry: AppLogEntry) -> [String: String] {
+        var context = entry.metadata
+        context["operation"] = entry.operation
+        context["category"] = entry.category.rawValue
+        context["level"] = entry.level.rawValue
+        return context
+    }
+}
+
+public protocol AppLogSanitizing: Sendable {
+    nonisolated func sanitize(_ entry: AppLogEntry) -> AppLogEntry
+}
+
+public struct AppLogSanitizer: AppLogSanitizing {
+    private nonisolated static let redactedValue = "[redacted]"
+    private nonisolated static let sensitiveKeyFragments = [
+        "address",
+        "birth",
+        "coordinate",
+        "diagnosis",
+        "dose",
+        "email",
+        "health",
+        "latitude",
+        "location",
+        "longitude",
+        "medication",
+        "medicine",
+        "name",
+        "note",
+        "patient",
+        "phone",
+        "postal",
+        "trigger",
+        "weather"
+    ]
+
+    public nonisolated init() {}
+
+    public nonisolated func sanitize(_ entry: AppLogEntry) -> AppLogEntry {
+        AppLogEntry(
+            id: entry.id,
+            timestamp: entry.timestamp,
+            category: entry.category,
+            level: entry.level,
+            operation: sanitizedText(entry.operation),
+            message: sanitizedText(entry.message),
+            metadata: entry.metadata.reduce(into: [:]) { partialResult, item in
+                partialResult[sanitizedText(item.key)] = sanitizedValue(item.value, forKey: item.key)
+            }
+        )
+    }
+
+    private nonisolated func sanitizedValue(_ value: String, forKey key: String) -> String {
+        guard !isSensitiveKey(key) else {
+            return Self.redactedValue
+        }
+
+        return sanitizedText(value)
+    }
+
+    private nonisolated func isSensitiveKey(_ key: String) -> Bool {
+        let normalizedKey = key.lowercased()
+        return Self.sensitiveKeyFragments.contains { normalizedKey.contains($0) }
+    }
+
+    private nonisolated func sanitizedText(_ text: String) -> String {
+        var sanitized = text
+        sanitized = sanitized.replacing(
+            #/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/#,
+            with: Self.redactedValue
+        )
+        sanitized = sanitized.replacing(
+            #/\b(?:\+?\d[\d\s().-]{6,}\d)\b/#,
+            with: Self.redactedValue
+        )
+        sanitized = sanitized.replacing(
+            #/\b(?:patient|patientin|medikament|medikation|trigger|notiz|standort|adresse|koordinate|diagnose)\b[^.,;\n]*/#.ignoresCase(),
+            with: Self.redactedValue
+        )
+        return sanitized
+    }
+}
+
+private struct SentrySDKLogClient: AppSentryClient {
+    nonisolated func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb) {
+        let sentryBreadcrumb = Breadcrumb(level: breadcrumb.level.sentryLevel, category: breadcrumb.category)
+        sentryBreadcrumb.message = breadcrumb.message
+        sentryBreadcrumb.type = "log"
+        sentryBreadcrumb.data = breadcrumb.data
+        SentrySDK.addBreadcrumb(sentryBreadcrumb)
+    }
+
+    nonisolated func captureEvent(_ event: AppRemoteLogEvent) {
+        let sentryEvent = Event(level: event.level.sentryLevel)
+        sentryEvent.message = SentryMessage(formatted: event.message)
+        sentryEvent.logger = "Symi.AppLog"
+        sentryEvent.extra = event.extra
+        SentrySDK.capture(event: sentryEvent)
+    }
+}
+
+private extension AppLogLevel {
+    nonisolated var remoteLevel: AppRemoteLogLevel {
+        switch self {
+        case .debug:
+            .debug
+        case .info:
+            .info
+        case .warning:
+            .warning
+        case .error:
+            .error
+        case .critical:
+            .fatal
+        }
+    }
+
+    nonisolated var sendsSentryEvent: Bool {
+        self == .error || self == .critical
+    }
+}
+
+private extension AppRemoteLogLevel {
+    nonisolated var sentryLevel: SentryLevel {
+        switch self {
+        case .debug:
+            .debug
+        case .info:
+            .info
+        case .warning:
+            .warning
+        case .error:
+            .error
+        case .fatal:
+            .fatal
         }
     }
 }

--- a/Symi/Sources/Shared/UsageDataConsent.swift
+++ b/Symi/Sources/Shared/UsageDataConsent.swift
@@ -96,6 +96,7 @@ final class AppTelemetryService: UsageDataConsentService {
 
         if !isSentryStarted, let sentryDSN = Self.sentryDSN {
             AppTelemetryGateway.startSentry(dsn: sentryDSN)
+            AppSentryLogReporter.shared.setEnabled(true)
             isSentryStarted = true
         } else if Self.sentryDSN == nil {
             Self.logger.notice("Sentry ist deaktiviert, weil keine gültige DSN in der App-Konfiguration gefunden wurde.")
@@ -109,6 +110,7 @@ final class AppTelemetryService: UsageDataConsentService {
 
     private func stopTelemetry() {
         if isSentryStarted {
+            AppSentryLogReporter.shared.setEnabled(false)
             AppTelemetryGateway.stopSentry()
             isSentryStarted = false
         }

--- a/Symi/Sources/Shared/UsageDataConsent.swift
+++ b/Symi/Sources/Shared/UsageDataConsent.swift
@@ -96,7 +96,7 @@ final class AppTelemetryService: UsageDataConsentService {
 
         if !isSentryStarted, let sentryDSN = Self.sentryDSN {
             AppTelemetryGateway.startSentry(dsn: sentryDSN)
-            AppSentryLogReporter.shared.setEnabled(true)
+            AppTelemetryGateway.setSentryLogReportingEnabled(true)
             isSentryStarted = true
         } else if Self.sentryDSN == nil {
             Self.logger.notice("Sentry ist deaktiviert, weil keine gültige DSN in der App-Konfiguration gefunden wurde.")
@@ -110,7 +110,7 @@ final class AppTelemetryService: UsageDataConsentService {
 
     private func stopTelemetry() {
         if isSentryStarted {
-            AppSentryLogReporter.shared.setEnabled(false)
+            AppTelemetryGateway.setSentryLogReportingEnabled(false)
             AppTelemetryGateway.stopSentry()
             isSentryStarted = false
         }

--- a/SymiTests/AppLogStoreTests.swift
+++ b/SymiTests/AppLogStoreTests.swift
@@ -58,11 +58,125 @@ struct AppLogStoreTests {
         let store = AppLogStore(fileManager: .default, baseDirectoryURL: directory, retentionWindow: 60 * 60 * 24 * 7, maxEntryCount: 10)
         await store.log(level: .info, category: .sync, operation: "sync.info", message: "Info")
         await store.log(level: .error, category: .sync, operation: "sync.error", message: "Fehler")
+        await store.log(level: .critical, category: .sync, operation: "sync.critical", message: "Kritisch")
 
         let entries = await store.recentEntries(filter: .errors)
 
-        #expect(entries.count == 1)
-        #expect(entries.first?.level == .error)
+        #expect(entries.count == 2)
+        #expect(entries.contains { $0.level == .error })
+        #expect(entries.contains { $0.level == .critical })
+    }
+
+    @Test
+    func sentryReporterCreatesBreadcrumbForInfoLog() async throws {
+        let client = CapturingSentryClient()
+        let reporter = AppSentryLogReporter(client: client)
+        reporter.setEnabled(true)
+        let store = AppLogStore(
+            fileManager: .default,
+            baseDirectoryURL: try makeTemporaryDirectory(),
+            retentionWindow: 60 * 60 * 24 * 7,
+            maxEntryCount: 10,
+            remoteReporter: reporter
+        )
+
+        await store.log(level: .info, category: .sync, operation: "sync.info", message: "Info", metadata: ["count": "1"])
+
+        #expect(client.breadcrumbs.count == 1)
+        #expect(client.events.isEmpty)
+        #expect(client.breadcrumbs.first?.level == .info)
+        #expect(client.breadcrumbs.first?.category == "sync")
+        #expect(client.breadcrumbs.first?.data["operation"] == "sync.info")
+    }
+
+    @Test
+    func sentryReporterCreatesEventForErrorLog() async throws {
+        let client = CapturingSentryClient()
+        let reporter = AppSentryLogReporter(client: client)
+        reporter.setEnabled(true)
+        let store = AppLogStore(
+            fileManager: .default,
+            baseDirectoryURL: try makeTemporaryDirectory(),
+            retentionWindow: 60 * 60 * 24 * 7,
+            maxEntryCount: 10,
+            remoteReporter: reporter
+        )
+
+        await store.log(level: .error, category: .sync, operation: "sync.error", message: "Fehler")
+
+        #expect(client.breadcrumbs.count == 1)
+        #expect(client.events.count == 1)
+        #expect(client.events.first?.level == .error)
+        #expect(client.events.first?.message == "Fehler")
+    }
+
+    @Test
+    func sentryReporterMapsCriticalLogsToFatalEvents() async throws {
+        let client = CapturingSentryClient()
+        let reporter = AppSentryLogReporter(client: client)
+        reporter.setEnabled(true)
+        let store = AppLogStore(
+            fileManager: .default,
+            baseDirectoryURL: try makeTemporaryDirectory(),
+            retentionWindow: 60 * 60 * 24 * 7,
+            maxEntryCount: 10,
+            remoteReporter: reporter
+        )
+
+        await store.log(level: .critical, category: .app, operation: "startup.failure", message: "Start fehlgeschlagen")
+
+        #expect(client.breadcrumbs.first?.level == .fatal)
+        #expect(client.events.first?.level == .fatal)
+    }
+
+    @Test
+    func sentryReporterRedactsSensitiveMetadataAndText() async throws {
+        let client = CapturingSentryClient()
+        let reporter = AppSentryLogReporter(client: client)
+        reporter.setEnabled(true)
+        let store = AppLogStore(
+            fileManager: .default,
+            baseDirectoryURL: try makeTemporaryDirectory(),
+            retentionWindow: 60 * 60 * 24 * 7,
+            maxEntryCount: 10,
+            remoteReporter: reporter
+        )
+
+        await store.log(
+            level: .error,
+            category: .app,
+            operation: "support.contact",
+            message: "Kontakt test@example.com wegen Medikament Aspirin",
+            metadata: [
+                "medicationName": "Aspirin",
+                "note": "starke Schmerzen",
+                "safeCount": "3"
+            ]
+        )
+
+        let event = try #require(client.events.first)
+        #expect(event.message == "Kontakt [redacted] wegen [redacted]")
+        #expect(event.extra["medicationName"] == "[redacted]")
+        #expect(event.extra["note"] == "[redacted]")
+        #expect(event.extra["safeCount"] == "3")
+    }
+
+    @Test
+    func sentryReporterDoesNothingWhenDisabled() async throws {
+        let client = CapturingSentryClient()
+        let reporter = AppSentryLogReporter(client: client)
+        let store = AppLogStore(
+            fileManager: .default,
+            baseDirectoryURL: try makeTemporaryDirectory(),
+            retentionWindow: 60 * 60 * 24 * 7,
+            maxEntryCount: 10,
+            remoteReporter: reporter
+        )
+
+        await store.log(level: .error, category: .sync, operation: "sync.error", message: "Fehler")
+
+        #expect(client.breadcrumbs.isEmpty)
+        #expect(client.events.isEmpty)
     }
 }
 
@@ -70,4 +184,30 @@ private func makeTemporaryDirectory() throws -> URL {
     let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     return directory
+}
+
+private final class CapturingSentryClient: AppSentryClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var capturedBreadcrumbs: [AppRemoteLogBreadcrumb] = []
+    private var capturedEvents: [AppRemoteLogEvent] = []
+
+    var breadcrumbs: [AppRemoteLogBreadcrumb] {
+        lock.withLock { capturedBreadcrumbs }
+    }
+
+    var events: [AppRemoteLogEvent] {
+        lock.withLock { capturedEvents }
+    }
+
+    func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb) {
+        lock.withLock {
+            capturedBreadcrumbs.append(breadcrumb)
+        }
+    }
+
+    func captureEvent(_ event: AppRemoteLogEvent) {
+        lock.withLock {
+            capturedEvents.append(event)
+        }
+    }
 }

--- a/SymiTests/AppLogStoreTests.swift
+++ b/SymiTests/AppLogStoreTests.swift
@@ -70,8 +70,8 @@ struct AppLogStoreTests {
     @Test
     func sentryReporterCreatesBreadcrumbForInfoLog() async throws {
         let client = CapturingSentryClient()
-        let reporter = AppSentryLogReporter(client: client)
-        reporter.setEnabled(true)
+        let reporter = await AppSentryLogReporter(client: client)
+        await reporter.setEnabled(true)
         let store = AppLogStore(
             fileManager: .default,
             baseDirectoryURL: try makeTemporaryDirectory(),
@@ -82,18 +82,20 @@ struct AppLogStoreTests {
 
         await store.log(level: .info, category: .sync, operation: "sync.info", message: "Info", metadata: ["count": "1"])
 
-        #expect(client.breadcrumbs.count == 1)
-        #expect(client.events.isEmpty)
-        #expect(client.breadcrumbs.first?.level == .info)
-        #expect(client.breadcrumbs.first?.category == "sync")
-        #expect(client.breadcrumbs.first?.data["operation"] == "sync.info")
+        let breadcrumbs = await client.breadcrumbs
+        let events = await client.events
+        #expect(breadcrumbs.count == 1)
+        #expect(events.isEmpty)
+        #expect(breadcrumbs.first?.level == .info)
+        #expect(breadcrumbs.first?.category == "sync")
+        #expect(breadcrumbs.first?.data["operation"] == "sync.info")
     }
 
     @Test
     func sentryReporterCreatesEventForErrorLog() async throws {
         let client = CapturingSentryClient()
-        let reporter = AppSentryLogReporter(client: client)
-        reporter.setEnabled(true)
+        let reporter = await AppSentryLogReporter(client: client)
+        await reporter.setEnabled(true)
         let store = AppLogStore(
             fileManager: .default,
             baseDirectoryURL: try makeTemporaryDirectory(),
@@ -104,17 +106,19 @@ struct AppLogStoreTests {
 
         await store.log(level: .error, category: .sync, operation: "sync.error", message: "Fehler")
 
-        #expect(client.breadcrumbs.count == 1)
-        #expect(client.events.count == 1)
-        #expect(client.events.first?.level == .error)
-        #expect(client.events.first?.message == "Fehler")
+        let breadcrumbs = await client.breadcrumbs
+        let events = await client.events
+        #expect(breadcrumbs.count == 1)
+        #expect(events.count == 1)
+        #expect(events.first?.level == .error)
+        #expect(events.first?.message == "Fehler")
     }
 
     @Test
     func sentryReporterMapsCriticalLogsToFatalEvents() async throws {
         let client = CapturingSentryClient()
-        let reporter = AppSentryLogReporter(client: client)
-        reporter.setEnabled(true)
+        let reporter = await AppSentryLogReporter(client: client)
+        await reporter.setEnabled(true)
         let store = AppLogStore(
             fileManager: .default,
             baseDirectoryURL: try makeTemporaryDirectory(),
@@ -125,15 +129,17 @@ struct AppLogStoreTests {
 
         await store.log(level: .critical, category: .app, operation: "startup.failure", message: "Start fehlgeschlagen")
 
-        #expect(client.breadcrumbs.first?.level == .fatal)
-        #expect(client.events.first?.level == .fatal)
+        let breadcrumbs = await client.breadcrumbs
+        let events = await client.events
+        #expect(breadcrumbs.first?.level == .fatal)
+        #expect(events.first?.level == .fatal)
     }
 
     @Test
     func sentryReporterRedactsSensitiveMetadataAndText() async throws {
         let client = CapturingSentryClient()
-        let reporter = AppSentryLogReporter(client: client)
-        reporter.setEnabled(true)
+        let reporter = await AppSentryLogReporter(client: client)
+        await reporter.setEnabled(true)
         let store = AppLogStore(
             fileManager: .default,
             baseDirectoryURL: try makeTemporaryDirectory(),
@@ -154,7 +160,7 @@ struct AppLogStoreTests {
             ]
         )
 
-        let event = try #require(client.events.first)
+        let event = try #require((await client.events).first)
         #expect(event.message == "Kontakt [redacted] wegen [redacted]")
         #expect(event.extra["medicationName"] == "[redacted]")
         #expect(event.extra["note"] == "[redacted]")
@@ -164,7 +170,7 @@ struct AppLogStoreTests {
     @Test
     func sentryReporterDoesNothingWhenDisabled() async throws {
         let client = CapturingSentryClient()
-        let reporter = AppSentryLogReporter(client: client)
+        let reporter = await AppSentryLogReporter(client: client)
         let store = AppLogStore(
             fileManager: .default,
             baseDirectoryURL: try makeTemporaryDirectory(),
@@ -175,8 +181,10 @@ struct AppLogStoreTests {
 
         await store.log(level: .error, category: .sync, operation: "sync.error", message: "Fehler")
 
-        #expect(client.breadcrumbs.isEmpty)
-        #expect(client.events.isEmpty)
+        let breadcrumbs = await client.breadcrumbs
+        let events = await client.events
+        #expect(breadcrumbs.isEmpty)
+        #expect(events.isEmpty)
     }
 }
 
@@ -186,28 +194,23 @@ private func makeTemporaryDirectory() throws -> URL {
     return directory
 }
 
-private final class CapturingSentryClient: AppSentryClient, @unchecked Sendable {
-    private let lock = NSLock()
+private actor CapturingSentryClient: AppSentryClient {
     private var capturedBreadcrumbs: [AppRemoteLogBreadcrumb] = []
     private var capturedEvents: [AppRemoteLogEvent] = []
 
     var breadcrumbs: [AppRemoteLogBreadcrumb] {
-        lock.withLock { capturedBreadcrumbs }
+        capturedBreadcrumbs
     }
 
     var events: [AppRemoteLogEvent] {
-        lock.withLock { capturedEvents }
+        capturedEvents
     }
 
     func addBreadcrumb(_ breadcrumb: AppRemoteLogBreadcrumb) {
-        lock.withLock {
-            capturedBreadcrumbs.append(breadcrumb)
-        }
+        capturedBreadcrumbs.append(breadcrumb)
     }
 
     func captureEvent(_ event: AppRemoteLogEvent) {
-        lock.withLock {
-            capturedEvents.append(event)
-        }
+        capturedEvents.append(event)
     }
 }

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -1,0 +1,29 @@
+# Logging
+
+Symi schreibt App-Logs über `AppLogStore`. Neue Log-Aufrufe sollen nicht direkt über `print`, `NSLog` oder Sentry laufen, sondern über die zentrale Schnittstelle:
+
+```swift
+await appLogStore.log(
+    level: .info,
+    category: .sync,
+    operation: "provider.fetch.finish",
+    message: "CloudKit-Änderungen wurden geladen.",
+    metadata: ["recordCount": "\(count)"]
+)
+```
+
+## Level
+
+- `debug`: technische Detailinformationen ohne Nutzdaten
+- `info`: erwartete App- und Sync-Ereignisse
+- `warning`: unerwartete, aber abgefangene Zustände
+- `error`: fehlgeschlagene Operationen
+- `critical`: App-kritische Fehler, die sofortige Analyse brauchen
+
+Normale Logs werden als Sentry-Breadcrumbs weitergegeben. `error` und `critical` werden zusätzlich als Sentry-Events erfasst. Die Weitergabe an Sentry ist erst aktiv, nachdem die Nutzerin oder der Nutzer der Nutzungsdaten-Erfassung zugestimmt hat und Sentry mit gültiger DSN gestartet wurde.
+
+## Datenschutz
+
+Metadaten und Nachrichten werden vor der Sentry-Weitergabe sanitizt. Schlüssel mit sensiblen Fragmenten wie `note`, `medication`, `trigger`, `location`, `patient`, `health`, `weather` oder Kontakt-/Standortbezug werden redigiert. Freitext mit E-Mail-Adressen, Telefonnummern oder Begriffen wie Medikament, Notiz, Trigger, Standort, Adresse, Koordinate oder Diagnose wird ebenfalls redigiert.
+
+Trotz Sanitizing sollen Log-Aufrufe keine Gesundheitsdaten, Freitextnotizen, Medikamente, Trigger, Standortdaten oder personenbezogene Inhalte übergeben. Verwende stattdessen technische Zähler, Operationen, Statuswerte und abstrakte Fehlerklassen.


### PR DESCRIPTION
## Zusammenfassung

- zentrale Logging-Abstraktion um mockbaren Sentry-Reporter erweitert
- Sentry-Breadcrumbs für normale Logs und Events für Error/Critical-Logs ergänzt
- Sanitizing/Redaction für sensible Nachrichten und Metadaten dokumentiert und getestet
- direkte Home-Debug-prints entfernt

## Datenschutz / Opt-In

Sentry-Weitergabe ist standardmäßig deaktiviert und wird erst nach aktivierter Nutzungsdaten-Erfassung sowie gültiger Sentry-DSN über `AppTelemetryService` eingeschaltet.

## Tests

- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=macOS,arch=arm64,variant=Mac Catalyst'`

Closes #285
