### PR TITLE
[codex] Improve CloudKit sync reliability

### DIFF
--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -2450,15 +2450,8 @@
         }
       }
     },
-    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst. Sync läuft halbautomatisch: Aktivierung startet einen Abgleich, danach nutzt du `Jetzt synchronisieren`." : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trash entries remain local and in the cloud until you intentionally restore them or permanently delete them later. Sync is semi-automatic: enabling it starts a sync, then you use `Sync Now`."
-          }
-        }
-      }
+    "Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst. Bei aktiviertem Cloud-Sync läuft der Abgleich automatisch; „Jetzt synchronisieren“ startet zusätzlich sofort einen Lauf." : {
+
     },
     "Paracetamol" : {
       "localizations" : {

--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -4,6 +4,9 @@
     "" : {
       "shouldTranslate" : false
     },
+    "(empfohlen, wenn du mehrere Geräte nutzt)" : {
+
+    },
     "/10" : {
       "localizations" : {
         "en" : {
@@ -301,6 +304,7 @@
       }
     },
     "Abweichende Felder: %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -760,6 +764,9 @@
         }
       }
     },
+    "Bitte wähle, welche Version du behalten möchtest." : {
+
+    },
     "Cloud hat recht" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -790,9 +797,6 @@
           }
         }
       }
-    },
-    "Cloud-Version übernehmen" : {
-
     },
     "Das Projekt steht unter der GNU GPL v3." : {
       "localizations" : {
@@ -975,6 +979,7 @@
       }
     },
     "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1435,6 +1440,7 @@
       }
     },
     "Episode" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1463,6 +1469,9 @@
           }
         }
       }
+    },
+    "Es gibt unterschiedliche Änderungen für diesen Eintrag." : {
+
     },
     "Export nur mit deiner Aktion" : {
       "localizations" : {
@@ -2056,10 +2065,8 @@
         }
       }
     },
-    "Lokale Version behalten" : {
-
-    },
     "Lokaler Stand und Cloud-Stand unterscheiden sich." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2188,6 +2195,9 @@
           }
         }
       }
+    },
+    "Meine Version behalten" : {
+
     },
     "Menstruationsstatus" : {
       "localizations" : {
@@ -3218,6 +3228,9 @@
         }
       }
     },
+    "Version aus der Cloud verwenden" : {
+
+    },
     "Verstanden" : {
       "localizations" : {
         "en" : {
@@ -3357,6 +3370,9 @@
           }
         }
       }
+    },
+    "Wenn zwei Geräte denselben Eintrag unterschiedlich geändert haben, entscheidest du hier, welche Version bleiben soll." : {
+
     },
     "Wetter" : {
       "localizations" : {

--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -188,6 +188,26 @@
         }
       }
     },
+    "%lld Konflikt%@ warten auf deine Entscheidung." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld Konflikt%2$@ warten auf deine Entscheidung."
+          }
+        }
+      }
+    },
+    "%lld Sync-Konflikt%@ entscheiden" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld Sync-Konflikt%2$@ entscheiden"
+          }
+        }
+      }
+    },
     "%lld von 10" : {
       "localizations" : {
         "en" : {
@@ -741,6 +761,7 @@
       }
     },
     "Cloud hat recht" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -769,6 +790,9 @@
           }
         }
       }
+    },
+    "Cloud-Version übernehmen" : {
+
     },
     "Das Projekt steht unter der GNU GPL v3." : {
       "localizations" : {
@@ -1851,6 +1875,7 @@
       }
     },
     "Konflikt lösen" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2001,6 +2026,7 @@
       }
     },
     "Lokal hat recht" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2029,6 +2055,9 @@
           }
         }
       }
