### PR TITLE
[codex] Refactor therapy navigation and settings

### DIFF
--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -425,6 +425,7 @@
       }
     },
     "Allgemein" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -494,7 +495,11 @@
         }
       }
     },
+    "App" : {
+
+    },
     "App verbessern" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -513,6 +518,9 @@
           }
         }
       }
+    },
+    "App-Information" : {
+
     },
     "App-Nutzung" : {
       "localizations" : {
@@ -789,6 +797,7 @@
       }
     },
     "Cloud-Daten verwalten" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -838,6 +847,9 @@
         }
       }
     },
+    "Daten & Sicherheit" : {
+
+    },
     "Daten wiederherstellen" : {
       "localizations" : {
         "en" : {
@@ -879,6 +891,7 @@
       }
     },
     "Dauermedikation hinzufügen" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -889,6 +902,7 @@
       }
     },
     "Dauermedikationen sind ein eigener Verlaufskontext und bleiben von Akutmedikation in Einträgen getrennt." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -977,6 +991,9 @@
           }
         }
       }
+    },
+    "Deine regelmäßige Medikation im Blick behalten" : {
+
     },
     "Der Abgleich arbeitet defensiv: Konflikte werden nicht still überschrieben, sondern hier sichtbar gemacht." : {
       "extractionState" : "stale",
@@ -1258,6 +1275,9 @@
           }
         }
       }
+    },
+    "Einnahmen & Anpassungen" : {
+
     },
     "Einschränkung: %@" : {
       "localizations" : {
@@ -1553,7 +1573,11 @@
         }
       }
     },
+    "Frequenz oder Uhrzeit, optional" : {
+
+    },
     "Frequenz, optional" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1614,6 +1638,7 @@
       }
     },
     "Gesundheit" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1642,6 +1667,12 @@
           }
         }
       }
+    },
+    "Heute" : {
+
+    },
+    "Hier siehst du den Verlauf deiner regelmäßigen Medikation. Dokumentierte Einnahmen aus Tagebucheinträgen bleiben weiterhin im Tagebuchkontext." : {
+
     },
     "Hilf uns, Symi besser zu machen." : {
       "localizations" : {
@@ -1682,6 +1713,12 @@
           }
         }
       }
+    },
+    "iCloud-Daten verwalten" : {
+
+    },
+    "iCloud-Synchronisation" : {
+
     },
     "In Sekunden eintragen" : {
       "localizations" : {
@@ -1814,6 +1851,7 @@
       }
     },
     "Keine aktive Dauermedikation." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1823,7 +1861,11 @@
         }
       }
     },
+    "Keine aktive regelmäßige Medikation." : {
+
+    },
     "Keine beendete Dauermedikation." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1832,6 +1874,9 @@
           }
         }
       }
+    },
+    "Keine beendete regelmäßige Medikation." : {
+
     },
     "Keine Diagnose, keine Therapieempfehlung" : {
       "localizations" : {
@@ -1872,6 +1917,9 @@
           }
         }
       }
+    },
+    "Keine regelmäßige Medikation für heute." : {
+
     },
     "Keine Zyklusangabe aus der App." : {
       "localizations" : {
@@ -2126,6 +2174,9 @@
         }
       }
     },
+    "Medikament hinzufügen" : {
+
+    },
     "Medikament nach Namen filtern" : {
       "localizations" : {
         "en" : {
@@ -2155,6 +2206,9 @@
           }
         }
       }
+    },
+    "Medikationsplan" : {
+
     },
     "Medizinischer Hinweis" : {
       "localizations" : {
@@ -2289,6 +2343,9 @@
         }
       }
     },
+    "Navigation" : {
+
+    },
     "Nein" : {
       "localizations" : {
         "en" : {
@@ -2328,6 +2385,9 @@
           }
         }
       }
+    },
+    "Noch keine Einträge im Therapieverlauf." : {
+
     },
     "Notiz" : {
       "localizations" : {
@@ -2621,6 +2681,9 @@
           }
         }
       }
+    },
+    "Regelmäßige Medikamente bleiben als eigener Therapiekontext von Akutmedikation in Tagebucheinträgen getrennt." : {
+
     },
     "ruhig" : {
       "localizations" : {
@@ -3059,6 +3122,7 @@
       }
     },
     "Sync aktivieren" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -3137,6 +3201,9 @@
           }
         }
       }
+    },
+    "Therapie" : {
+
     },
     "Tippe doppelt, um diesen Schritt zu bearbeiten." : {
       "localizations" : {
@@ -3227,6 +3294,12 @@
           }
         }
       }
+    },
+    "Verbindungen" : {
+
+    },
+    "Verlauf" : {
+
     },
     "Version aus der Cloud verwenden" : {
 

--- a/Symi/Sources/App/AppContainer.swift
+++ b/Symi/Sources/App/AppContainer.swift
@@ -93,7 +93,6 @@ final class AppContainer {
                 SettingsController(
                     episodeRepository: episodeRepository,
                     medicationRepository: medicationCatalogRepository,
-                    continuousMedicationRepository: continuousMedicationRepository,
                     syncService: syncService,
                     appLogService: appLogStore,
                     healthService: healthService,
@@ -101,6 +100,11 @@ final class AppContainer {
                 )
             },
             dataExport: dataExport
+        )
+        let therapy = TherapyFeatureDependencies(
+            makeTherapyViewModel: {
+                TherapyViewModel(repository: continuousMedicationRepository)
+            }
         )
         self.featureDependencies = AppFeatureDependencies(
             home: HomeFeatureDependencies(
@@ -120,6 +124,7 @@ final class AppContainer {
             capture: capture,
             history: history,
             insights: insights,
+            therapy: therapy,
             settings: settings,
             dataExport: dataExport
         )
@@ -140,6 +145,7 @@ struct AppFeatureDependencies {
     let capture: CaptureFeatureDependencies
     let history: HistoryFeatureDependencies
     let insights: InsightsFeatureDependencies
+    let therapy: TherapyFeatureDependencies
     let settings: SettingsFeatureDependencies
     let dataExport: DataExportFeatureDependencies
 }
@@ -170,6 +176,11 @@ struct HistoryFeatureDependencies {
 @MainActor
 struct InsightsFeatureDependencies {
     let loadResult: (InsightPeriod) async throws -> InsightResult
+}
+
+@MainActor
+struct TherapyFeatureDependencies {
+    let makeTherapyViewModel: () -> TherapyViewModel
 }
 
 @MainActor

--- a/Symi/Sources/App/AppShellView.swift
+++ b/Symi/Sources/App/AppShellView.swift
@@ -4,6 +4,7 @@ enum Tab: String, CaseIterable, Identifiable {
     case journal
     case insights
     case report
+    case therapy
     case settings
 
     var id: String { rawValue }
@@ -13,6 +14,7 @@ enum Tab: String, CaseIterable, Identifiable {
         case .journal: "Tagebuch"
         case .insights: "Insights"
         case .report: "Bericht"
+        case .therapy: "Therapie"
         case .settings: "Einstellungen"
         }
     }
@@ -22,6 +24,7 @@ enum Tab: String, CaseIterable, Identifiable {
         case .journal: "book.pages"
         case .insights: "sparkle.magnifyingglass"
         case .report: "doc.text"
+        case .therapy: "pills.fill"
         case .settings: "gearshape"
         }
     }
@@ -92,6 +95,16 @@ struct AppShellView: View {
             .tag(Tab.report)
 
             NavigationStack {
+                content(for: .therapy)
+            }
+            .tabItem {
+                Label(Tab.therapy.title, systemImage: Tab.therapy.systemImage)
+            }
+            .accessibilityLabel("\(Tab.therapy.title) Tab")
+            .accessibilityIdentifier("tab-\(Tab.therapy.rawValue)")
+            .tag(Tab.therapy)
+
+            NavigationStack {
                 content(for: .settings)
             }
             .tabItem {
@@ -142,6 +155,8 @@ struct AppShellView: View {
             InsightsView(dependencies: features.insights)
         case .report:
             ReportView(dependencies: features.dataExport)
+        case .therapy:
+            TherapyView(dependencies: features.therapy)
         case .settings:
             SettingsView(dependencies: features.settings, showsCloseButton: false)
         }
@@ -152,7 +167,7 @@ struct AppShellView: View {
         switch tab {
         case .journal, .insights:
             content(for: tab)
-        case .report, .settings:
+        case .report, .therapy, .settings:
             RegularDetailSurface {
                 content(for: tab)
             }

--- a/Symi/Sources/Core/Settings/SettingsCore.swift
+++ b/Symi/Sources/Core/Settings/SettingsCore.swift
@@ -87,17 +87,13 @@ final class SettingsController {
     private(set) var summary = SettingsSummaryData(activeEpisodeCount: 0, trashCount: 0, conflictCount: 0)
     private(set) var deletedEpisodes: [EpisodeRecord] = []
     private(set) var deletedDefinitions: [MedicationDefinitionRecord] = []
-    private(set) var continuousMedications: [ContinuousMedicationRecord] = []
     private(set) var logEntries: [AppLogEntry] = []
     private(set) var logShareURL: URL?
     private(set) var healthSettingsRevision = 0
     var logFilter: AppLogFilter = .all
-    var continuousMedicationEditor: ContinuousMedicationDraft?
-    var continuousMedicationMessage: String?
 
     private let episodeRepository: EpisodeRepository
     private let medicationRepository: MedicationCatalogRepository
-    private let continuousMedicationRepository: ContinuousMedicationRepository
     private let loadSettingsUseCase: LoadSettingsUseCase
     private let restoreDeletedItemUseCase: RestoreDeletedItemUseCase
     private let syncService: SyncService
@@ -112,7 +108,6 @@ final class SettingsController {
     init(
         episodeRepository: EpisodeRepository,
         medicationRepository: MedicationCatalogRepository,
-        continuousMedicationRepository: ContinuousMedicationRepository,
         syncService: SyncService,
         appLogService: AppLogService,
         healthService: HealthService,
@@ -120,7 +115,6 @@ final class SettingsController {
     ) {
         self.episodeRepository = episodeRepository
         self.medicationRepository = medicationRepository
-        self.continuousMedicationRepository = continuousMedicationRepository
         self.syncService = syncService
         self.appLogService = appLogService
         self.healthService = healthService
@@ -170,7 +164,6 @@ final class SettingsController {
 
         let episodeRepository = episodeRepository
         let medicationRepository = medicationRepository
-        let continuousMedicationRepository = continuousMedicationRepository
         loadTask = Task { [weak self] in
             guard let self else { return }
             do {
@@ -178,15 +171,13 @@ final class SettingsController {
                 let deleted = try await Task.detached(priority: .userInitiated) {
                     (
                         try episodeRepository.fetchDeleted(),
-                        try medicationRepository.fetchDeletedDefinitions(),
-                        try continuousMedicationRepository.fetchAll()
+                        try medicationRepository.fetchDeletedDefinitions()
                     )
                 }.value
                 guard !Task.isCancelled else { return }
                 summary = loadedSummary
                 deletedEpisodes = deleted.0
                 deletedDefinitions = deleted.1
-                continuousMedications = deleted.2
             } catch is CancellationError {
                 return
             } catch {
@@ -254,53 +245,6 @@ final class SettingsController {
             }
             guard !Task.isCancelled else { return }
             load()
-        }
-    }
-
-    func presentContinuousMedicationEditor(for medication: ContinuousMedicationRecord?) {
-        continuousMedicationEditor = medication.map(ContinuousMedicationDraft.init(record:)) ?? ContinuousMedicationDraft()
-        continuousMedicationMessage = nil
-    }
-
-    func saveContinuousMedication(_ draft: ContinuousMedicationDraft) async {
-        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedName.isEmpty else {
-            continuousMedicationMessage = "Bitte gib ein Medikament an."
-            return
-        }
-
-        let repository = continuousMedicationRepository
-        var normalizedDraft = draft
-        normalizedDraft.name = trimmedName
-
-        do {
-            _ = try await Task.detached(priority: .userInitiated) {
-                try repository.save(normalizedDraft)
-            }.value
-            continuousMedicationEditor = nil
-            continuousMedicationMessage = nil
-            load()
-        } catch {
-            continuousMedicationMessage = "Dauermedikation konnte nicht gespeichert werden."
-        }
-    }
-
-    func endContinuousMedication(id: UUID) {
-        let repository = continuousMedicationRepository
-        Task { [weak self] in
-            guard let self else { return }
-            guard let medication = continuousMedications.first(where: { $0.id == id }) else { return }
-            var draft = ContinuousMedicationDraft(record: medication)
-            draft.endDate = .now
-
-            do {
-                _ = try await Task.detached(priority: .userInitiated) {
-                    try repository.save(draft)
-                }.value
-                load()
-            } catch {
-                continuousMedicationMessage = "Dauermedikation konnte nicht beendet werden."
-            }
         }
     }
 

--- a/Symi/Sources/Core/Therapy/TherapyDomain.swift
+++ b/Symi/Sources/Core/Therapy/TherapyDomain.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Observation
+
+struct TherapyMedicationItem: Identifiable, Equatable, Sendable {
+    nonisolated let id: UUID
+    nonisolated let name: String
+    nonisolated let dosage: String
+    nonisolated let frequency: String
+    nonisolated let timeText: String
+    nonisolated let isActive: Bool
+    nonisolated let startDate: Date
+    nonisolated let endDate: Date?
+
+    nonisolated init(record: ContinuousMedicationRecord) {
+        id = record.id
+        name = record.name
+        dosage = record.dosage.isEmpty ? "Dosierung nicht angegeben" : record.dosage
+        frequency = record.frequency
+        timeText = Self.timeText(from: record.frequency)
+        isActive = record.isActive
+        startDate = record.startDate
+        endDate = record.endDate
+    }
+
+    private nonisolated static func timeText(from frequency: String) -> String {
+        let pattern = #"\b\d{1,2}:\d{2}\b"#
+        guard let range = frequency.range(of: pattern, options: .regularExpression) else {
+            return "Heute"
+        }
+
+        return String(frequency[range])
+    }
+}
+
+struct LoadTherapyUseCase {
+    let repository: ContinuousMedicationRepository
+
+    func execute() async throws -> [ContinuousMedicationRecord] {
+        let repository = repository
+        return try await Task.detached(priority: .userInitiated) {
+            try repository.fetchAll()
+        }.value
+    }
+}
+
+@MainActor
+@Observable
+final class TherapyViewModel {
+    private(set) var medications: [ContinuousMedicationRecord] = []
+    var medicationEditor: ContinuousMedicationDraft?
+    var message: String?
+
+    private let repository: ContinuousMedicationRepository
+    private let loadTherapyUseCase: LoadTherapyUseCase
+    @ObservationIgnored private var loadTask: Task<Void, Never>?
+
+    init(repository: ContinuousMedicationRepository) {
+        self.repository = repository
+        self.loadTherapyUseCase = LoadTherapyUseCase(repository: repository)
+    }
+
+    var todayMedications: [TherapyMedicationItem] {
+        medications
+            .filter(\.isActive)
+            .map(TherapyMedicationItem.init(record:))
+    }
+
+    var activeMedications: [ContinuousMedicationRecord] {
+        medications.filter(\.isActive)
+    }
+
+    var endedMedications: [ContinuousMedicationRecord] {
+        medications.filter { !$0.isActive }
+    }
+
+    func load() {
+        loadTask?.cancel()
+        loadTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let loaded = try await loadTherapyUseCase.execute()
+                guard !Task.isCancelled else { return }
+                medications = loaded
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                message = "Therapie konnte nicht geladen werden."
+            }
+        }
+    }
+
+    func presentMedicationEditor(for medication: ContinuousMedicationRecord?) {
+        medicationEditor = medication.map(ContinuousMedicationDraft.init(record:)) ?? ContinuousMedicationDraft()
+        message = nil
+    }
+
+    func saveMedication(_ draft: ContinuousMedicationDraft) async {
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else {
+            message = "Bitte gib ein Medikament an."
+            return
+        }
+
+        let repository = repository
+        var normalizedDraft = draft
+        normalizedDraft.name = trimmedName
+
+        do {
+            _ = try await Task.detached(priority: .userInitiated) {
+                try repository.save(normalizedDraft)
+            }.value
+            medicationEditor = nil
+            message = nil
+            load()
+        } catch {
+            message = "Medikationsplan konnte nicht gespeichert werden."
+        }
+    }
+
+    func endMedication(id: UUID) {
+        let repository = repository
+        Task { [weak self] in
+            guard let self else { return }
+            guard let medication = medications.first(where: { $0.id == id }) else { return }
+            var draft = ContinuousMedicationDraft(record: medication)
+            draft.endDate = .now
+
+            do {
+                _ = try await Task.detached(priority: .userInitiated) {
+                    try repository.save(draft)
+                }.value
+                load()
+            } catch {
+                message = "Medikament konnte nicht beendet werden."
+            }
+        }
+    }
+}

--- a/Symi/Sources/Features/Export/ExportView.swift
+++ b/Symi/Sources/Features/Export/ExportView.swift
@@ -36,8 +36,8 @@ struct SettingsView: View {
                         }
 
                         HStack(spacing: SymiSpacing.lg) {
-                            statValue(title: "Ausstehend", value: "\(controller.syncStatus.queuedUpdates)")
-                            statValue(title: "Ungesynct", value: "\(controller.syncStatus.unsyncedRecords)")
+                            statValue(title: "Wartet", value: "\(controller.syncStatus.queuedUpdates)")
+                            statValue(title: "Lokal", value: "\(controller.syncStatus.unsyncedRecords)")
                             statValue(title: "Konflikte", value: "\(controller.conflicts.count)")
                         }
 
@@ -52,7 +52,7 @@ struct SettingsView: View {
                     .brandGroupedRow()
                 }
 
-                Toggle("Sync aktivieren", isOn: Binding(
+                Toggle("iCloud-Synchronisation", isOn: Binding(
                     get: { controller.isSyncEnabled },
                     set: { controller.setSyncEnabled($0) }
                 ))
@@ -61,7 +61,7 @@ struct SettingsView: View {
                 NavigationLink {
                     ManageCloudDataView(dataExportDependencies: dependencies.dataExport, controller: controller)
                 } label: {
-                    Label("Cloud-Daten verwalten", systemImage: "icloud")
+                    Label("iCloud-Daten verwalten", systemImage: "icloud")
                 }
 
                 if !controller.conflicts.isEmpty {
@@ -110,31 +110,19 @@ struct SettingsView: View {
                     .brandGroupedRow()
                 }
             } header: {
-                Text("Gesundheit")
+                Text("Verbindungen")
             } footer: {
                 Text("Apple-Health-Daten bleiben optional. Gelesene Werte werden als Apple-Health-Kontext gekennzeichnet; geschriebene Symptome enthalten keine Notizen.")
             }
 
-            Section("Allgemein") {
-                NavigationLink {
-                    ContinuousMedicationSettingsView(controller: controller)
-                } label: {
-                    Label("Dauermedikation", systemImage: "pills")
-                }
-
-                Link(destination: ProductBranding.websiteURL) {
-                    Label("symiapp.com", systemImage: "link")
-                }
+            Section("Daten & Sicherheit") {
+                BackupSettingsCardView(dependencies: dependencies.dataExport)
 
                 NavigationLink {
                     ProductInformationView(mode: .standard)
                 } label: {
                     Label("Datenschutz und Hinweise", systemImage: "hand.raised")
                 }
-            }
-
-            Section("Daten") {
-                BackupSettingsCardView(dependencies: dependencies.dataExport)
             }
 
             Section {
@@ -144,9 +132,15 @@ struct SettingsView: View {
                 ))
                 .tint(AppTheme.symiPetrol)
             } header: {
-                Text("App verbessern")
+                Text("App")
             } footer: {
                 Text("Symi verwendet nur anonyme Nutzungs- und Diagnosedaten. Tagebuchinhalte, Gesundheitsdaten und personenbezogene Daten werden nicht übertragen. Du kannst diese Einstellung jederzeit ändern.")
+            }
+
+            Section("App-Information") {
+                Link(destination: ProductBranding.websiteURL) {
+                    Label("symiapp.com", systemImage: "link")
+                }
             }
 
             Section("Übersicht") {
@@ -197,8 +191,8 @@ struct SettingsView: View {
         }
 
         return controller.isSyncEnabled
-            ? "Synchronisation ist bereit. Lokale Änderungen bleiben bis zum nächsten Lauf sicher auf dem Gerät."
-            : "Synchronisation ist deaktiviert. Alle Daten bleiben lokal auf diesem Gerät erhalten."
+            ? "iCloud-Synchronisation ist bereit. Lokale Änderungen bleiben bis zum nächsten Abgleich sicher auf dem Gerät."
+            : "iCloud-Synchronisation ist deaktiviert. Alle Daten bleiben lokal auf diesem Gerät erhalten."
     }
 
     private var syncStalenessWarning: String? {
@@ -210,7 +204,7 @@ struct SettingsView: View {
 
     private var syncContractSummary: String {
         [
-            "Cloud-Sync läuft automatisch, sobald er aktiviert ist.",
+            "iCloud-Sync läuft automatisch, sobald er aktiviert ist.",
             "Symi gleicht Änderungen ab, wenn die App geöffnet wird, wenn du Daten änderst oder wenn die Verbindung wieder da ist.",
             "„Jetzt synchronisieren“ startet zusätzlich sofort einen Abgleich."
         ].joined(separator: " ")
@@ -284,201 +278,6 @@ struct SettingsView: View {
         #else
         .topBarLeading
         #endif
-    }
-}
-
-private struct ContinuousMedicationSettingsView: View {
-    @Bindable var controller: SettingsController
-
-    var body: some View {
-        List {
-            Section {
-                Button {
-                    controller.presentContinuousMedicationEditor(for: nil)
-                } label: {
-                    Label("Dauermedikation hinzufügen", systemImage: "plus")
-                }
-            } footer: {
-                Text("Dauermedikationen sind ein eigener Verlaufskontext und bleiben von Akutmedikation in Einträgen getrennt.")
-            }
-
-            Section("Aktuell") {
-                let active = controller.continuousMedications.filter(\.isActive)
-                if active.isEmpty {
-                    Text("Keine aktive Dauermedikation.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(active) { medication in
-                        ContinuousMedicationSettingsRow(
-                            medication: medication,
-                            onEdit: { controller.presentContinuousMedicationEditor(for: medication) },
-                            onEnd: { controller.endContinuousMedication(id: medication.id) }
-                        )
-                    }
-                }
-            }
-
-            Section("Beendet") {
-                let ended = controller.continuousMedications.filter { !$0.isActive }
-                if ended.isEmpty {
-                    Text("Keine beendete Dauermedikation.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(ended) { medication in
-                        ContinuousMedicationSettingsRow(
-                            medication: medication,
-                            onEdit: { controller.presentContinuousMedicationEditor(for: medication) },
-                            onEnd: nil
-                        )
-                    }
-                }
-            }
-
-            if let message = controller.continuousMedicationMessage {
-                Section {
-                    Text(message)
-                        .foregroundStyle(AppTheme.symiCoral)
-                }
-            }
-        }
-        .navigationTitle("Dauermedikation")
-        .brandGroupedScreen()
-        .sheet(item: $controller.continuousMedicationEditor) { draft in
-            NavigationStack {
-                ContinuousMedicationEditorSheet(
-                    draft: draft,
-                    onCancel: { controller.continuousMedicationEditor = nil },
-                    onSave: { draft in
-                        Task {
-                            await controller.saveContinuousMedication(draft)
-                        }
-                    }
-                )
-            }
-            .presentationDetents([.medium, .large])
-        }
-        .task {
-            controller.load()
-        }
-        .refreshable {
-            controller.load()
-        }
-    }
-}
-
-private struct ContinuousMedicationSettingsRow: View {
-    let medication: ContinuousMedicationRecord
-    let onEdit: () -> Void
-    let onEnd: (() -> Void)?
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
-            HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
-                    Text(medication.name)
-                        .font(.headline)
-                    if !medication.detailText.isEmpty {
-                        Text(medication.detailText)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                Spacer()
-
-                Text(medication.isActive ? "Aktiv" : "Beendet")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(medication.isActive ? AppTheme.symiSage : .secondary)
-            }
-
-            Text(dateRangeText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            HStack {
-                Button("Bearbeiten", action: onEdit)
-                if let onEnd {
-                    Button("Beenden", role: .destructive, action: onEnd)
-                }
-            }
-            .buttonStyle(.borderless)
-        }
-        .padding(.vertical, SymiSpacing.xxs)
-        .brandGroupedRow()
-    }
-
-    private var dateRangeText: String {
-        let start = medication.startDate.formatted(date: .abbreviated, time: .omitted)
-        guard let endDate = medication.endDate else {
-            return "Seit \(start)"
-        }
-
-        return "\(start) bis \(endDate.formatted(date: .abbreviated, time: .omitted))"
-    }
-}
-
-private struct ContinuousMedicationEditorSheet: View {
-    @Environment(\.dismiss) private var dismiss
-    @State private var draft: ContinuousMedicationDraft
-    @State private var hasEndDate: Bool
-
-    let onCancel: () -> Void
-    let onSave: (ContinuousMedicationDraft) -> Void
-
-    init(
-        draft: ContinuousMedicationDraft,
-        onCancel: @escaping () -> Void,
-        onSave: @escaping (ContinuousMedicationDraft) -> Void
-    ) {
-        _draft = State(initialValue: draft)
-        _hasEndDate = State(initialValue: draft.endDate != nil)
-        self.onCancel = onCancel
-        self.onSave = onSave
-    }
-
-    var body: some View {
-        Form {
-            Section("Medikament") {
-                TextField("Name", text: $draft.name)
-                    .textInputAutocapitalization(.words)
-                TextField("Dosierung, optional", text: $draft.dosage)
-                TextField("Frequenz, optional", text: $draft.frequency)
-            }
-
-            Section("Zeitraum") {
-                DatePicker("Startdatum", selection: $draft.startDate, displayedComponents: .date)
-                Toggle("Enddatum setzen", isOn: $hasEndDate.animation())
-                if hasEndDate {
-                    DatePicker(
-                        "Enddatum",
-                        selection: Binding(
-                            get: { draft.endDate ?? draft.startDate },
-                            set: { draft.endDate = $0 }
-                        ),
-                        displayedComponents: .date
-                    )
-                }
-            }
-        }
-        .navigationTitle(draft.id == nil ? "Dauermedikation" : "Bearbeiten")
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button("Abbrechen") {
-                    onCancel()
-                    dismiss()
-                }
-            }
-            ToolbarItem(placement: .confirmationAction) {
-                Button("Sichern") {
-                    var normalizedDraft = draft
-                    if !hasEndDate {
-                        normalizedDraft.endDate = nil
-                    }
-                    onSave(normalizedDraft)
-                    dismiss()
-                }
-            }
-        }
     }
 }
 
@@ -957,7 +756,7 @@ private enum ConflictDiffPresenter {
         case .medicationDefinition(let payload):
             return payload.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Medikament" : payload.name
         case .continuousMedication(let payload):
-            return payload.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Dauermedikation" : payload.name
+            return payload.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Regelmäßige Medikation" : payload.name
         }
     }
 
@@ -1002,7 +801,7 @@ private enum ConflictDiffPresenter {
         appendDifference(id: "functionalImpact", label: "Auswirkung im Alltag", myValue: text(local.functionalImpact), cloudValue: text(remote.functionalImpact), to: &differences)
         appendDifference(id: "menstruationStatus", label: "Zyklusstatus", myValue: menstruationStatus(local.menstruationStatus), cloudValue: menstruationStatus(remote.menstruationStatus), to: &differences)
         appendDifference(id: "medications", label: "Medikamente", myValue: medicationList(local.medications), cloudValue: medicationList(remote.medications), to: &differences)
-        appendDifference(id: "continuousMedicationChecks", label: "Dauermedikation", myValue: continuousMedicationChecks(local.continuousMedicationChecks), cloudValue: continuousMedicationChecks(remote.continuousMedicationChecks), to: &differences)
+        appendDifference(id: "continuousMedicationChecks", label: "Regelmäßige Medikation", myValue: continuousMedicationChecks(local.continuousMedicationChecks), cloudValue: continuousMedicationChecks(remote.continuousMedicationChecks), to: &differences)
         appendDifference(id: "weatherSnapshot", label: "Wetter", myValue: weather(local.weatherSnapshot), cloudValue: weather(remote.weatherSnapshot), to: &differences)
         appendDifference(id: "healthContext", label: "Apple-Health-Kontext", myValue: healthContext(local.healthContext), cloudValue: healthContext(remote.healthContext), to: &differences)
     }

--- a/Symi/Sources/Features/Therapy/TherapyView.swift
+++ b/Symi/Sources/Features/Therapy/TherapyView.swift
@@ -1,0 +1,463 @@
+import SwiftUI
+
+struct TherapyView: View {
+    @State private var viewModel: TherapyViewModel
+
+    init(dependencies: TherapyFeatureDependencies) {
+        _viewModel = State(initialValue: dependencies.makeTherapyViewModel())
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: SymiSpacing.dashboardSpacing) {
+                TherapyHeader()
+
+                TherapyOverviewCard()
+
+                TherapyTodaySection(medications: viewModel.todayMedications)
+
+                TherapyNavigationSection(viewModel: viewModel)
+
+                if let message = viewModel.message {
+                    Text(message)
+                        .font(.subheadline)
+                        .foregroundStyle(AppTheme.symiCoral)
+                        .padding(.horizontal, SymiSpacing.xxl)
+                }
+            }
+            .padding(.horizontal, SymiSpacing.groupedHorizontalInset)
+            .padding(.top, SymiSpacing.screenTopInset)
+            .padding(.bottom, SymiSpacing.reportBottomPadding)
+            .wideContent(maxWidth: AppTheme.readableContentMaxWidth)
+        }
+        .navigationTitle("Therapie")
+        .brandScreen()
+        .task {
+            viewModel.load()
+        }
+        .refreshable {
+            viewModel.load()
+        }
+    }
+}
+
+private struct TherapyHeader: View {
+    var body: some View {
+        Text("Therapie")
+            .font(.largeTitle.weight(.bold))
+            .foregroundStyle(AppTheme.symiPetrol)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
+    }
+}
+
+private struct TherapyOverviewCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.sm) {
+            Label("Übersicht", systemImage: "pills.fill")
+                .font(.headline)
+                .foregroundStyle(AppTheme.symiPetrol)
+
+            Text("Deine regelmäßige Medikation im Blick behalten")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .therapyCard()
+    }
+}
+
+private struct TherapyTodaySection: View {
+    let medications: [TherapyMedicationItem]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.md) {
+            Text("Heute")
+                .font(.headline)
+                .foregroundStyle(AppTheme.symiPetrol)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(spacing: SymiSpacing.xs) {
+                if medications.isEmpty {
+                    Text("Keine regelmäßige Medikation für heute.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    ForEach(medications) { medication in
+                        TherapyMedicationRow(medication: medication)
+
+                        if medication.id != medications.last?.id {
+                            Divider()
+                        }
+                    }
+                }
+            }
+            .therapyCard()
+        }
+    }
+}
+
+private struct TherapyMedicationRow: View {
+    let medication: TherapyMedicationItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: SymiSpacing.md) {
+            Image(systemName: "pills")
+                .font(.headline)
+                .foregroundStyle(AppTheme.symiPetrol)
+                .frame(width: SymiSize.entryDetailContextIcon, height: SymiSize.entryDetailContextIcon)
+                .background(AppTheme.symiSage.opacity(SymiOpacity.secondaryFill), in: Circle())
+
+            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+                Text(medication.name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+
+                Text(medication.dosage)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: SymiSpacing.md)
+
+            Text(medication.timeText)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(AppTheme.symiPetrol)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.vertical, SymiSpacing.xs)
+    }
+}
+
+private struct TherapyNavigationSection: View {
+    @Bindable var viewModel: TherapyViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.md) {
+            Text("Navigation")
+                .font(.headline)
+                .foregroundStyle(AppTheme.symiPetrol)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(spacing: SymiSpacing.zero) {
+                NavigationLink {
+                    TherapyPlanView(viewModel: viewModel)
+                } label: {
+                    TherapyNavigationRow(
+                        icon: "list.bullet.clipboard",
+                        title: "Medikationsplan",
+                        subtitle: "Alle Medikamente & Zeitpläne"
+                    )
+                }
+                .buttonStyle(.plain)
+
+                Divider()
+                    .padding(.leading, SymiSize.entryDetailContextIcon + SymiSpacing.md)
+
+                NavigationLink {
+                    TherapyHistoryView(viewModel: viewModel)
+                } label: {
+                    TherapyNavigationRow(
+                        icon: "clock.arrow.circlepath",
+                        title: "Verlauf",
+                        subtitle: "Einnahmen & Anpassungen"
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+            .therapyCard()
+        }
+    }
+}
+
+private struct TherapyNavigationRow: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(spacing: SymiSpacing.md) {
+            Image(systemName: icon)
+                .font(.headline)
+                .foregroundStyle(AppTheme.symiPetrol)
+                .frame(width: SymiSize.entryDetailContextIcon, height: SymiSize.entryDetailContextIcon)
+
+            VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, SymiSpacing.md)
+    }
+}
+
+struct TherapyPlanView: View {
+    @Bindable var viewModel: TherapyViewModel
+
+    var body: some View {
+        List {
+            Section {
+                Button {
+                    viewModel.presentMedicationEditor(for: nil)
+                } label: {
+                    Label("Medikament hinzufügen", systemImage: "plus")
+                }
+            } footer: {
+                Text("Regelmäßige Medikamente bleiben als eigener Therapiekontext von Akutmedikation in Tagebucheinträgen getrennt.")
+            }
+
+            Section("Aktuell") {
+                if viewModel.activeMedications.isEmpty {
+                    Text("Keine aktive regelmäßige Medikation.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.activeMedications) { medication in
+                        TherapyPlanMedicationRow(
+                            medication: medication,
+                            onEdit: { viewModel.presentMedicationEditor(for: medication) },
+                            onEnd: { viewModel.endMedication(id: medication.id) }
+                        )
+                    }
+                }
+            }
+
+            Section("Beendet") {
+                if viewModel.endedMedications.isEmpty {
+                    Text("Keine beendete regelmäßige Medikation.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.endedMedications) { medication in
+                        TherapyPlanMedicationRow(
+                            medication: medication,
+                            onEdit: { viewModel.presentMedicationEditor(for: medication) },
+                            onEnd: nil
+                        )
+                    }
+                }
+            }
+
+            if let message = viewModel.message {
+                Section {
+                    Text(message)
+                        .foregroundStyle(AppTheme.symiCoral)
+                }
+            }
+        }
+        .navigationTitle("Medikationsplan")
+        .brandGroupedScreen()
+        .sheet(item: $viewModel.medicationEditor) { draft in
+            NavigationStack {
+                TherapyMedicationEditorSheet(
+                    draft: draft,
+                    onCancel: { viewModel.medicationEditor = nil },
+                    onSave: { draft in
+                        Task {
+                            await viewModel.saveMedication(draft)
+                        }
+                    }
+                )
+            }
+            .presentationDetents([.medium, .large])
+        }
+        .task {
+            viewModel.load()
+        }
+        .refreshable {
+            viewModel.load()
+        }
+    }
+}
+
+struct TherapyHistoryView: View {
+    @Bindable var viewModel: TherapyViewModel
+
+    var body: some View {
+        List {
+            Section {
+                if viewModel.medications.isEmpty {
+                    Text("Noch keine Einträge im Therapieverlauf.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.medications) { medication in
+                        VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+                            Text(medication.name)
+                                .font(.headline)
+                            Text(medication.detailText.isEmpty ? "Keine Dosierung oder Frequenz angegeben." : medication.detailText)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                            Text(dateRangeText(for: medication))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, SymiSpacing.xxs)
+                        .brandGroupedRow()
+                    }
+                }
+            } header: {
+                Text("Einnahmen & Anpassungen")
+            } footer: {
+                Text("Hier siehst du den Verlauf deiner regelmäßigen Medikation. Dokumentierte Einnahmen aus Tagebucheinträgen bleiben weiterhin im Tagebuchkontext.")
+            }
+        }
+        .navigationTitle("Verlauf")
+        .brandGroupedScreen()
+        .task {
+            viewModel.load()
+        }
+        .refreshable {
+            viewModel.load()
+        }
+    }
+
+    private func dateRangeText(for medication: ContinuousMedicationRecord) -> String {
+        let start = medication.startDate.formatted(date: .abbreviated, time: .omitted)
+        guard let endDate = medication.endDate else {
+            return "Seit \(start)"
+        }
+
+        return "\(start) bis \(endDate.formatted(date: .abbreviated, time: .omitted))"
+    }
+}
+
+private struct TherapyPlanMedicationRow: View {
+    let medication: ContinuousMedicationRecord
+    let onEdit: () -> Void
+    let onEnd: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.xs) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+                    Text(medication.name)
+                        .font(.headline)
+                    if !medication.detailText.isEmpty {
+                        Text(medication.detailText)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                Text(medication.isActive ? "Aktiv" : "Beendet")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(medication.isActive ? AppTheme.symiSage : .secondary)
+            }
+
+            Text(dateRangeText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Button("Bearbeiten", action: onEdit)
+                if let onEnd {
+                    Button("Beenden", role: .destructive, action: onEnd)
+                }
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(.vertical, SymiSpacing.xxs)
+        .brandGroupedRow()
+    }
+
+    private var dateRangeText: String {
+        let start = medication.startDate.formatted(date: .abbreviated, time: .omitted)
+        guard let endDate = medication.endDate else {
+            return "Seit \(start)"
+        }
+
+        return "\(start) bis \(endDate.formatted(date: .abbreviated, time: .omitted))"
+    }
+}
+
+private struct TherapyMedicationEditorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var draft: ContinuousMedicationDraft
+    @State private var hasEndDate: Bool
+
+    let onCancel: () -> Void
+    let onSave: (ContinuousMedicationDraft) -> Void
+
+    init(
+        draft: ContinuousMedicationDraft,
+        onCancel: @escaping () -> Void,
+        onSave: @escaping (ContinuousMedicationDraft) -> Void
+    ) {
+        _draft = State(initialValue: draft)
+        _hasEndDate = State(initialValue: draft.endDate != nil)
+        self.onCancel = onCancel
+        self.onSave = onSave
+    }
+
+    var body: some View {
+        Form {
+            Section("Medikament") {
+                TextField("Name", text: $draft.name)
+                    .textInputAutocapitalization(.words)
+                TextField("Dosierung, optional", text: $draft.dosage)
+                TextField("Frequenz oder Uhrzeit, optional", text: $draft.frequency)
+            }
+
+            Section("Zeitraum") {
+                DatePicker("Startdatum", selection: $draft.startDate, displayedComponents: .date)
+                Toggle("Enddatum setzen", isOn: $hasEndDate.animation())
+                if hasEndDate {
+                    DatePicker(
+                        "Enddatum",
+                        selection: Binding(
+                            get: { draft.endDate ?? draft.startDate },
+                            set: { draft.endDate = $0 }
+                        ),
+                        displayedComponents: .date
+                    )
+                }
+            }
+        }
+        .navigationTitle(draft.id == nil ? "Medikament" : "Bearbeiten")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Abbrechen") {
+                    onCancel()
+                    dismiss()
+                }
+            }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Sichern") {
+                    var normalizedDraft = draft
+                    if !hasEndDate {
+                        normalizedDraft.endDate = nil
+                    }
+                    onSave(normalizedDraft)
+                    dismiss()
+                }
+            }
+        }
+    }
+}
+
+private struct TherapyCardModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding(SymiSpacing.xxl)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(SymiColors.card.color, in: RoundedRectangle(cornerRadius: SymiRadius.card, style: .continuous))
+            .shadow(color: SymiColors.primaryPetrol.color.opacity(SymiOpacity.hairline), radius: 16, x: 0, y: 8)
+    }
+}
+
+private extension View {
+    func therapyCard() -> some View {
+        modifier(TherapyCardModifier())
+    }
+}

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -22,7 +22,7 @@ public enum SyncServiceState: String, Codable, CaseIterable, Sendable {
         case .conflict:
             "Konflikt"
         case .noICloudAccount:
-            "Kein iCloud-Account"
+            "iCloud ist derzeit nicht verfügbar"
         case .offline:
             "Offline"
         }


### PR DESCRIPTION
## Summary

- Adds a new main `Therapie` tab between `Bericht` and `Einstellungen`.
- Moves regular medication management into a separate Therapy domain and view model.
- Cleans Settings down to system configuration: synchronisation, connections, data/security, app settings, and overview.
- Updates user-facing sync wording and string catalog entries.

Related to #59.

## Validation

- `xcodebuild -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath build/CodexDerivedData build`
- `xcodebuild test -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath build/CodexDerivedData`