+    },
+    "Lokale Version behalten" : {
+
     },
     "Lokaler Stand und Cloud-Stand unterscheiden sich." : {
       "localizations" : {

--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -6,6 +6,7 @@ final class AppContainer {
     let featureDependencies: AppFeatureDependencies
 
     private let startupMaintenanceService: StartupMaintenanceService
+    private let syncCoordinator: SyncCoordinator
 
     init(
         modelContainer: ModelContainer,
@@ -17,6 +18,7 @@ final class AppContainer {
         healthContextStore: HealthContextStore = HealthContextStore(),
         usageDataConsentService: UsageDataConsentService = AppTelemetryService.shared
     ) {
+        self.syncCoordinator = syncCoordinator
         let episodeWeatherContextService = EpisodeWeatherContextService(
             weatherService: weatherService,
             locationService: locationService
@@ -125,6 +127,10 @@ final class AppContainer {
 
     func startDeferredMaintenanceIfNeeded() {
         startupMaintenanceService.startIfNeeded()
+    }
+
+    func appDidBecomeActive() {
+        syncCoordinator.appDidBecomeActive()
     }
 }
 

--- a/Symi/Sources/App/AppShellView.swift
+++ b/Symi/Sources/App/AppShellView.swift
@@ -32,6 +32,7 @@ struct AppShellView: View {
     private var features: AppFeatureDependencies { appContainer.featureDependencies }
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.scenePhase) private var scenePhase
     @State private var selectedTab: Tab = .journal
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
 
@@ -48,6 +49,13 @@ struct AppShellView: View {
         .toolbarColorScheme(.dark, for: .navigationBar)
         .task {
             appContainer.startDeferredMaintenanceIfNeeded()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active else {
+                return
+            }
+
+            appContainer.appDidBecomeActive()
         }
     }
 

--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -96,7 +96,8 @@ enum ScreenshotBootstrap {
         let syncCoordinator = SyncCoordinator(
             modelContainer: container,
             appLogStore: appLogStore,
-            healthContextStore: healthContextStore
+            healthContextStore: healthContextStore,
+            autostart: false
         )
         let appContainer = AppContainer(
             modelContainer: container,

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -696,7 +696,7 @@ private struct ManageCloudDataView: View {
                 statusRow("Sync", controller.isSyncEnabled ? "Aktiviert" : "Deaktiviert")
                 statusRow("Letzter Upload", formatted(controller.syncStatus.lastUploadedAt))
                 statusRow("Letzter Download", formatted(controller.syncStatus.lastDownloadedAt))
-                statusRow("Ungesyncte Records", "\(controller.syncStatus.unsyncedRecords)")
+                statusRow("Nicht synchronisiert", "\(controller.syncStatus.unsyncedRecords)")
                 statusRow("Offene Konflikte", "\(controller.conflicts.count)")
                 statusRow("Papierkorb", "\(controller.summary.trashCount)")
 
@@ -739,7 +739,7 @@ private struct ManageCloudDataView: View {
                 if !controller.isSyncEnabled {
                     Text("Aktiviere den Sync, um iCloud-Synchronisation und Konfliktbehandlung zu verwenden.")
                 } else {
-                    Text("Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht.")
+                    Text("Wenn zwei Geräte denselben Eintrag unterschiedlich geändert haben, entscheidest du hier, welche Version bleiben soll.")
                 }
             }
 
@@ -755,32 +755,43 @@ private struct ManageCloudDataView: View {
                         .brandGroupedRow()
 
                     ForEach(controller.conflicts) { conflict in
+                        let differences = ConflictDiffPresenter.differences(for: conflict)
+
                         VStack(alignment: .leading, spacing: SymiSpacing.xs) {
-                            Text(conflictTitle(for: conflict))
+                            Text(ConflictDiffPresenter.title(for: conflict))
                                 .font(.headline)
-                            Text("Lokaler Stand und Cloud-Stand unterscheiden sich.")
+                            Text("Es gibt unterschiedliche Änderungen für diesen Eintrag.")
                                 .font(.subheadline)
-                            Text(versionSummary("Lokal", envelope: conflict.local))
+
+                            Text("Bitte wähle, welche Version du behalten möchtest.")
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(versionSummary("Cloud", envelope: conflict.remote))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text("Abweichende Felder: \(conflict.conflictingFields.joined(separator: ", "))")
-                                .font(.subheadline)
                                 .foregroundStyle(.secondary)
 
+                            VStack(alignment: .leading, spacing: SymiSpacing.xs) {
+                                ForEach(differences) { difference in
+                                    ConflictDifferenceRow(difference: difference)
+                                }
+                            }
+                            .padding(.top, SymiSpacing.xxs)
+
                             HStack(spacing: SymiSpacing.sm) {
-                                Button("Lokale Version behalten") {
+                                Button("Meine Version behalten") {
                                     resolveConflict(conflict, preferLocal: true)
                                 }
                                 .buttonStyle(.bordered)
 
-                                Button("Cloud-Version übernehmen") {
-                                    resolveConflict(conflict, preferLocal: false)
+                                VStack(alignment: .leading, spacing: SymiSpacing.micro) {
+                                    Button("Version aus der Cloud verwenden") {
+                                        resolveConflict(conflict, preferLocal: false)
+                                    }
+                                    .buttonStyle(.borderedProminent)
+
+                                    Text("(empfohlen, wenn du mehrere Geräte nutzt)")
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
                                 }
-                                .buttonStyle(.borderedProminent)
                             }
+                            .padding(.top, SymiSpacing.xxs)
                             .disabled(isResolvingConflict)
                         }
                         .padding(.vertical, SymiSpacing.xxs)
@@ -841,16 +852,13 @@ private struct ManageCloudDataView: View {
         .refreshable {
             controller.load()
         }
-    }
-
-    private func conflictTitle(for conflict: SyncConflict) -> String {
-        switch conflict.entityType {
-        case .episode:
-            "Episode"
-        case .medicationDefinition:
-            "Medikamentenvorlage"
-        case .continuousMedication:
-            "Dauermedikation"
+        .task {
+            await resolveIdenticalConflictsIfNeeded()
+        }
+        .onChange(of: controller.conflicts.map(\.id)) { _, _ in
+            Task {
+                await resolveIdenticalConflictsIfNeeded()
+            }
         }
     }
 
@@ -869,11 +877,6 @@ private struct ManageCloudDataView: View {
         }
 
         return date.formatted(date: .numeric, time: .shortened)
-    }
-
-    private func versionSummary(_ title: String, envelope: SyncDocumentEnvelope) -> String {
-        let deletedSuffix = envelope.deletedAt == nil ? "" : " · gelöscht"
-        return "\(title): geändert \(formatted(envelope.modifiedAt))\(deletedSuffix)"
     }
 
     private var syncStalenessWarning: String? {
@@ -898,6 +901,262 @@ private struct ManageCloudDataView: View {
                 isResolvingConflict = false
             }
         }
+    }
+
+    private func resolveIdenticalConflictsIfNeeded() async {
+        let identicalConflicts = controller.conflicts.filter {
+            ConflictDiffPresenter.differences(for: $0).isEmpty
+        }
+
+        guard !identicalConflicts.isEmpty else {
+            return
+        }
+
+        for conflict in identicalConflicts {
+            await controller.resolveConflictUsingRemote(conflict)
+        }
+        controller.load()
+    }
+}
+
+private struct ConflictDifferenceRow: View {
+    let difference: ConflictDisplayDifference
+    private let cloudValueColor = Color(red: 15 / 255, green: 61 / 255, blue: 62 / 255)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.micro) {
+            Text(difference.label)
+                .font(.subheadline.weight(.semibold))
+
+            HStack(alignment: .firstTextBaseline, spacing: SymiSpacing.xs) {
+                Text(difference.myValue)
+                    .foregroundStyle(.secondary)
+                Image(systemName: "arrow.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(difference.cloudValue)
+                    .foregroundStyle(cloudValueColor)
+            }
+            .font(.subheadline)
+            .textSelection(.enabled)
+        }
+    }
+}
+
+private struct ConflictDisplayDifference: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let myValue: String
+    let cloudValue: String
+}
+
+private enum ConflictDiffPresenter {
+    static func title(for conflict: SyncConflict) -> String {
+        switch conflict.local.payload {
+        case .episode(let payload):
+            return "Eintrag vom \(dateOnly(payload.startedAt))"
+        case .medicationDefinition(let payload):
+            return payload.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Medikament" : payload.name
+        case .continuousMedication(let payload):
+            return payload.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Dauermedikation" : payload.name
+        }
+    }
+
+    static func differences(for conflict: SyncConflict) -> [ConflictDisplayDifference] {
+        var differences: [ConflictDisplayDifference] = []
+        appendDifference(
+            id: "deletedAt",
+            label: "Status",
+            myValue: conflict.local.deletedAt == nil ? "Vorhanden" : "Entfernt",
+            cloudValue: conflict.remote.deletedAt == nil ? "Vorhanden" : "Entfernt",
+            to: &differences
+        )
+
+        switch (conflict.local.payload, conflict.remote.payload) {
+        case (.episode(let local), .episode(let remote)):
+            appendEpisodeDifferences(local: local, remote: remote, to: &differences)
+        case (.medicationDefinition(let local), .medicationDefinition(let remote)):
+            appendMedicationDefinitionDifferences(local: local, remote: remote, to: &differences)
+        case (.continuousMedication(let local), .continuousMedication(let remote)):
+            appendContinuousMedicationDifferences(local: local, remote: remote, to: &differences)
+        default:
+            appendDifference(id: "kind", label: "Art des Eintrags", myValue: "Eintrag", cloudValue: "Andere Art von Eintrag", to: &differences)
+        }
+
+        return differences
+    }
+
+    private static func appendEpisodeDifferences(
+        local: SyncEpisodePayload,
+        remote: SyncEpisodePayload,
+        to differences: inout [ConflictDisplayDifference]
+    ) {
+        appendDifference(id: "startedAt", label: "Beginn", myValue: dateAndTime(local.startedAt), cloudValue: dateAndTime(remote.startedAt), to: &differences)
+        appendDifference(id: "endedAt", label: "Ende", myValue: optionalDateAndTime(local.endedAt), cloudValue: optionalDateAndTime(remote.endedAt), to: &differences)
+        appendDifference(id: "type", label: "Art des Eintrags", myValue: episodeType(local.type), cloudValue: episodeType(remote.type), to: &differences)
+        appendDifference(id: "intensity", label: "Schmerzstärke", myValue: intensity(local.intensity), cloudValue: intensity(remote.intensity), to: &differences)
+        appendDifference(id: "painLocation", label: "Schmerzort", myValue: text(local.painLocation), cloudValue: text(remote.painLocation), to: &differences)
+        appendDifference(id: "painCharacter", label: "Schmerzart", myValue: text(local.painCharacter), cloudValue: text(remote.painCharacter), to: &differences)
+        appendDifference(id: "notes", label: "Notiz", myValue: text(local.notes), cloudValue: text(remote.notes), to: &differences)
+        appendDifference(id: "symptoms", label: "Symptome", myValue: list(local.symptoms), cloudValue: list(remote.symptoms), to: &differences)
+        appendDifference(id: "triggers", label: "Auslöser", myValue: list(local.triggers), cloudValue: list(remote.triggers), to: &differences)
+        appendDifference(id: "functionalImpact", label: "Auswirkung im Alltag", myValue: text(local.functionalImpact), cloudValue: text(remote.functionalImpact), to: &differences)
+        appendDifference(id: "menstruationStatus", label: "Zyklusstatus", myValue: menstruationStatus(local.menstruationStatus), cloudValue: menstruationStatus(remote.menstruationStatus), to: &differences)
+        appendDifference(id: "medications", label: "Medikamente", myValue: medicationList(local.medications), cloudValue: medicationList(remote.medications), to: &differences)
+        appendDifference(id: "continuousMedicationChecks", label: "Dauermedikation", myValue: continuousMedicationChecks(local.continuousMedicationChecks), cloudValue: continuousMedicationChecks(remote.continuousMedicationChecks), to: &differences)
+        appendDifference(id: "weatherSnapshot", label: "Wetter", myValue: weather(local.weatherSnapshot), cloudValue: weather(remote.weatherSnapshot), to: &differences)
+        appendDifference(id: "healthContext", label: "Apple-Health-Kontext", myValue: healthContext(local.healthContext), cloudValue: healthContext(remote.healthContext), to: &differences)
+    }
+
+    private static func appendMedicationDefinitionDifferences(
+        local: SyncMedicationDefinitionPayload,
+        remote: SyncMedicationDefinitionPayload,
+        to differences: inout [ConflictDisplayDifference]
+    ) {
+        appendDifference(id: "name", label: "Name", myValue: text(local.name), cloudValue: text(remote.name), to: &differences)
+        appendDifference(id: "category", label: "Kategorie", myValue: medicationCategory(local.category), cloudValue: medicationCategory(remote.category), to: &differences)
+        appendDifference(id: "suggestedDosage", label: "Dosierung", myValue: text(local.suggestedDosage), cloudValue: text(remote.suggestedDosage), to: &differences)
+        appendDifference(id: "groupTitle", label: "Gruppe", myValue: text(local.groupTitle), cloudValue: text(remote.groupTitle), to: &differences)
+    }
+
+    private static func appendContinuousMedicationDifferences(
+        local: SyncContinuousMedicationPayload,
+        remote: SyncContinuousMedicationPayload,
+        to differences: inout [ConflictDisplayDifference]
+    ) {
+        appendDifference(id: "name", label: "Name", myValue: text(local.name), cloudValue: text(remote.name), to: &differences)
+        appendDifference(id: "dosage", label: "Dosierung", myValue: text(local.dosage), cloudValue: text(remote.dosage), to: &differences)
+        appendDifference(id: "frequency", label: "Häufigkeit", myValue: text(local.frequency), cloudValue: text(remote.frequency), to: &differences)
+        appendDifference(id: "startDate", label: "Start", myValue: dateOnly(local.startDate), cloudValue: dateOnly(remote.startDate), to: &differences)
+        appendDifference(id: "endDate", label: "Ende", myValue: optionalDateOnly(local.endDate), cloudValue: optionalDateOnly(remote.endDate), to: &differences)
+    }
+
+    private static func appendDifference(
+        id: String,
+        label: String,
+        myValue: String,
+        cloudValue: String,
+        to differences: inout [ConflictDisplayDifference]
+    ) {
+        guard myValue != cloudValue else {
+            return
+        }
+
+        differences.append(
+            ConflictDisplayDifference(
+                id: id,
+                label: label,
+                myValue: myValue,
+                cloudValue: cloudValue
+            )
+        )
+    }
+
+    private static func text(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Nicht eingetragen" : trimmed
+    }
+
+    private static func list(_ values: [String]) -> String {
+        let cleaned = values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .sorted()
+
+        return cleaned.isEmpty ? "Nicht vorhanden" : cleaned.joined(separator: ", ")
+    }
+
+    private static func episodeType(_ value: String) -> String {
+        EpisodeType(storageValue: value).displayName
+    }
+
+    private static func menstruationStatus(_ value: String) -> String {
+        MenstruationStatus(storageValue: value).displayName
+    }
+
+    private static func medicationCategory(_ value: String) -> String {
+        MedicationCategory(storageValue: value).displayName
+    }
+
+    private static func medicationEffectiveness(_ value: String) -> String {
+        MedicationEffectiveness(storageValue: value).displayName
+    }
+
+    private static func intensity(_ value: Int) -> String {
+        value <= 0 ? "Nicht bewertet" : "\(value) (\(PainIntensityLevel(intensity: value).displayLabel))"
+    }
+
+    private static func medicationList(_ medications: [SyncMedicationEntryPayload]) -> String {
+        let summaries = medications
+            .map { medication in
+                [
+                    text(medication.name),
+                    text(medication.dosage),
+                    medication.quantity > 1 ? "\(medication.quantity)x" : nil,
+                    medicationEffectiveness(medication.effectiveness) == "Teilweise" ? nil : "Wirkung: \(medicationEffectiveness(medication.effectiveness))"
+                ]
+                .compactMap { $0 }
+                .filter { $0 != "Nicht eingetragen" }
+                .joined(separator: " · ")
+            }
+            .filter { !$0.isEmpty }
+            .sorted()
+
+        return summaries.isEmpty ? "Nicht vorhanden" : summaries.joined(separator: ", ")
+    }
+
+    private static func continuousMedicationChecks(_ checks: [SyncContinuousMedicationCheckPayload]) -> String {
+        let summaries = checks
+            .map { check in
+                let status = check.wasTaken ? "genommen" : "nicht genommen"
+                return [text(check.name), text(check.dosage), status]
+                    .filter { $0 != "Nicht eingetragen" }
+                    .joined(separator: " · ")
+            }
+            .filter { !$0.isEmpty }
+            .sorted()
+
+        return summaries.isEmpty ? "Nicht vorhanden" : summaries.joined(separator: ", ")
+    }
+
+    private static func weather(_ weather: SyncWeatherSnapshotPayload?) -> String {
+        guard let weather else {
+            return "Nicht vorhanden"
+        }
+
+        var parts = [text(weather.condition)]
+        if let temperature = weather.temperature {
+            parts.append("\(temperature.formatted(.number.precision(.fractionLength(0 ... 1)))) °C")
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    private static func healthContext(_ context: HealthContextSnapshotData?) -> String {
+        context == nil ? "Nicht vorhanden" : "Vorhanden"
+    }
+
+    private static func optionalDateAndTime(_ date: Date?) -> String {
+        guard let date else {
+            return "Nicht eingetragen"
+        }
+
+        return dateAndTime(date)
+    }
+
+    private static func optionalDateOnly(_ date: Date?) -> String {
+        guard let date else {
+            return "Nicht eingetragen"
+        }
+
+        return dateOnly(date)
+    }
+
+    private static func dateAndTime(_ date: Date) -> String {
+        date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    private static func dateOnly(_ date: Date) -> String {
+        date.formatted(date: .abbreviated, time: .omitted)
     }
 }
 

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -64,6 +64,15 @@ struct SettingsView: View {
                     Label("Cloud-Daten verwalten", systemImage: "icloud")
                 }
 
+                if !controller.conflicts.isEmpty {
+                    NavigationLink {
+                        ManageCloudDataView(dataExportDependencies: dependencies.dataExport, controller: controller)
+                    } label: {
+                        Label("\(controller.conflicts.count) Sync-Konflikt\(controller.conflicts.count == 1 ? "" : "e") entscheiden", systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(AppTheme.symiCoral)
+                    }
+                }
+
                 NavigationLink {
                     SyncLogView(controller: controller)
                 } label: {
@@ -679,7 +688,6 @@ private struct SyncStatusView: View {
 private struct ManageCloudDataView: View {
     let dataExportDependencies: DataExportFeatureDependencies
     @Bindable var controller: SettingsController
-    @State private var selectedConflict: SyncConflict?
     @State private var isResolvingConflict = false
 
     var body: some View {
@@ -740,19 +748,40 @@ private struct ManageCloudDataView: View {
                     Text("Keine offenen Konflikte.")
                         .foregroundStyle(.secondary)
                 } else {
+                    Label("\(controller.conflicts.count) Konflikt\(controller.conflicts.count == 1 ? "" : "e") warten auf deine Entscheidung.", systemImage: "exclamationmark.triangle.fill")
+                        .font(.subheadline)
+                        .foregroundStyle(AppTheme.symiCoral)
+                        .padding(.vertical, SymiSpacing.xxs)
+                        .brandGroupedRow()
+
                     ForEach(controller.conflicts) { conflict in
                         VStack(alignment: .leading, spacing: SymiSpacing.xs) {
                             Text(conflictTitle(for: conflict))
                                 .font(.headline)
                             Text("Lokaler Stand und Cloud-Stand unterscheiden sich.")
                                 .font(.subheadline)
+                            Text(versionSummary("Lokal", envelope: conflict.local))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(versionSummary("Cloud", envelope: conflict.remote))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                             Text("Abweichende Felder: \(conflict.conflictingFields.joined(separator: ", "))")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
 
-                            Button("Konflikt lösen") {
-                                selectedConflict = conflict
+                            HStack(spacing: SymiSpacing.sm) {
+                                Button("Lokale Version behalten") {
+                                    resolveConflict(conflict, preferLocal: true)
+                                }
+                                .buttonStyle(.bordered)
+
+                                Button("Cloud-Version übernehmen") {
+                                    resolveConflict(conflict, preferLocal: false)
+                                }
+                                .buttonStyle(.borderedProminent)
                             }
+                            .disabled(isResolvingConflict)
                         }
                         .padding(.vertical, SymiSpacing.xxs)
                         .brandGroupedRow()
@@ -809,28 +838,6 @@ private struct ManageCloudDataView: View {
                     .background(.thinMaterial, in: RoundedRectangle(cornerRadius: SymiRadius.flowBanner, style: .continuous))
             }
         }
-        .confirmationDialog(
-            selectedConflict.map(dialogTitle(for:)) ?? "Sync-Konflikt",
-            isPresented: selectedConflictPresented,
-            titleVisibility: .visible,
-            presenting: selectedConflict
-        ) { conflict in
-            Button("Lokal hat recht") {
-                resolveConflict(conflict, preferLocal: true)
-            }
-            Button("Cloud hat recht") {
-                resolveConflict(conflict, preferLocal: false)
-            }
-            Button("Abbrechen", role: .cancel) {}
-        } message: { conflict in
-            Text(dialogMessage(for: conflict))
-        }
-        .onAppear {
-            presentNextConflictIfNeeded()
-        }
-        .onChange(of: controller.conflicts.map(\.id)) { _, _ in
-            presentNextConflictIfNeeded()
-        }
         .refreshable {
             controller.load()
         }
@@ -864,6 +871,11 @@ private struct ManageCloudDataView: View {
         return date.formatted(date: .numeric, time: .shortened)
     }
 
+    private func versionSummary(_ title: String, envelope: SyncDocumentEnvelope) -> String {
+        let deletedSuffix = envelope.deletedAt == nil ? "" : " · gelöscht"
+        return "\(title): geändert \(formatted(envelope.modifiedAt))\(deletedSuffix)"
+    }
+
     private var syncStalenessWarning: String? {
         controller.syncStatus.staleDataWarning(
             isSyncEnabled: controller.isSyncEnabled,
@@ -871,35 +883,7 @@ private struct ManageCloudDataView: View {
         )
     }
 
-    private var selectedConflictPresented: Binding<Bool> {
-        Binding(
-            get: { selectedConflict != nil },
-            set: { isPresented in
-                if !isPresented {
-                    selectedConflict = nil
-                }
-            }
-        )
-    }
-
-    private func dialogTitle(for conflict: SyncConflict) -> String {
-        "\(conflictTitle(for: conflict)) in Konflikt"
-    }
-
-    private func dialogMessage(for conflict: SyncConflict) -> String {
-        "Der lokale Stand und die Cloud-Daten unterscheiden sich. Wähle, welche Version gelten soll. Abweichende Felder: \(conflict.conflictingFields.joined(separator: ", "))."
-    }
-
-    private func presentNextConflictIfNeeded() {
-        guard selectedConflict == nil, !controller.conflicts.isEmpty else {
-            return
-        }
-
-        selectedConflict = controller.conflicts.first
-    }
-
     private func resolveConflict(_ conflict: SyncConflict, preferLocal: Bool) {
-        selectedConflict = nil
         isResolvingConflict = true
 
         Task {
@@ -912,7 +896,6 @@ private struct ManageCloudDataView: View {
 
             await MainActor.run {
                 isResolvingConflict = false
-                presentNextConflictIfNeeded()
             }
         }
     }

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -921,7 +921,6 @@ private struct ManageCloudDataView: View {
 
 private struct ConflictDifferenceRow: View {
     let difference: ConflictDisplayDifference
-    private let cloudValueColor = Color(red: 15 / 255, green: 61 / 255, blue: 62 / 255)
 
     var body: some View {
         VStack(alignment: .leading, spacing: SymiSpacing.micro) {
@@ -935,7 +934,7 @@ private struct ConflictDifferenceRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Text(difference.cloudValue)
-                    .foregroundStyle(cloudValueColor)
+                    .foregroundStyle(SymiColors.primaryPetrol.color)
             }
             .font(.subheadline)
             .textSelection(.enabled)

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -201,9 +201,9 @@ struct SettingsView: View {
 
     private var syncContractSummary: String {
         [
-            "Sync ist halbautomatisch: Aktivieren startet sofort einen Abgleich; App-Start lädt den gespeicherten Sync-Status und startet den Provider.",
-            "Danach löst du den Cloud-Abgleich bewusst mit `Jetzt synchronisieren` aus.",
-            "CloudKit-Subscriptions werden nicht angelegt; stale Stände, ungesyncte Records und Konflikte bleiben sichtbar."
+            "Cloud-Sync läuft automatisch, sobald er aktiviert ist.",
+            "Symi gleicht Änderungen ab, wenn die App geöffnet wird, wenn du Daten änderst oder wenn die Verbindung wieder da ist.",
+            "„Jetzt synchronisieren“ startet zusätzlich sofort einen Abgleich."
         ].joined(separator: " ")
     }
 
@@ -614,9 +614,11 @@ private struct SyncStatusView: View {
 
             Section("Sync-Vertrag") {
                 Text([
-                    "Symi arbeitet lokal-first.",
-                    "Bei aktivem iCloud-Sync startet ein neuer Abgleich sofort nach dem Aktivieren und danach nur, wenn du ihn mit `Jetzt synchronisieren` auslöst.",
-                    "Beim App-Start wird der gespeicherte Sync-Status geladen und der Provider vorbereitet; Push- oder Subscription-gesteuerte Hintergrundabgleiche gibt es derzeit nicht."
+                    "Symi speichert deine Daten zuerst sicher auf diesem Gerät.",
+                    "Wenn Cloud-Sync aktiv ist, gleicht Symi Änderungen automatisch mit iCloud ab: beim Aktivieren, beim Öffnen der App, nach Änderungen und sobald die Verbindung wieder da ist.",
+                    "„Jetzt synchronisieren“ startet zusätzlich sofort einen Abgleich.",
+                    "Wenn etwas nicht klappt, bleiben deine lokalen Daten erhalten. Symi zeigt dir, ob du es erneut versuchen kannst oder ob erst ein App- oder Cloud-Problem behoben werden muss.",
+                    "Bei Unterschieden zwischen Geräten entscheidet Symi nicht still für dich. Konflikte bleiben sichtbar, bis du auswählst, welcher Stand gelten soll."
                 ].joined(separator: " "))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
@@ -652,7 +654,7 @@ private struct SyncStatusView: View {
         case .disabled:
             "Der Cloud-Sync ist ausgeschaltet. Lokale Daten bleiben unverändert verfügbar."
         case .ready:
-            "Der Sync-Dienst ist bereit. Änderungen werden beim nächsten Lauf in die private iCloud-Datenbank übertragen."
+            "Der Sync-Dienst ist bereit. Änderungen werden automatisch und per „Jetzt synchronisieren“ in die private iCloud-Datenbank übertragen."
         case .syncing:
             "Es läuft gerade ein Abgleich zwischen lokalem Speicher und iCloud."
         case .needsAttention:
@@ -700,7 +702,7 @@ private struct ManageCloudDataView: View {
             } header: {
                 Text("Übersicht")
             } footer: {
-                Text("Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst. Sync läuft halbautomatisch: Aktivierung startet einen Abgleich, danach nutzt du `Jetzt synchronisieren`.")
+                Text("Papierkorb-Einträge bleiben lokal und in der Cloud erhalten, bis du sie bewusst wiederherstellst oder später einmal endgültig entfernst. Bei aktiviertem Cloud-Sync läuft der Abgleich automatisch; „Jetzt synchronisieren“ startet zusätzlich sofort einen Lauf.")
             }
 
             Section {
@@ -716,7 +718,7 @@ private struct ManageCloudDataView: View {
                         await controller.retryLastError()
                     }
                 }
-                .disabled(!controller.isSyncEnabled || controller.syncStatus.lastError == nil)
+                .disabled(!controller.isSyncEnabled || !controller.syncStatus.lastErrorIsRetryable)
 
                 NavigationLink {
                     DataBackupSettingsView(dependencies: dataExportDependencies)

--- a/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
+++ b/Symi/Sources/Features/Sync/CloudKitSyncProvider.swift
@@ -8,11 +8,19 @@ enum SyncProviderEvent: Sendable {
     case didSendRecords([CKRecord])
     case didFailToSend([SyncFailedRecordSave])
     case didEncounterError(String)
+    case didRecoverAccountAvailability
 }
 
 struct SyncFailedRecordSave: Sendable {
     let recordID: CKRecord.ID
     let error: CKError
+    let serverRecord: CKRecord?
+
+    init(recordID: CKRecord.ID, error: CKError, serverRecord: CKRecord? = nil) {
+        self.recordID = recordID
+        self.error = error
+        self.serverRecord = serverRecord
+    }
 }
 
 protocol SyncProvider: AnyObject, Sendable {
@@ -210,8 +218,72 @@ final class CloudKitSyncProvider: NSObject, SyncProvider {
         await log(level: .info, operation: "provider.send.start", message: "CloudKit-Änderungen werden gesendet.", metadata: [
             "pendingRecords": "\(pendingRecordCount)"
         ])
-        _ = try await providerState.sendChanges(zoneID: zoneID)
+        do {
+            _ = try await providerState.sendChanges(zoneID: zoneID)
+        } catch let error as CKError {
+            if await handlePartialSendFailure(error) {
+                await log(level: .warning, operation: "provider.send.partialFailure", message: "CloudKit hat einzelne Records abgelehnt; Details wurden an den Coordinator übergeben.")
+                return
+            }
+            throw error
+        }
         await log(level: .info, operation: "provider.send.finish", message: "CloudKit-Änderungen wurden gesendet.")
+    }
+
+    private func handlePartialSendFailure(_ error: CKError) async -> Bool {
+        let partialErrors: [(CKRecord.ID, CKError)]
+        if let errors = error.userInfo[CKPartialErrorsByItemIDKey] as? [CKRecord.ID: Error] {
+            partialErrors = errors.compactMap { recordID, error in
+                guard let ckError = error as? CKError else {
+                    return nil
+                }
+
+                return (recordID, ckError)
+            }
+        } else if let errors = error.userInfo[CKPartialErrorsByItemIDKey] as? [AnyHashable: Error] {
+            partialErrors = errors.compactMap { key, error in
+                guard let recordID = key as? CKRecord.ID, let ckError = error as? CKError else {
+                    return nil
+                }
+
+                return (recordID, ckError)
+            }
+        } else {
+            return false
+        }
+
+        var failures: [SyncFailedRecordSave] = []
+        for (recordID, recordError) in partialErrors {
+            let serverRecord = await resolvedServerRecord(for: recordID, error: recordError)
+            failures.append(SyncFailedRecordSave(recordID: recordID, error: recordError, serverRecord: serverRecord))
+        }
+
+        guard !failures.isEmpty else {
+            return false
+        }
+
+        await eventHandler(.didFailToSend(failures))
+        return true
+    }
+
+    private func resolvedServerRecord(for recordID: CKRecord.ID, error: CKError) async -> CKRecord? {
+        if let serverRecord = error.serverRecord {
+            return serverRecord
+        }
+
+        guard error.code == .serverRecordChanged else {
+            return nil
+        }
+
+        do {
+            return try await container.privateCloudDatabase.record(for: recordID)
+        } catch {
+            await log(level: .warning, operation: "provider.serverRecordChanged.fetchFailed", message: "Vorhandener Server-Record konnte nach Konfliktmeldung nicht geladen werden.", metadata: [
+                "recordID": recordID.recordName,
+                "error": error.localizedDescription
+            ])
+            return nil
+        }
     }
 }
 
@@ -230,7 +302,7 @@ extension CloudKitSyncProvider: CKSyncEngineDelegate {
             await eventHandler(.didDeleteRecords(changes.deletions.map(\.recordID)))
         case .sentRecordZoneChanges(let changes):
             let failures = changes.failedRecordSaves.map {
-                SyncFailedRecordSave(recordID: $0.record.recordID, error: $0.error)
+                SyncFailedRecordSave(recordID: $0.record.recordID, error: $0.error, serverRecord: $0.error.serverRecord)
             }
             await providerState.removeSentRecordNames(changes.savedRecords.map { $0.recordID.recordName })
             await log(level: failures.isEmpty ? .info : .warning, operation: "provider.event.sentRecordZoneChanges", message: "Upload-Ergebnis erhalten.", metadata: [
@@ -276,6 +348,7 @@ extension CloudKitSyncProvider: CKSyncEngineDelegate {
                 await log(level: .info, operation: "provider.event.accountChange", message: "iCloud-Account ist wieder verfügbar.", metadata: [
                     "changeType": "\(change.changeType)"
                 ])
+                await eventHandler(.didRecoverAccountAvailability)
             @unknown default:
                 await log(level: .warning, operation: "provider.event.accountChange.unknown", message: "Unbekannte iCloud-Änderung erkannt.")
                 await eventHandler(.didEncounterError("Unbekannte iCloud-Änderung erkannt."))

--- a/Symi/Sources/Features/Sync/SyncCoordinator.swift
+++ b/Symi/Sources/Features/Sync/SyncCoordinator.swift
@@ -1,7 +1,16 @@
 import CloudKit
 import Foundation
+import Network
 import Observation
 import SwiftData
+
+typealias SyncProviderFactory = @MainActor @Sendable (
+    SyncStateStore,
+    CKRecordZone.ID,
+    AppLogStore,
+    @escaping @Sendable (CKRecord.ID) async -> CKRecord?,
+    @escaping @Sendable (SyncProviderEvent) async -> Void
+) -> any SyncProvider
 
 @MainActor
 @Observable
@@ -15,8 +24,15 @@ final class SyncCoordinator {
     private let appLogStore: AppLogStore
     private let repository: LocalSyncRepository
     private let deviceID: String
+    private let providerFactory: SyncProviderFactory
     private var provider: (any SyncProvider)?
     private let zoneID = SyncConfiguration.zoneID
+    private var syncRunTask: Task<Void, Never>?
+    private var automaticSyncTask: Task<Void, Never>?
+    private var localChangeObserverTask: Task<Void, Never>?
+    private var networkMonitor: NWPathMonitor?
+    private var currentSyncRunHadError = false
+    private let networkMonitorQueue = DispatchQueue(label: "Symi.Sync.NetworkMonitor")
 
     init(
         modelContainer: ModelContainer,
@@ -24,18 +40,29 @@ final class SyncCoordinator {
         healthContextStore: HealthContextStore = HealthContextStore(),
         stateStore: SyncStateStore = SyncStateStore(),
         deviceID: String? = nil,
-        autostart: Bool = true
+        autostart: Bool = true,
+        providerFactory: @escaping SyncProviderFactory = { stateStore, zoneID, appLogStore, recordProvider, eventHandler in
+            CloudKitSyncProvider(
+                stateStore: stateStore,
+                zoneID: zoneID,
+                appLogStore: appLogStore,
+                recordProvider: recordProvider,
+                eventHandler: eventHandler
+            )
+        }
     ) {
         self.modelContainer = modelContainer
         self.stateStore = stateStore
         self.appLogStore = appLogStore
         self.repository = LocalSyncRepository(modelContainer: modelContainer, healthContextStore: healthContextStore)
         self.deviceID = deviceID ?? Self.persistedDeviceID()
+        self.providerFactory = providerFactory
 
         guard autostart else {
             return
         }
 
+        startLocalChangeObserver()
         Task {
             await loadPersistedState()
         }
@@ -70,6 +97,8 @@ final class SyncCoordinator {
 
             if isEnabled {
                 await ensureStarted()
+                startNetworkMonitorIfNeeded()
+                triggerAutomaticSync(reason: "loadPersistedState")
             }
         }
     }
@@ -83,8 +112,11 @@ final class SyncCoordinator {
 
             if enabled {
                 await ensureStarted()
+                startNetworkMonitorIfNeeded()
                 await syncNow()
             } else {
+                automaticSyncTask?.cancel()
+                stopNetworkMonitor()
                 await provider?.stop()
                 provider = nil
                 status = await buildStatusSnapshot(baseState: .disabled, isSyncing: false)
@@ -99,6 +131,24 @@ final class SyncCoordinator {
     }
 
     func syncNow() async {
+        if let syncRunTask {
+            await syncRunTask.value
+            return
+        }
+
+        let task = Task { @MainActor in
+            await performSyncNow()
+        }
+        syncRunTask = task
+        await task.value
+        syncRunTask = nil
+    }
+
+    func appDidBecomeActive() {
+        triggerAutomaticSync(reason: "appDidBecomeActive", debounce: .seconds(0))
+    }
+
+    private func performSyncNow() async {
         await PerformanceInstrumentation.measure("SyncManualRun") {
             guard isEnabled else {
                 await log(level: .warning, operation: "coordinator.syncNow.skip", message: "Sync wurde angefordert, ist aber deaktiviert.")
@@ -118,6 +168,7 @@ final class SyncCoordinator {
             status = await buildStatusSnapshot(baseState: .syncing, isSyncing: true)
 
             do {
+                currentSyncRunHadError = false
                 try await PerformanceInstrumentation.measure("SyncProviderFetch") {
                     try await provider.fetch()
                 }
@@ -125,13 +176,16 @@ final class SyncCoordinator {
                 try await PerformanceInstrumentation.measure("SyncProviderSend") {
                     try await provider.send()
                 }
-                await stateStore.clearLastError()
+                if !currentSyncRunHadError {
+                    await stateStore.clearLastError()
+                }
                 await logStateStoreEvents()
                 await log(level: .info, operation: "coordinator.syncNow.finish", message: "Sync-Lauf erfolgreich abgeschlossen.", metadata: [
                     "conflicts": "\(await stateStore.conflicts().count)"
                 ])
             } catch {
-                await stateStore.setLastError(error.localizedDescription)
+                currentSyncRunHadError = true
+                await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
                 await logStateStoreEvents()
                 await log(level: .error, operation: "coordinator.syncNow.error", message: "Sync-Lauf fehlgeschlagen.", metadata: [
                     "error": error.localizedDescription
@@ -180,7 +234,7 @@ final class SyncCoordinator {
             ])
             status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
         } catch {
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
             await log(level: .error, operation: "coordinator.resolveConflictUsingRemote.error", message: "Konflikt konnte nicht mit Cloud-Daten aufgelöst werden.", metadata: [
                 "documentID": conflict.documentID,
                 "error": error.localizedDescription
@@ -195,14 +249,14 @@ final class SyncCoordinator {
                 return
             }
 
-            let cloudProvider = CloudKitSyncProvider(
-                stateStore: stateStore,
-                zoneID: zoneID,
-                appLogStore: appLogStore,
-                recordProvider: { [weak self] recordID in
+            let cloudProvider = providerFactory(
+                stateStore,
+                zoneID,
+                appLogStore,
+                { [weak self] recordID in
                     await self?.recordForUpload(recordID: recordID)
                 },
-                eventHandler: { [weak self] event in
+                { [weak self] event in
                     await self?.handleProviderEvent(event)
                 }
             )
@@ -215,7 +269,7 @@ final class SyncCoordinator {
                 }
                 await log(level: .info, operation: "coordinator.ensureStarted", message: "Sync-Provider wurde initialisiert.")
             } catch {
-                await stateStore.setLastError(error.localizedDescription)
+                await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
                 await log(level: .error, operation: "coordinator.ensureStarted.error", message: "Sync-Provider konnte nicht gestartet werden.", metadata: [
                     "error": error.localizedDescription
                 ])
@@ -234,7 +288,7 @@ final class SyncCoordinator {
             }
             envelope = fetchedEnvelope
         } catch {
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
             await log(level: .error, operation: "coordinator.recordForUpload.error", message: "Lokales Dokument für Upload konnte nicht geladen werden.", metadata: [
                 "recordID": recordID.recordName,
                 "error": error.localizedDescription
@@ -305,6 +359,7 @@ final class SyncCoordinator {
             conflicts = await stateStore.conflicts()
             await stateStore.setLastUploadedAt(.now)
         case .didFailToSend(let failures):
+            currentSyncRunHadError = currentSyncRunHadError || failures.contains { !isRepairableServerRecordChange($0) }
             await log(level: .warning, operation: "coordinator.provider.didFailToSend", message: "Ein Teil des Uploads ist fehlgeschlagen.", metadata: [
                 "count": "\(failures.count)"
             ])
@@ -312,10 +367,14 @@ final class SyncCoordinator {
                 await handleFailedSave(failure)
             }
         case .didEncounterError(let message):
-            await stateStore.setLastError(message)
+            currentSyncRunHadError = true
+            await stateStore.setLastError(message, isRetryable: SyncErrorClassifier.isRetryable(message: message))
             await log(level: .error, operation: "coordinator.provider.didEncounterError", message: "Der Provider hat einen Fehler gemeldet.", metadata: [
                 "error": message
             ])
+        case .didRecoverAccountAvailability:
+            await log(level: .info, operation: "coordinator.provider.didRecoverAccountAvailability", message: "iCloud-Account ist verfügbar; automatischer Sync wird geplant.")
+            triggerAutomaticSync(reason: "iCloudAccountAvailable", debounce: .seconds(0))
         }
 
         status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
@@ -334,7 +393,7 @@ final class SyncCoordinator {
         do {
             localEnvelope = try repository.envelope(documentID: remoteEnvelope.documentID, deviceID: deviceID)
         } catch {
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
             await log(level: .error, operation: "coordinator.applyRemoteRecord.localEnvelopeError", message: "Lokaler Vergleichsstand konnte nicht geladen werden.", metadata: [
                 "documentID": remoteEnvelope.documentID,
                 "error": error.localizedDescription
@@ -345,7 +404,7 @@ final class SyncCoordinator {
         do {
             try repository.validate(remote: remoteEnvelope)
         } catch {
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
 
             if let localEnvelope {
                 await stateStore.saveConflict(
@@ -424,7 +483,7 @@ final class SyncCoordinator {
                 await log(level: .info, operation: "coordinator.applyRemoteRecord.insert", message: "Remote-Record wurde lokal neu angelegt.", metadata: metadata(for: remoteEnvelope, shadow: shadow))
             }
         } catch {
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
             await log(level: .error, operation: "coordinator.applyRemoteRecord.error", message: "Remote-Record konnte nicht angewendet werden.", metadata: [
                 "documentID": remoteEnvelope.documentID,
                 "error": error.localizedDescription
@@ -439,7 +498,7 @@ final class SyncCoordinator {
         do {
             localEnvelope = try repository.envelope(documentID: recordID.recordName, deviceID: deviceID)
         } catch {
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
             await log(level: .error, operation: "coordinator.handleRemoteDeletion.loadError", message: "Lokaler Stand für Remote-Löschung konnte nicht geladen werden.", metadata: [
                 "recordID": recordID.recordName,
                 "error": error.localizedDescription
@@ -471,7 +530,7 @@ final class SyncCoordinator {
                 "entityType": tombstone.entityType.rawValue
             ])
         } catch {
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
             await log(level: .error, operation: "coordinator.handleRemoteDeletion.error", message: "Remote-Löschung konnte lokal nicht angewendet werden.", metadata: [
                 "recordID": recordID.recordName,
                 "error": error.localizedDescription
@@ -486,8 +545,8 @@ final class SyncCoordinator {
                 "recordID": failure.recordID.recordName,
                 "errorCode": "\(failure.error.code.rawValue)"
             ])
-            guard let serverRecord = failure.error.serverRecord else {
-                await stateStore.setLastError(failure.error.localizedDescription)
+            guard let serverRecord = failure.serverRecord ?? failure.error.serverRecord else {
+                await stateStore.setLastError(failure.error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(failure.error))
                 await log(level: .error, operation: "coordinator.handleFailedSave.serverRecordMissing", message: "Server-Record fehlt trotz Konfliktmeldung.", metadata: [
                     "recordID": failure.recordID.recordName
                 ])
@@ -495,14 +554,88 @@ final class SyncCoordinator {
             }
 
             await applyRemoteRecord(serverRecord)
+            triggerAutomaticSync(reason: "serverRecordChangedRepair", debounce: .seconds(0))
         default:
-            await stateStore.setLastError(failure.error.localizedDescription)
+            let syncError = SyncErrorClassifier.classify(failure.error)
+            await stateStore.setLastError(syncError.userMessage, isRetryable: syncError.isRetryable)
             await log(level: .error, operation: "coordinator.handleFailedSave.error", message: "Record konnte nicht gespeichert werden.", metadata: [
                 "recordID": failure.recordID.recordName,
                 "errorCode": "\(failure.error.code.rawValue)",
-                "error": failure.error.localizedDescription
+                "error": failure.error.localizedDescription,
+                "isRetryable": "\(syncError.isRetryable)"
             ])
         }
+    }
+
+    private func isRepairableServerRecordChange(_ failure: SyncFailedRecordSave) -> Bool {
+        failure.error.code == .serverRecordChanged
+            && (failure.serverRecord != nil || failure.error.serverRecord != nil)
+    }
+
+    private func startLocalChangeObserver() {
+        guard localChangeObserverTask == nil else {
+            return
+        }
+
+        localChangeObserverTask = Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(named: .symiLocalSyncDataDidChange) {
+                await MainActor.run {
+                    self?.triggerAutomaticSync(reason: "localDataChanged")
+                }
+            }
+        }
+    }
+
+    private func triggerAutomaticSync(reason: String, debounce: Duration = .seconds(1)) {
+        guard isEnabled else {
+            return
+        }
+
+        automaticSyncTask?.cancel()
+        automaticSyncTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: debounce)
+            } catch {
+                return
+            }
+
+            await MainActor.run {
+                self?.startAutomaticSyncRun(reason: reason)
+            }
+        }
+    }
+
+    private func startAutomaticSyncRun(reason: String) {
+        Task { [weak self] in
+            await self?.log(level: .info, operation: "coordinator.automaticSync", message: "Automatischer Sync-Lauf wird gestartet.", metadata: [
+                "reason": reason
+            ])
+            await self?.syncNow()
+        }
+    }
+
+    private func startNetworkMonitorIfNeeded() {
+        guard networkMonitor == nil else {
+            return
+        }
+
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard path.status == .satisfied else {
+                return
+            }
+
+            Task { @MainActor [weak self] in
+                self?.triggerAutomaticSync(reason: "networkAvailable", debounce: .seconds(0))
+            }
+        }
+        monitor.start(queue: networkMonitorQueue)
+        networkMonitor = monitor
+    }
+
+    private func stopNetworkMonitor() {
+        networkMonitor?.cancel()
+        networkMonitor = nil
     }
 
     private func queueUnsyncedDocuments() async throws {
@@ -552,6 +685,7 @@ final class SyncCoordinator {
         let shadows = await stateStore.shadows()
         let conflictList = await stateStore.conflicts()
         var lastError = await stateStore.lastError()
+        let lastErrorIsRetryable = await stateStore.lastErrorIsRetryable()
         let pendingRecordCount = await provider?.queuedChangeCount ?? 0
         let accountState = await provider?.accountAvailability ?? (isEnabled ? .needsAttention : .disabled)
 
@@ -575,7 +709,7 @@ final class SyncCoordinator {
             localEnvelopes = try repository.allEnvelopes(deviceID: deviceID)
         } catch {
             lastError = error.localizedDescription
-            await stateStore.setLastError(error.localizedDescription)
+            await stateStore.setLastError(error.localizedDescription, isRetryable: SyncErrorClassifier.isRetryable(error))
             await log(level: .error, operation: "coordinator.buildStatusSnapshot.localEnvelopeError", message: "Lokale Sync-Dokumente konnten für den Status nicht geladen werden.", metadata: [
                 "error": error.localizedDescription
             ])
@@ -595,7 +729,8 @@ final class SyncCoordinator {
             unsyncedRecords: unsyncedCount,
             lastDownloadedAt: await stateStore.lastDownloadedAt(),
             lastUploadedAt: await stateStore.lastUploadedAt(),
-            lastError: lastError
+            lastError: lastError,
+            lastErrorIsRetryable: lastErrorIsRetryable
         )
     }
 
@@ -660,5 +795,104 @@ final class SyncCoordinator {
         }
 
         return ["payloadValidation"]
+    }
+}
+
+struct ClassifiedSyncError {
+    let userMessage: String
+    let isRetryable: Bool
+}
+
+enum SyncErrorClassifier {
+    static func classify(_ error: Error) -> ClassifiedSyncError {
+        if let ckError = error as? CKError {
+            return classify(ckError)
+        }
+
+        return ClassifiedSyncError(
+            userMessage: error.localizedDescription,
+            isRetryable: isRetryable(message: error.localizedDescription)
+        )
+    }
+
+    static func classify(_ error: CKError) -> ClassifiedSyncError {
+        let message = error.localizedDescription
+        if isCloudKitSchemaConfigurationError(error) || isCloudKitSchemaConfigurationError(message: message) {
+            return ClassifiedSyncError(
+                userMessage: "Sync kann aktuell nicht abgeschlossen werden, weil die Cloud-Konfiguration nicht zur App-Version passt. Deine lokalen Daten bleiben erhalten. Details: \(message)",
+                isRetryable: false
+            )
+        }
+
+        return ClassifiedSyncError(
+            userMessage: message,
+            isRetryable: isRetryable(error)
+        )
+    }
+
+    static func isRetryable(_ error: Error) -> Bool {
+        classify(error).isRetryable
+    }
+
+    static func isRetryable(message: String) -> Bool {
+        if isCloudKitSchemaConfigurationError(message: message) {
+            return false
+        }
+
+        let lowercased = message.lowercased()
+        return [
+            "network",
+            "internet",
+            "offline",
+            "timed out",
+            "timeout",
+            "temporarily",
+            "service unavailable",
+            "rate limit",
+            "try again",
+            "erneut",
+            "nicht erreichbar"
+        ].contains { lowercased.contains($0) }
+    }
+
+    private static func isRetryable(_ error: CKError) -> Bool {
+        if isCloudKitSchemaConfigurationError(error) || isCloudKitSchemaConfigurationError(message: error.localizedDescription) {
+            return false
+        }
+
+        switch error.code {
+        case .networkUnavailable,
+             .networkFailure,
+             .serviceUnavailable,
+             .requestRateLimited,
+             .zoneBusy,
+             .resultsTruncated,
+             .operationCancelled,
+             .notAuthenticated:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isCloudKitSchemaConfigurationError(_ error: CKError) -> Bool {
+        switch error.code {
+        case .serverRejectedRequest,
+             .invalidArguments,
+             .zoneNotFound,
+             .unknownItem:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isCloudKitSchemaConfigurationError(message: String) -> Bool {
+        let lowercased = message.lowercased()
+        return lowercased.contains("cannot create new type")
+            || lowercased.contains("production schema")
+            || lowercased.contains("record type")
+            || lowercased.contains("field")
+            || lowercased.contains("schema")
     }
 }

--- a/Symi/Sources/Features/Sync/SyncCoordinator.swift
+++ b/Symi/Sources/Features/Sync/SyncCoordinator.swift
@@ -664,83 +664,6 @@ final class SyncCoordinator {
         networkMonitor = nil
     }
 
-    private func resolveActionableStatusIfNeeded(_ snapshot: SyncStatusSnapshot, reason: String) async {
-        guard isEnabled, snapshot.state != .syncing else {
-            return
-        }
-
-        let openConflicts = await stateStore.conflicts().count
-        let uploadableLocalChanges = max(0, snapshot.unsyncedRecords - openConflicts)
-        var shouldSync = false
-
-        if uploadableLocalChanges > 0 {
-            await logAutomaticStatusResolution(
-                key: "uploadableLocalChanges",
-                operation: "coordinator.statusAutoResolution.uploadableLocalChanges",
-                message: "Lokale Änderungen wurden automatisch für den nächsten iCloud-Abgleich vorgemerkt.",
-                metadata: [
-                    "reason": reason,
-                    "count": "\(uploadableLocalChanges)"
-                ]
-            )
-            shouldSync = true
-        }
-
-        if snapshot.lastDownloadedAt == nil {
-            await logAutomaticStatusResolution(
-                key: "missingInitialDownload",
-                operation: "coordinator.statusAutoResolution.missingInitialDownload",
-                message: "Fehlender iCloud-Download wird automatisch nachgeholt.",
-                metadata: [
-                    "reason": reason
-                ]
-            )
-            shouldSync = true
-        } else if let lastDownloadedAt = snapshot.lastDownloadedAt,
-                  Date().timeIntervalSince(lastDownloadedAt) >= SyncStatusSnapshot.staleDataWarningInterval {
-            await logAutomaticStatusResolution(
-                key: "staleDownload",
-                operation: "coordinator.statusAutoResolution.staleDownload",
-                message: "Veralteter iCloud-Download wurde erkannt; ein automatischer Abgleich wird gestartet.",
-                metadata: [
-                    "reason": reason,
-                    "lastDownloadedAt": lastDownloadedAt.ISO8601Format()
-                ]
-            )
-            shouldSync = true
-        }
-
-        if snapshot.lastErrorIsRetryable {
-            await logAutomaticStatusResolution(
-                key: "retryableLastError",
-                operation: "coordinator.statusAutoResolution.retryableLastError",
-                message: "Ein vorübergehender Sync-Fehler wird automatisch erneut versucht.",
-                metadata: [
-                    "reason": reason
-                ]
-            )
-            shouldSync = true
-        }
-
-        if shouldSync {
-            triggerAutomaticSync(reason: "statusAutoResolution", debounce: .seconds(0))
-        }
-    }
-
-    private func logAutomaticStatusResolution(
-        key: String,
-        operation: String,
-        message: String,
-        metadata: [String: String]
-    ) async {
-        guard !loggedAutomaticStatusResolutionKeys.contains(key) else {
-            return
-        }
-
-        loggedAutomaticStatusResolutionKeys.insert(key)
-        await log(level: .info, operation: operation, message: message, metadata: metadata)
-    }
-
     private func queueUnsyncedDocuments() async throws {
         try await PerformanceInstrumentation.measure("SyncQueueUnsyncedDocuments") {
             guard let provider else {
@@ -864,6 +787,95 @@ final class SyncCoordinator {
         }
     }
 
+}
+
+extension SyncCoordinator {
+    private func resolveActionableStatusIfNeeded(_ snapshot: SyncStatusSnapshot, reason: String) async {
+        guard isEnabled, snapshot.state != .syncing else {
+            return
+        }
+
+        let openConflicts = await stateStore.conflicts().count
+        let uploadableLocalChanges = max(0, snapshot.unsyncedRecords - openConflicts)
+        var shouldSync = false
+
+        if uploadableLocalChanges > 0 {
+            await logAutomaticStatusResolution(
+                key: "uploadableLocalChanges",
+                operation: "coordinator.statusAutoResolution.uploadableLocalChanges",
+                message: "Lokale Änderungen wurden automatisch für den nächsten iCloud-Abgleich vorgemerkt.",
+                metadata: [
+                    "reason": reason,
+                    "count": "\(uploadableLocalChanges)"
+                ]
+            )
+            shouldSync = true
+        }
+
+        if snapshot.lastDownloadedAt == nil {
+            await logAutomaticStatusResolution(
+                key: "missingInitialDownload",
+                operation: "coordinator.statusAutoResolution.missingInitialDownload",
+                message: "Fehlender iCloud-Download wird automatisch nachgeholt.",
+                metadata: [
+                    "reason": reason
+                ]
+            )
+            shouldSync = true
+        } else if let lastDownloadedAt = snapshot.lastDownloadedAt,
+                  Date().timeIntervalSince(lastDownloadedAt) >= SyncStatusSnapshot.staleDataWarningInterval {
+            await logAutomaticStatusResolution(
+                key: "staleDownload",
+                operation: "coordinator.statusAutoResolution.staleDownload",
+                message: "Veralteter iCloud-Download wurde erkannt; ein automatischer Abgleich wird gestartet.",
+                metadata: [
+                    "reason": reason,
+                    "lastDownloadedAt": lastDownloadedAt.ISO8601Format()
+                ]
+            )
+            shouldSync = true
+        }
+
+        if snapshot.lastErrorIsRetryable {
+            await logAutomaticStatusResolution(
+                key: "retryableLastError",
+                operation: "coordinator.statusAutoResolution.retryableLastError",
+                message: "Ein vorübergehender Sync-Fehler wird automatisch erneut versucht.",
+                metadata: [
+                    "reason": reason
+                ]
+            )
+            shouldSync = true
+        }
+
+        if shouldSync {
+            triggerAutomaticSync(reason: "statusAutoResolution", debounce: .seconds(0))
+        }
+    }
+
+    private func logAutomaticStatusResolution(
+        key: String,
+        operation: String,
+        message: String,
+        metadata: [String: String]
+    ) async {
+        guard !loggedAutomaticStatusResolutionKeys.contains(key) else {
+            return
+        }
+
+        loggedAutomaticStatusResolutionKeys.insert(key)
+        await log(level: .info, operation: operation, message: message, metadata: metadata)
+    }
+
+    private static func hasSameUserVisibleContent(
+        _ local: SyncDocumentEnvelope,
+        _ remote: SyncDocumentEnvelope
+    ) -> Bool {
+        local.entityType == remote.entityType
+            && local.deletedAt == remote.deletedAt
+            && local.payload == remote.payload
+    }
+
     private func metadata(for envelope: SyncDocumentEnvelope, shadow: SyncShadow?) -> [String: String] {
         var values: [String: String] = [
             "documentID": envelope.documentID,
@@ -898,15 +910,6 @@ final class SyncCoordinator {
         }
 
         return ["payloadValidation"]
-    }
-
-    private static func hasSameUserVisibleContent(
-        _ local: SyncDocumentEnvelope,
-        _ remote: SyncDocumentEnvelope
-    ) -> Bool {
-        local.entityType == remote.entityType
-            && local.deletedAt == remote.deletedAt
-            && local.payload == remote.payload
     }
 }
 

--- a/Symi/Sources/Features/Sync/SyncCoordinator.swift
+++ b/Symi/Sources/Features/Sync/SyncCoordinator.swift
@@ -32,6 +32,7 @@ final class SyncCoordinator {
     private var localChangeObserverTask: Task<Void, Never>?
     private var networkMonitor: NWPathMonitor?
     private var currentSyncRunHadError = false
+    private var loggedAutomaticStatusResolutionKeys = Set<String>()
     private let networkMonitorQueue = DispatchQueue(label: "Symi.Sync.NetworkMonitor")
 
     init(
@@ -124,7 +125,9 @@ final class SyncCoordinator {
 
     func refreshStatus() {
         Task {
-            status = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+            let snapshot = await buildStatusSnapshot(baseState: currentBaseState(), isSyncing: false)
+            status = snapshot
+            await resolveActionableStatusIfNeeded(snapshot, reason: "refreshStatus")
         }
     }
 
@@ -466,6 +469,16 @@ final class SyncCoordinator {
                     )
                     await stateStore.removeConflict(documentID: remoteEnvelope.documentID)
                     await log(level: .info, operation: "coordinator.applyRemoteRecord.merged", message: "Remote-Record wurde konfliktfrei gemergt.", metadata: metadata(for: merge.merged, shadow: shadow))
+                } else if Self.hasSameUserVisibleContent(localEnvelope, remoteEnvelope) {
+                    await stateStore.saveShadow(
+                        SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
+                        for: remoteEnvelope.documentID
+                    )
+                    await stateStore.removeConflict(documentID: remoteEnvelope.documentID)
+                    await log(level: .info, operation: "coordinator.applyRemoteRecord.identicalContent", message: "Konflikt wurde automatisch gelöst, weil der sichtbare Inhalt identisch ist.", metadata: [
+                        "documentID": remoteEnvelope.documentID,
+                        "entityType": remoteEnvelope.entityType.rawValue
+                    ])
                 } else {
                     await stateStore.saveShadow(
                         SyncShadow(envelope: remoteEnvelope, recordSystemFields: CloudKitRecordCodec.systemFields(for: record)),
@@ -651,6 +664,83 @@ final class SyncCoordinator {
         networkMonitor = nil
     }
 
+    private func resolveActionableStatusIfNeeded(_ snapshot: SyncStatusSnapshot, reason: String) async {
+        guard isEnabled, snapshot.state != .syncing else {
+            return
+        }
+
+        let openConflicts = await stateStore.conflicts().count
+        let uploadableLocalChanges = max(0, snapshot.unsyncedRecords - openConflicts)
+        var shouldSync = false
+
+        if uploadableLocalChanges > 0 {
+            await logAutomaticStatusResolution(
+                key: "uploadableLocalChanges",
+                operation: "coordinator.statusAutoResolution.uploadableLocalChanges",
+                message: "Lokale Änderungen wurden automatisch für den nächsten iCloud-Abgleich vorgemerkt.",
+                metadata: [
+                    "reason": reason,
+                    "count": "\(uploadableLocalChanges)"
+                ]
+            )
+            shouldSync = true
+        }
+
+        if snapshot.lastDownloadedAt == nil {
+            await logAutomaticStatusResolution(
+                key: "missingInitialDownload",
+                operation: "coordinator.statusAutoResolution.missingInitialDownload",
+                message: "Fehlender iCloud-Download wird automatisch nachgeholt.",
+                metadata: [
+                    "reason": reason
+                ]
+            )
+            shouldSync = true
+        } else if let lastDownloadedAt = snapshot.lastDownloadedAt,
+                  Date().timeIntervalSince(lastDownloadedAt) >= SyncStatusSnapshot.staleDataWarningInterval {
+            await logAutomaticStatusResolution(
+                key: "staleDownload",
+                operation: "coordinator.statusAutoResolution.staleDownload",
+                message: "Veralteter iCloud-Download wurde erkannt; ein automatischer Abgleich wird gestartet.",
+                metadata: [
+                    "reason": reason,
+                    "lastDownloadedAt": lastDownloadedAt.ISO8601Format()
+                ]
+            )
+            shouldSync = true
+        }
+
+        if snapshot.lastErrorIsRetryable {
+            await logAutomaticStatusResolution(
+                key: "retryableLastError",
+                operation: "coordinator.statusAutoResolution.retryableLastError",
+                message: "Ein vorübergehender Sync-Fehler wird automatisch erneut versucht.",
+                metadata: [
+                    "reason": reason
+                ]
+            )
+            shouldSync = true
+        }
+
+        if shouldSync {
+            triggerAutomaticSync(reason: "statusAutoResolution", debounce: .seconds(0))
+        }
+    }
+
+    private func logAutomaticStatusResolution(
+        key: String,
+        operation: String,
+        message: String,
+        metadata: [String: String]
+    ) async {
+        guard !loggedAutomaticStatusResolutionKeys.contains(key) else {
+            return
+        }
+
+        loggedAutomaticStatusResolutionKeys.insert(key)
+        await log(level: .info, operation: operation, message: message, metadata: metadata)
+    }
+
     private func queueUnsyncedDocuments() async throws {
         try await PerformanceInstrumentation.measure("SyncQueueUnsyncedDocuments") {
             guard let provider else {
@@ -808,6 +898,15 @@ final class SyncCoordinator {
         }
 
         return ["payloadValidation"]
+    }
+
+    private static func hasSameUserVisibleContent(
+        _ local: SyncDocumentEnvelope,
+        _ remote: SyncDocumentEnvelope
+    ) -> Bool {
+        local.entityType == remote.entityType
+            && local.deletedAt == remote.deletedAt
+            && local.payload == remote.payload
     }
 }
 

--- a/Symi/Sources/Features/Sync/SyncCoordinator.swift
+++ b/Symi/Sources/Features/Sync/SyncCoordinator.swift
@@ -117,8 +117,6 @@ final class SyncCoordinator {
             } else {
                 automaticSyncTask?.cancel()
                 stopNetworkMonitor()
-                await provider?.stop()
-                provider = nil
                 status = await buildStatusSnapshot(baseState: .disabled, isSyncing: false)
             }
         }
@@ -325,6 +323,21 @@ final class SyncCoordinator {
         case .didUpdateState(let serialization):
             await stateStore.saveEngineState(serialization)
             await log(level: .debug, operation: "coordinator.provider.didUpdateState", message: "Engine-Status wurde persistiert.")
+        default:
+            guard isEnabled else {
+                await log(level: .debug, operation: "coordinator.provider.eventIgnored", message: "Provider-Ereignis wurde ignoriert, weil Cloud-Sync deaktiviert ist.")
+                status = await buildStatusSnapshot(baseState: .disabled, isSyncing: false)
+                return
+            }
+
+            await handleEnabledProviderEvent(event)
+        }
+    }
+
+    private func handleEnabledProviderEvent(_ event: SyncProviderEvent) async {
+        switch event {
+        case .didUpdateState:
+            return
         case .didFetchRecords(let records):
             await log(level: .info, operation: "coordinator.provider.didFetchRecords", message: "Remote-Records empfangen.", metadata: [
                 "count": "\(records.count)"

--- a/Symi/Sources/Features/Sync/SyncStateStore.swift
+++ b/Symi/Sources/Features/Sync/SyncStateStore.swift
@@ -24,6 +24,7 @@ actor SyncStateStore {
         var lastUploadedAt: Date?
         var lastDownloadedAt: Date?
         var lastError: String?
+        var lastErrorIsRetryable = false
 
         private enum CodingKeys: String, CodingKey {
             case schemaVersion
@@ -34,6 +35,7 @@ actor SyncStateStore {
             case lastUploadedAt
             case lastDownloadedAt
             case lastError
+            case lastErrorIsRetryable
         }
 
         init() {}
@@ -58,6 +60,7 @@ actor SyncStateStore {
             self.lastUploadedAt = try container.decodeIfPresent(Date.self, forKey: .lastUploadedAt)
             self.lastDownloadedAt = try container.decodeIfPresent(Date.self, forKey: .lastDownloadedAt)
             self.lastError = try container.decodeIfPresent(String.self, forKey: .lastError)
+            self.lastErrorIsRetryable = try container.decodeIfPresent(Bool.self, forKey: .lastErrorIsRetryable) ?? false
         }
     }
 
@@ -223,13 +226,19 @@ actor SyncStateStore {
         state.lastError
     }
 
-    func setLastError(_ error: String?) {
+    func lastErrorIsRetryable() -> Bool {
+        state.lastError != nil && state.lastErrorIsRetryable
+    }
+
+    func setLastError(_ error: String?, isRetryable: Bool = true) {
         state.lastError = error
+        state.lastErrorIsRetryable = error == nil ? false : isRetryable
         persist()
     }
 
     func clearLastError() {
         state.lastError = nil
+        state.lastErrorIsRetryable = false
         persist()
     }
 
@@ -255,6 +264,7 @@ actor SyncStateStore {
 
     private func recordPersistenceFailure(operation: String, message: String, metadata: [String: String]) {
         state.lastError = message
+        state.lastErrorIsRetryable = false
         persistenceEvents.append(
             PersistenceEvent(
                 level: .error,

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -127,6 +127,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, Sendable {
         try DomainValidator.validate(target)
         try context.save()
         try healthContextStore.save(healthContext, for: target.id)
+        NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
         return target.id
     }
 
@@ -138,6 +139,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, Sendable {
 
         episode.markDeleted()
         try context.save()
+        NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
     }
 
     nonisolated func restore(id: UUID) throws {
@@ -148,6 +150,7 @@ final class SwiftDataEpisodeRepository: EpisodeRepository, Sendable {
 
         episode.restore()
         try context.save()
+        NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
     }
 
     nonisolated func fetchDeleted() throws -> [EpisodeRecord] {
@@ -229,6 +232,7 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
 
         try DomainValidator.validate(medication)
         try context.save()
+        NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
         return ContinuousMedicationRecord(medication: medication)
     }
 
@@ -240,6 +244,7 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
 
         context.delete(medication)
         try context.save()
+        NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
     }
 
     nonisolated private func readContext() -> ModelContext {
@@ -316,6 +321,7 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository, S
         }
 
         try context.save()
+        NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
         return MedicationDefinitionRecord(definition: definition)
     }
 
@@ -327,6 +333,7 @@ final class SwiftDataMedicationCatalogRepository: MedicationCatalogRepository, S
 
         definition.markDeleted()
         try context.save()
+        NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
     }
 
     nonisolated func fetchDeletedDefinitions() throws -> [MedicationDefinitionRecord] {

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -103,31 +103,9 @@ public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
             return "\(openConflictCount) Sync-Konflikt\(openConflictCount == 1 ? "" : "e") warten auf eine Entscheidung. Bearbeite erst weiter, wenn klar ist, welcher Stand gelten soll."
         }
 
-        if unsyncedRecords > 0 {
-            return "\(unsyncedRecords) lokale Änderung\(unsyncedRecords == 1 ? "" : "en") sind noch nicht in iCloud bestätigt. Synchronisiere vor dem Bearbeiten auf anderen Geräten."
-        }
-
-        guard let lastDownloadedAt else {
-            return "Dieses Gerät hat noch keinen iCloud-Download abgeschlossen. Synchronisiere vor dem Bearbeiten, wenn du Symi auf mehreren Geräten nutzt."
-        }
-
-        let age = now.timeIntervalSince(lastDownloadedAt)
-        guard age >= Self.staleDataWarningInterval else {
-            return nil
-        }
-
-        return "Der letzte iCloud-Download liegt \(Self.relativeDurationDescription(for: age)) zurück. Synchronisiere vor dem Bearbeiten, damit du nicht auf einem alten Stand arbeitest."
+        return nil
     }
 
-    private nonisolated static func relativeDurationDescription(for interval: TimeInterval) -> String {
-        let hours = max(1, Int(interval / 3_600))
-        guard hours >= 48 else {
-            return "\(hours) Stunde\(hours == 1 ? "" : "n")"
-        }
-
-        let days = max(1, hours / 24)
-        return "\(days) Tag\(days == 1 ? "" : "e")"
-    }
 }
 
 extension Notification.Name {

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -68,6 +68,7 @@ public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
     public nonisolated var lastDownloadedAt: Date?
     public nonisolated var lastUploadedAt: Date?
     public nonisolated var lastError: String?
+    public nonisolated var lastErrorIsRetryable: Bool
 
     public nonisolated init(
         state: SyncServiceState = .disabled,
@@ -76,7 +77,8 @@ public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
         unsyncedRecords: Int = 0,
         lastDownloadedAt: Date? = nil,
         lastUploadedAt: Date? = nil,
-        lastError: String? = nil
+        lastError: String? = nil,
+        lastErrorIsRetryable: Bool = false
     ) {
         self.state = state
         self.service = service
@@ -85,6 +87,7 @@ public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
         self.lastDownloadedAt = lastDownloadedAt
         self.lastUploadedAt = lastUploadedAt
         self.lastError = lastError
+        self.lastErrorIsRetryable = lastErrorIsRetryable
     }
 
     public nonisolated func staleDataWarning(
@@ -125,6 +128,10 @@ public struct SyncStatusSnapshot: Codable, Equatable, Sendable {
         let days = max(1, hours / 24)
         return "\(days) Tag\(days == 1 ? "" : "e")"
     }
+}
+
+extension Notification.Name {
+    nonisolated static let symiLocalSyncDataDidChange = Notification.Name("SymiLocalSyncDataDidChange")
 }
 
 public struct SyncDocumentEnvelope: Codable, Equatable, Sendable {

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -882,7 +882,8 @@ private func makeSyncTestStack(provider: FakeSyncProvider? = nil) throws -> Sync
     )
 }
 
-private final class FakeSyncProvider: SyncProvider, @unchecked Sendable {
+@MainActor
+private final class FakeSyncProvider: SyncProvider {
     private let lock = NSLock()
     private let failedSaveError: CKError?
     var serverRecordForFailure: CKRecord?

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 struct SyncMergeEngineTests {
     @Test
-    func syncStatusWarnsWhenLastDownloadIsStale() {
+    func syncStatusDoesNotWarnWhenLastDownloadIsStale() {
         let now = Date(timeIntervalSince1970: 200_000)
         let status = SyncStatusSnapshot(
             state: .ready,
@@ -17,11 +17,11 @@ struct SyncMergeEngineTests {
 
         let warning = status.staleDataWarning(now: now, isSyncEnabled: true, openConflictCount: 0)
 
-        #expect(warning?.contains("letzte iCloud-Download") == true)
+        #expect(warning == nil)
     }
 
     @Test
-    func syncStatusPrioritizesConflictsAndUnsyncedRecords() {
+    func syncStatusOnlyWarnsForConflictsThatNeedDecision() {
         let status = SyncStatusSnapshot(
             state: .conflict,
             unsyncedRecords: 3,
@@ -40,7 +40,7 @@ struct SyncMergeEngineTests {
         )
 
         #expect(conflictWarning?.contains("2 Sync-Konflikte") == true)
-        #expect(unsyncedWarning?.contains("3 lokale Änderungen") == true)
+        #expect(unsyncedWarning == nil)
     }
 
     @Test

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -644,6 +644,74 @@ struct SyncMergeEngineTests {
 
         #expect(pending == [changed.documentID])
     }
+
+    @Test
+    @MainActor
+    func manualSyncUploadsLocalChangeAndClearsUnsyncedRecords() async throws {
+        let fakeProvider = FakeSyncProvider()
+        let stack = try makeSyncTestStack(provider: fakeProvider)
+        await stack.stateStore.setSyncEnabled(true)
+        let documentID = try insertBaseEpisode(in: stack.container)
+
+        await stack.coordinator.loadPersistedState()
+        await stack.coordinator.syncNow()
+
+        let shadow = await stack.stateStore.shadow(for: documentID)
+
+        #expect(shadow?.envelope.documentID == documentID)
+        #expect(stack.coordinator.status.unsyncedRecords == 0)
+        #expect(await fakeProvider.sentRecordNames.contains(documentID))
+    }
+
+    @Test
+    @MainActor
+    func failedManualSyncKeepsNonRetryableSchemaErrorVisible() async throws {
+        let fakeProvider = FakeSyncProvider(
+            failedSaveError: productionSchemaCKError()
+        )
+        let stack = try makeSyncTestStack(provider: fakeProvider)
+        await stack.stateStore.setSyncEnabled(true)
+        _ = try insertBaseEpisode(in: stack.container)
+
+        await stack.coordinator.loadPersistedState()
+        await stack.coordinator.syncNow()
+
+        #expect(stack.coordinator.status.lastError?.contains("Cloud-Konfiguration") == true)
+        #expect(stack.coordinator.status.lastErrorIsRetryable == false)
+        #expect(stack.coordinator.status.unsyncedRecords == 1)
+    }
+
+    @Test
+    @MainActor
+    func existingServerRecordRepairsShadowAndClearsUnsyncedRecord() async throws {
+        let fakeProvider = FakeSyncProvider(
+            failedSaveError: insertAlreadyExistsCKError()
+        )
+        let stack = try makeSyncTestStack(provider: fakeProvider)
+        await stack.stateStore.setSyncEnabled(true)
+        let documentID = try insertBaseEpisode(in: stack.container)
+        let envelope = try requireEnvelope(from: stack.repository, documentID: documentID)
+        fakeProvider.serverRecordForFailure = try record(from: envelope)
+
+        await stack.coordinator.loadPersistedState()
+        await stack.coordinator.syncNow()
+
+        let shadow = await stack.stateStore.shadow(for: documentID)
+
+        #expect(shadow?.envelope == envelope)
+        #expect(shadow?.recordSystemFields != nil)
+        #expect(stack.coordinator.status.lastError == nil)
+        #expect(stack.coordinator.status.unsyncedRecords == 0)
+    }
+
+    @Test
+    @MainActor
+    func cloudKitProductionSchemaErrorIsNotRetryable() {
+        let classified = SyncErrorClassifier.classify(productionSchemaCKError())
+
+        #expect(classified.isRetryable == false)
+        #expect(classified.userMessage.contains("Cloud-Konfiguration") == true)
+    }
 }
 
 private func episodeEnvelope(
@@ -769,7 +837,7 @@ private extension Array {
 }
 
 @MainActor
-private func makeSyncTestStack() throws -> SyncTestStack {
+private func makeSyncTestStack(provider: FakeSyncProvider? = nil) throws -> SyncTestStack {
     let schema = Schema(versionedSchema: SymiSchemaV6.self)
     let configuration = ModelConfiguration(
         "sync-tests-\(UUID().uuidString)",
@@ -787,7 +855,21 @@ private func makeSyncTestStack() throws -> SyncTestStack {
         healthContextStore: healthContextStore,
         stateStore: stateStore,
         deviceID: syncTestDeviceID,
-        autostart: false
+        autostart: false,
+        providerFactory: { _, _, _, recordProvider, eventHandler in
+            if let provider {
+                provider.install(recordProvider: recordProvider, eventHandler: eventHandler)
+                return provider
+            }
+
+            return CloudKitSyncProvider(
+                stateStore: stateStore,
+                zoneID: syncTestZoneID,
+                appLogStore: appLogStore,
+                recordProvider: recordProvider,
+                eventHandler: eventHandler
+            )
+        }
     )
     let repository = LocalSyncRepository(modelContainer: container, healthContextStore: healthContextStore)
 
@@ -798,6 +880,131 @@ private func makeSyncTestStack() throws -> SyncTestStack {
         repository: repository,
         healthContextStore: healthContextStore
     )
+}
+
+private final class FakeSyncProvider: SyncProvider, @unchecked Sendable {
+    private let lock = NSLock()
+    private let failedSaveError: CKError?
+    var serverRecordForFailure: CKRecord?
+    private var queuedRecordNames: [String] = []
+    private var _sentRecordNames: [String] = []
+    private var recordProvider: (@Sendable (CKRecord.ID) async -> CKRecord?)?
+    private var eventHandler: (@Sendable (SyncProviderEvent) async -> Void)?
+
+    init(failedSaveError: CKError? = nil) {
+        self.failedSaveError = failedSaveError
+    }
+
+    var sentRecordNames: [String] {
+        get async {
+            lock.withLock {
+                _sentRecordNames
+            }
+        }
+    }
+
+    var queuedChangeCount: Int {
+        get async {
+            lock.withLock {
+                queuedRecordNames.count
+            }
+        }
+    }
+
+    var accountAvailability: SyncServiceState {
+        get async {
+            .ready
+        }
+    }
+
+    func install(
+        recordProvider: @escaping @Sendable (CKRecord.ID) async -> CKRecord?,
+        eventHandler: @escaping @Sendable (SyncProviderEvent) async -> Void
+    ) {
+        lock.withLock {
+            self.recordProvider = recordProvider
+            self.eventHandler = eventHandler
+        }
+    }
+
+    func start() async throws {}
+
+    func stop() async {
+        lock.withLock {
+            queuedRecordNames.removeAll()
+        }
+    }
+
+    func queue(recordNames: [String]) async {
+        lock.withLock {
+            queuedRecordNames.append(contentsOf: recordNames)
+        }
+    }
+
+    func fetch() async throws {}
+
+    func send() async throws {
+        let snapshot = lock.withLock {
+            (queuedRecordNames, recordProvider, eventHandler)
+        }
+
+        guard let recordProvider = snapshot.1, let eventHandler = snapshot.2 else {
+            return
+        }
+
+        var records: [CKRecord] = []
+        var failures: [SyncFailedRecordSave] = []
+        for recordName in snapshot.0 {
+            let recordID = CKRecord.ID(recordName: recordName, zoneID: syncTestZoneID)
+            if let record = await recordProvider(recordID) {
+                if let failedSaveError {
+                    let serverRecord = lock.withLock {
+                        serverRecordForFailure
+                    }
+                    failures.append(SyncFailedRecordSave(recordID: record.recordID, error: failedSaveError, serverRecord: serverRecord))
+                } else {
+                    records.append(record)
+                }
+            }
+        }
+
+        lock.withLock {
+            _sentRecordNames.append(contentsOf: records.map { $0.recordID.recordName })
+            if failures.isEmpty {
+                queuedRecordNames.removeAll()
+            }
+        }
+        if !records.isEmpty {
+            await eventHandler(.didSendRecords(records))
+        }
+        if !failures.isEmpty {
+            await eventHandler(.didFailToSend(failures))
+        }
+    }
+}
+
+private func productionSchemaCKError() -> CKError {
+    let error = NSError(
+        domain: CKError.errorDomain,
+        code: CKError.serverRejectedRequest.rawValue,
+        userInfo: [
+            NSLocalizedDescriptionKey: "Cannot create new type SyncDocument in production schema"
+        ]
+    )
+
+    return CKError(_nsError: error)
+}
+
+private func insertAlreadyExistsCKError() -> CKError {
+    let error = NSError(
+        domain: CKError.errorDomain,
+        code: CKError.serverRecordChanged.rawValue,
+        userInfo: [
+            NSLocalizedDescriptionKey: "record to insert already exists"
+        ]
+    )
+
+    return CKError(_nsError: error)
 }
 
 @MainActor


### PR DESCRIPTION
## Zusammenfassung

Dieser PR verbessert die Zuverlässigkeit des CloudKit-Syncs und macht verbleibende Konflikte für Benutzer verständlicher.

Closes #293

## Änderungen

- behandelt bestehende CloudKit-Records korrekt, wenn der Server meldet, dass ein einzufügender Datensatz bereits existiert
- verhindert doppelte Registrierung der CloudKit-SyncEngine-Background-Tasks
- macht Sync-Konflikte direkt in der App lösbar
- ersetzt technische Konflikttexte durch verständliche deutsche Beschreibungen ohne IDs oder interne Feldnamen
- löst Konflikte automatisch, wenn der sichtbare Inhalt identisch ist
- blendet wiederherstellbare Sync-Hinweise wie veraltete oder fehlende iCloud-Downloads aus und stößt stattdessen automatisch einen Sync an
- schreibt Info-Logs für automatisch behandelte Sync-Zustände

## Hintergrund

Einige Sync-Zustände wurden bisher als Meldung an Benutzer weitergereicht, obwohl die App sie selbst beheben kann. Außerdem waren Konflikte zu technisch formuliert und teilweise nicht direkt entscheidbar. Der PR verschiebt diese Fälle in automatische Sync-Aktionen und lässt nur echte Entscheidungen sichtbar.

## Validierung

- `xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16'`
- `swiftlint`
- Ergebnis: `TEST SUCCEEDED`, `swiftlint` ohne Violations