### PR TITLE
Remove custom localization helpers

### DIFF
--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -27,13 +27,13 @@ enum EntryStartedAtPreset: String, CaseIterable, Identifiable, Sendable {
     var title: String {
         switch self {
         case .now:
-            EntryFlowLocalized.text(de: "Jetzt", en: "Now")
+            "Jetzt"
         case .oneHourAgo:
-            EntryFlowLocalized.text(de: "Vor 1 Std.", en: "1 hr ago")
+            "Vor 1 Std."
         case .todayMorning:
-            EntryFlowLocalized.text(de: "Heute Morgen", en: "This morning")
+            "Heute Morgen"
         case .custom:
-            EntryFlowLocalized.text(de: "Anderer Zeitpunkt", en: "Different time")
+            "Anderer Zeitpunkt"
         }
     }
 
@@ -115,16 +115,6 @@ enum EntryDayPartPreset: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
-enum EntryFlowLocalized {
-    static var isEnglish: Bool {
-        Locale.current.language.languageCode?.identifier == "en"
-    }
-
-    static func text(de german: String, en english: String) -> String {
-        isEnglish ? english : german
-    }
-}
-
 @MainActor
 @Observable
 final class EntryContinuousMedicationController {
@@ -161,31 +151,31 @@ final class EntryFlowCoordinator {
     static let steps: [EntryFlowStep] = [.headache, .medication, .triggers, .note, .review]
 
     let symptomOptions = [
-        EntryFlowLocalized.text(de: "Übelkeit", en: "Nausea"),
-        EntryFlowLocalized.text(de: "Lichtempfindlichkeit", en: "Light sensitivity"),
-        EntryFlowLocalized.text(de: "Geräuschempfindlichkeit", en: "Sound sensitivity"),
+        "Übelkeit",
+        "Lichtempfindlichkeit",
+        "Geräuschempfindlichkeit",
         "Aura",
-        EntryFlowLocalized.text(de: "Kiefer-/Aufbissschmerz", en: "Jaw/bite pain"),
-        EntryFlowLocalized.text(de: "Pochen, Pulsieren", en: "Throbbing, pulsing")
+        "Kiefer-/Aufbissschmerz",
+        "Pochen, Pulsieren"
     ]
     let triggerOptions = [
-        EntryFlowLocalized.text(de: "Wetter", en: "Weather"),
+        "Wetter",
         "Stress",
-        EntryFlowLocalized.text(de: "Erhöhte Arbeitsbelastung", en: "High workload"),
-        EntryFlowLocalized.text(de: "Regel", en: "Period"),
-        EntryFlowLocalized.text(de: "Schlafdauer", en: "Sleep duration"),
-        EntryFlowLocalized.text(de: "Sport", en: "Exercise"),
-        EntryFlowLocalized.text(de: "Ernährung", en: "Nutrition"),
-        EntryFlowLocalized.text(de: "Bildschirmzeit", en: "Screen time"),
-        EntryFlowLocalized.text(de: "Bewegung", en: "Movement"),
-        EntryFlowLocalized.text(de: "Flüssigkeit", en: "Hydration")
+        "Erhöhte Arbeitsbelastung",
+        "Regel",
+        "Schlafdauer",
+        "Sport",
+        "Ernährung",
+        "Bildschirmzeit",
+        "Bewegung",
+        "Flüssigkeit"
     ]
     let painLocationOptions = [
-        EntryFlowLocalized.text(de: "Stirn", en: "Forehead"),
-        EntryFlowLocalized.text(de: "Schläfen", en: "Temples"),
-        EntryFlowLocalized.text(de: "Nacken", en: "Neck"),
-        EntryFlowLocalized.text(de: "Einseitig", en: "One side"),
-        EntryFlowLocalized.text(de: "Überall", en: "All over")
+        "Stirn",
+        "Schläfen",
+        "Nacken",
+        "Einseitig",
+        "Überall"
     ]
     let medicationController: EpisodeMedicationSelectionController
     let continuousMedicationController: EntryContinuousMedicationController

--- a/Symi/Sources/Core/Insights/InsightCore.swift
+++ b/Symi/Sources/Core/Insights/InsightCore.swift
@@ -19,11 +19,11 @@ enum InsightCategory: String, CaseIterable, Equatable, Sendable {
     var displayTitle: String {
         switch self {
         case .weekdayPattern:
-            InsightLocalized.text(de: "Wochentag", en: "Weekday")
+            "Wochentag"
         case .triggerCorrelation:
             "Trigger"
         case .averageIntensity:
-            InsightLocalized.text(de: "Durchschnitt", en: "Average")
+            "Durchschnitt"
         case .trend:
             "Trend"
         }
@@ -86,11 +86,11 @@ enum InsightPeriod: String, CaseIterable, Identifiable, Equatable, Sendable {
     var displayTitle: String {
         switch self {
         case .sevenDays:
-            InsightLocalized.text(de: "7 Tage", en: "7 days")
+            "7 Tage"
         case .thirtyDays:
-            InsightLocalized.text(de: "30 Tage", en: "30 days")
+            "30 Tage"
         case .threeMonths:
-            InsightLocalized.text(de: "3 Monate", en: "3 months")
+            "3 Monate"
         }
     }
 
@@ -111,16 +111,6 @@ enum InsightPeriod: String, CaseIterable, Identifiable, Equatable, Sendable {
         }
 
         return calendar.date(byAdding: component, value: value, to: referenceDate) ?? referenceDate
-    }
-}
-
-enum InsightLocalized {
-    static var isEnglish: Bool {
-        Locale.current.language.languageCode?.identifier == "en"
-    }
-
-    static func text(de german: String, en english: String) -> String {
-        isEnglish ? english : german
     }
 }
 
@@ -209,18 +199,15 @@ extension InsightEmptyState {
         if qualifiedEpisodeCount == 0 {
             self = InsightEmptyState(
                 reason: .noQualifiedEntries,
-                title: InsightLocalized.text(de: "Noch nicht genug Einträge für Muster", en: "Not enough entries for patterns yet"),
-                message: InsightLocalized.text(
-                    de: "Wenn du einige Schmerz- oder Migräneeinträge erfasst hast, zeigt Symi hier vorsichtige Hinweise.",
-                    en: "Once you have logged a few pain or migraine entries, Symi shows careful hints here."
-                ),
+                title: "Noch nicht genug Einträge für Muster",
+                message: "Wenn du einige Schmerz- oder Migräneeinträge erfasst hast, zeigt Symi hier vorsichtige Hinweise.",
                 requiredEntryCount: minimumCount,
                 availableEntryCount: qualifiedEpisodeCount
             )
         } else {
             self = InsightEmptyState(
                 reason: .notEnoughQualifiedEntries(required: minimumCount, available: qualifiedEpisodeCount),
-                title: InsightLocalized.text(de: "Noch nicht genug Einträge für Muster", en: "Not enough entries for patterns yet"),
+                title: "Noch nicht genug Einträge für Muster",
                 message: "\(qualifiedEpisodeCount) von \(minimumCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden. Sobald mehr Daten da sind, sucht Symi nach vorsichtigen Mustern.",
                 requiredEntryCount: minimumCount,
                 availableEntryCount: qualifiedEpisodeCount
@@ -231,11 +218,8 @@ extension InsightEmptyState {
     static func noVisibleInsights(qualifiedEpisodeCount: Int, minimumCount: Int) -> InsightEmptyState {
         InsightEmptyState(
             reason: .noVisibleInsights,
-            title: InsightLocalized.text(de: "Noch kein vorsichtiges Muster sichtbar", en: "No careful pattern visible yet"),
-            message: InsightLocalized.text(
-                de: "Es gibt genug Einträge, aber noch nichts, das in deinen Einträgen auffällig genug ist.",
-                en: "There are enough entries, but nothing in them stands out clearly enough yet."
-            ),
+            title: "Noch kein vorsichtiges Muster sichtbar",
+            message: "Es gibt genug Einträge, aber noch nichts, das in deinen Einträgen auffällig genug ist.",
             requiredEntryCount: minimumCount,
             availableEntryCount: qualifiedEpisodeCount
         )
@@ -893,21 +877,21 @@ enum InsightFormatter {
     private static func weekdayName(for weekday: Int) -> String {
         switch weekday {
         case 1:
-            InsightLocalized.text(de: "Sonntag", en: "Sunday")
+            "Sonntag"
         case 2:
-            InsightLocalized.text(de: "Montag", en: "Monday")
+            "Montag"
         case 3:
-            InsightLocalized.text(de: "Dienstag", en: "Tuesday")
+            "Dienstag"
         case 4:
-            InsightLocalized.text(de: "Mittwoch", en: "Wednesday")
+            "Mittwoch"
         case 5:
-            InsightLocalized.text(de: "Donnerstag", en: "Thursday")
+            "Donnerstag"
         case 6:
-            InsightLocalized.text(de: "Freitag", en: "Friday")
+            "Freitag"
         case 7:
-            InsightLocalized.text(de: "Samstag", en: "Saturday")
+            "Samstag"
         default:
-            InsightLocalized.text(de: "ein Wochentag", en: "a weekday")
+            "ein Wochentag"
         }
     }
 

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -146,11 +146,11 @@ private struct EntryHeadacheStepView: View {
     @State private var isDatePickerExpanded = false
     @State private var dateFeedbackTrigger = 0
     private let visiblePainLocations: [EntryPainLocationOption] = [
-        .init(title: EntryFlowLocalized.text(de: "Stirn", en: "Forehead"), imageName: "PainLocationForehead"),
-        .init(title: EntryFlowLocalized.text(de: "Schläfen", en: "Temples"), imageName: "PainLocationTemples"),
+        .init(title: "Stirn", imageName: "PainLocationForehead"),
+        .init(title: "Schläfen", imageName: "PainLocationTemples"),
         // .init(title: "Nacken", imageName: "PainLocationNeck"),
-        .init(title: EntryFlowLocalized.text(de: "Einseitig", en: "One side"), imageName: "PainLocationLeftTemple"),
-        .init(title: EntryFlowLocalized.text(de: "Überall", en: "All over"), imageName: "PainLocationCrown")
+        .init(title: "Einseitig", imageName: "PainLocationLeftTemple"),
+        .init(title: "Überall", imageName: "PainLocationCrown")
     ]
 
     var body: some View {
@@ -162,7 +162,7 @@ private struct EntryHeadacheStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            InputFlowFieldGroup(title: EntryFlowLocalized.text(de: "Wie stark sind die Schmerzen?", en: "How strong is the pain?")) {
+            InputFlowFieldGroup(title: "Wie stark sind die Schmerzen?") {
                 InputFlowHeadacheOptionGrid {
                     ForEach(PainIntensityLevel.selectableCases, id: \.self) { level in
                         PainIntensitySelectionTile(
@@ -178,7 +178,7 @@ private struct EntryHeadacheStepView: View {
                 .accessibilityIdentifier("entry-intensity-card")
             }
 
-            InputFlowFieldGroup(title: EntryFlowLocalized.text(de: "Wo spürst du den Schmerz?", en: "Where do you feel the pain?")) {
+            InputFlowFieldGroup(title: "Wo spürst du den Schmerz?") {
                 InputFlowHeadacheOptionGrid {
                     ForEach(visiblePainLocations) { location in
                         PainLocationSelectionTile(
@@ -220,10 +220,10 @@ private struct EntryHeadacheStepView: View {
         } footer: {
             EntryFlowFooter(
                 isSaving: coordinator.isSaving,
-                primaryTitle: EntryFlowLocalized.text(de: "Weiter", en: "Continue"),
+                primaryTitle: "Weiter",
                 primarySystemImage: "arrow.right",
                 primaryIdentifier: "entry-flow-next",
-                secondaryTitle: EntryFlowLocalized.text(de: "Nur Kopfschmerz speichern", en: "Save headache only"),
+                secondaryTitle: "Nur Kopfschmerz speichern",
                 secondaryIdentifier: "entry-flow-save-headache-only",
                 isPrimaryDisabled: !coordinator.draft.hasSelectedIntensity,
                 isSecondaryDisabled: !coordinator.draft.hasSelectedIntensity,
@@ -270,7 +270,7 @@ private struct EntryHeadacheStepView: View {
             return
         }
 
-        coordinator.draft.selectedPainLocations = [EntryFlowLocalized.text(de: "Schläfen", en: "Temples")]
+        coordinator.draft.selectedPainLocations = ["Schläfen"]
     }
 }
 
@@ -302,7 +302,7 @@ private struct EntryDayPartFieldGroup<Content: View>: View {
         VStack(alignment: .leading, spacing: SymiSpacing.lg) {
             VStack(alignment: .leading, spacing: SymiSpacing.xs) {
                 HStack(spacing: SymiSpacing.sm) {
-                    Text(EntryFlowLocalized.text(de: "Tagesbereich", en: "Time of day"))
+                    Text("Tagesbereich")
                         .font(SymiTypography.flowSectionTitle)
                         .foregroundStyle(AppTheme.symiTextSecondary)
 
@@ -509,8 +509,8 @@ private struct PainLocationSelectionTile: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(option.title)
-        .accessibilityValue(isSelected ? EntryFlowLocalized.text(de: "Ausgewählt", en: "Selected") : EntryFlowLocalized.text(de: "Nicht ausgewählt", en: "Not selected"))
-        .accessibilityHint(isSelected ? EntryFlowLocalized.text(de: "Entfernt die Auswahl.", en: "Removes the selection.") : EntryFlowLocalized.text(de: "Wählt diese Option aus.", en: "Selects this option."))
+        .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
+        .accessibilityHint(isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus.")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
         .accessibilityIdentifier(accessibilityIdentifier)
     }
@@ -534,20 +534,20 @@ private struct EntryMedicationStepView: View {
     let onCancel: () -> Void
 
     @State private var selectedDosage = "400 mg"
-    @State private var selectedTakenAt = EntryFlowLocalized.text(de: "Jetzt", en: "Now")
+    @State private var selectedTakenAt = "Jetzt"
 
     private let medicationOptions: [EntryMedicationOption] = [
         EntryMedicationOption(title: "Ibuprofen", symbolName: "pills", category: .nsar, defaultDosage: "400 mg"),
         EntryMedicationOption(title: "Triptan", symbolName: "capsule", category: .triptan, defaultDosage: ""),
         EntryMedicationOption(title: "Paracetamol", symbolName: "syringe", category: .paracetamol, defaultDosage: "500 mg"),
-        EntryMedicationOption(title: EntryFlowLocalized.text(de: "Andere", en: "Other"), symbolName: "ellipsis", category: .other, defaultDosage: "")
+        EntryMedicationOption(title: "Andere", symbolName: "ellipsis", category: .other, defaultDosage: "")
     ]
-    private let dosageOptions = ["200 mg", "400 mg", "600 mg", EntryFlowLocalized.text(de: "Andere", en: "Other")]
+    private let dosageOptions = ["200 mg", "400 mg", "600 mg", "Andere"]
     private let takenAtOptions = [
-        EntryFlowLocalized.text(de: "Jetzt", en: "Now"),
-        EntryFlowLocalized.text(de: "Vor 1 Std.", en: "1 hr ago"),
-        EntryFlowLocalized.text(de: "Vor 2 Std.", en: "2 hrs ago"),
-        EntryFlowLocalized.text(de: "Anderer Zeitpunkt", en: "Different time")
+        "Jetzt",
+        "Vor 1 Std.",
+        "Vor 2 Std.",
+        "Anderer Zeitpunkt"
     ]
 
     var body: some View {
@@ -560,7 +560,7 @@ private struct EntryMedicationStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            InputFlowFieldGroup(title: EntryFlowLocalized.text(de: "Welche Medikation?", en: "Which medication?")) {
+            InputFlowFieldGroup(title: "Welche Medikation?") {
                 VStack(spacing: SymiSpacing.tileSpacing) {
                     InputFlowTileGrid(minimumColumnWidth: SymiSize.flowTwoColumnTileGridMinWidth) {
                         ForEach(medicationOptions) { option in
@@ -578,8 +578,8 @@ private struct EntryMedicationStepView: View {
 
                     InputFlowSelectionTile(
                         title: coordinator.draft.continuousMedicationChecks.isEmpty
-                            ? EntryFlowLocalized.text(de: "Keine Medikation", en: "No medication")
-                            : EntryFlowLocalized.text(de: "Keine weitere Medikation", en: "No more medication"),
+                            ? "Keine Medikation"
+                            : "Keine weitere Medikation",
                         systemImage: "slash.circle",
                         isSelected: medicationController.selectedMedications.isEmpty,
                         theme: .medication,
@@ -590,7 +590,7 @@ private struct EntryMedicationStepView: View {
                 }
             }
 
-            InputFlowFieldGroup(title: EntryFlowLocalized.text(de: "Dosierung", en: "Dosage")) {
+            InputFlowFieldGroup(title: "Dosierung") {
                 InputFlowPillGrid {
                     ForEach(dosageOptions, id: \.self) { dosage in
                         InputFlowPillOption(
@@ -605,7 +605,7 @@ private struct EntryMedicationStepView: View {
                 }
             }
 
-            InputFlowFieldGroup(title: EntryFlowLocalized.text(de: "Wann hast du es eingenommen?", en: "When did you take it?")) {
+            InputFlowFieldGroup(title: "Wann hast du es eingenommen?") {
                 InputFlowPillGrid {
                     ForEach(takenAtOptions, id: \.self) { option in
                         InputFlowPillOption(
@@ -626,10 +626,10 @@ private struct EntryMedicationStepView: View {
         } footer: {
             EntryFlowFooter(
                 isSaving: coordinator.isSaving,
-                primaryTitle: EntryFlowLocalized.text(de: "Weiter", en: "Continue"),
+                primaryTitle: "Weiter",
                 primarySystemImage: "arrow.right",
                 primaryIdentifier: "entry-flow-next",
-                secondaryTitle: EntryFlowLocalized.text(de: "Überspringen", en: "Skip"),
+                secondaryTitle: "Überspringen",
                 secondaryIdentifier: "entry-flow-skip",
                 onPrimary: coordinator.continueToNextStep,
                 onSecondary: coordinator.skipCurrentStep
@@ -681,12 +681,12 @@ private struct EntryMedicationStepView: View {
     }
 
     private func selectMedication(_ option: EntryMedicationOption, controller: EpisodeMedicationSelectionController) {
-        if option.title == EntryFlowLocalized.text(de: "Andere", en: "Other") {
+        if option.title == "Andere" {
             controller.presentEditor(for: nil)
             return
         }
 
-        let dosage = selectedDosage == EntryFlowLocalized.text(de: "Andere", en: "Other") ? option.defaultDosage : selectedDosage
+        let dosage = selectedDosage == "Andere" ? option.defaultDosage : selectedDosage
         controller.toggleMedicationSelection(
             named: option.title,
             fallbackCategory: option.category,
@@ -702,13 +702,13 @@ private struct EntryTriggersStepView: View {
 
     private let triggerOptions: [EntryTriggerOption] = [
         EntryTriggerOption(title: "Stress", symbolName: "brain.head.profile"),
-        EntryTriggerOption(title: EntryFlowLocalized.text(de: "Wetter", en: "Weather"), symbolName: "cloud.sun"),
-        EntryTriggerOption(title: EntryFlowLocalized.text(de: "Schlaf", en: "Sleep"), symbolName: "moon"),
-        EntryTriggerOption(title: EntryFlowLocalized.text(de: "Ernährung", en: "Nutrition"), symbolName: "fork.knife.circle"),
-        EntryTriggerOption(title: EntryFlowLocalized.text(de: "Bildschirmzeit", en: "Screen time"), symbolName: "ipad.landscape.and.iphone"),
-        EntryTriggerOption(title: EntryFlowLocalized.text(de: "Zyklus", en: "Cycle"), symbolName: "drop"),
-        EntryTriggerOption(title: EntryFlowLocalized.text(de: "Bewegung", en: "Movement"), symbolName: "figure.run"),
-        EntryTriggerOption(title: EntryFlowLocalized.text(de: "Flüssigkeit", en: "Hydration"), symbolName: "waterbottle")
+        EntryTriggerOption(title: "Wetter", symbolName: "cloud.sun"),
+        EntryTriggerOption(title: "Schlaf", symbolName: "moon"),
+        EntryTriggerOption(title: "Ernährung", symbolName: "fork.knife.circle"),
+        EntryTriggerOption(title: "Bildschirmzeit", symbolName: "ipad.landscape.and.iphone"),
+        EntryTriggerOption(title: "Zyklus", symbolName: "drop"),
+        EntryTriggerOption(title: "Bewegung", symbolName: "figure.run"),
+        EntryTriggerOption(title: "Flüssigkeit", symbolName: "waterbottle")
     ]
 
     var body: some View {
@@ -720,7 +720,7 @@ private struct EntryTriggersStepView: View {
             onBack: onBack,
             onCancel: onCancel
         ) {
-            InputFlowFieldGroup(title: EntryFlowLocalized.text(de: "Wähle alle passenden aus.", en: "Select all that apply.")) {
+            InputFlowFieldGroup(title: "Wähle alle passenden aus.") {
                 InputFlowTileGrid(minimumColumnWidth: SymiSize.flowTwoColumnTileGridMinWidth) {
                     ForEach(triggerOptions) { option in
                         InputFlowSelectionTile(
@@ -736,14 +736,14 @@ private struct EntryTriggersStepView: View {
                 }
             }
 
-            EntryInfoBanner(text: EntryFlowLocalized.text(de: "Du kannst mehrere auswählen.", en: "You can select multiple options."))
+            EntryInfoBanner(text: "Du kannst mehrere auswählen.")
         } footer: {
             EntryFlowFooter(
                 isSaving: coordinator.isSaving,
-                primaryTitle: EntryFlowLocalized.text(de: "Weiter", en: "Continue"),
+                primaryTitle: "Weiter",
                 primarySystemImage: "arrow.right",
                 primaryIdentifier: "entry-flow-next",
-                secondaryTitle: EntryFlowLocalized.text(de: "Überspringen", en: "Skip"),
+                secondaryTitle: "Überspringen",
                 secondaryIdentifier: "entry-flow-skip",
                 onPrimary: coordinator.continueToNextStep,
                 onSecondary: coordinator.skipCurrentStep

--- a/Symi/Sources/Features/Export/PDFExportWriter.swift
+++ b/Symi/Sources/Features/Export/PDFExportWriter.swift
@@ -172,7 +172,7 @@ nonisolated enum PDFExportWriter {
     }
 
     private static func localized(_ key: String) -> String {
-        String(localized: String.LocalizationValue(key), bundle: .main)
+        key
     }
 
     private static func formatted(_ key: String, _ arguments: CVarArg...) -> String {

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -62,8 +62,8 @@ struct HomeView: View {
 
                 if homeState == .insights {
                     HomePrimaryButton(
-                        title: HomeLocalized.text(de: "Neuer Eintrag", en: "New entry"),
-                        subtitle: HomeLocalized.text(de: "Starte einen neuen Eintrag", en: "Start a new entry")
+                        title: "Neuer Eintrag",
+                        subtitle: "Starte einen neuen Eintrag"
                     ) {
                         isPresentingEpisodeEditor = true
                     }
@@ -109,8 +109,8 @@ struct HomeView: View {
 
                 if homeState == .insights {
                     HomePrimaryButton(
-                        title: HomeLocalized.text(de: "Neuer Eintrag", en: "New entry"),
-                        subtitle: HomeLocalized.text(de: "Starte einen neuen Eintrag", en: "Start a new entry")
+                        title: "Neuer Eintrag",
+                        subtitle: "Starte einen neuen Eintrag"
                     ) {
                         isPresentingEpisodeEditor = true
                     }
@@ -181,16 +181,6 @@ struct HomeView: View {
         return HomeInsightCardData.makeCards(from: patternPreviewData.cards)
     }
 
-}
-
-private enum HomeLocalized {
-    static var isEnglish: Bool {
-        Locale.current.language.languageCode?.identifier == "en"
-    }
-
-    static func text(de german: String, en english: String) -> String {
-        isEnglish ? english : german
-    }
 }
 
 enum HomeState: Equatable {
@@ -342,11 +332,11 @@ private struct OnboardingCard: View {
     private var primaryActionTitle: String {
         switch state {
         case .empty:
-            HomeLocalized.text(de: "Jetzt eintragen", en: "Log now")
+            "Jetzt eintragen"
         case .early:
-            HomeLocalized.text(de: "Weiter eintragen", en: "Keep logging")
+            "Weiter eintragen"
         case .insights:
-            HomeLocalized.text(de: "Neuer Eintrag", en: "New entry")
+            "Neuer Eintrag"
         }
     }
 }
@@ -415,12 +405,12 @@ private struct OnboardingContextBlock: View {
 
             VStack(alignment: .leading, spacing: HomeRhythm.sm) {
                 contextItem(
-                    title: HomeLocalized.text(de: "Achte auf mögliche Auslöser", en: "Watch for possible triggers"),
-                    subtitle: HomeLocalized.text(de: "z. B. Stress, Schlaf oder Wetter", en: "e.g. stress, sleep, or weather")
+                    title: "Achte auf mögliche Auslöser",
+                    subtitle: "z. B. Stress, Schlaf oder Wetter"
                 )
                 contextItem(
-                    title: HomeLocalized.text(de: "Notiere, was noch Einfluss hat", en: "Note what else has an effect"),
-                    subtitle: HomeLocalized.text(de: "z. B. Medikamente oder Zyklus", en: "e.g. medication or cycle")
+                    title: "Notiere, was noch Einfluss hat",
+                    subtitle: "z. B. Medikamente oder Zyklus"
                 )
             }
         }
@@ -618,27 +608,21 @@ private struct HomeInsightCardData: Identifiable, Equatable {
     static let fallbackCards = [
         HomeInsightCardData(
             id: "evening",
-            title: HomeLocalized.text(
-                de: "Bei dir treten Schmerzen abends häufiger auf",
-                en: "Your pain appears more often in the evening"
-            ),
-            subtitle: HomeLocalized.text(de: "Vor allem zwischen 18–22 Uhr", en: "Mostly between 6-10 PM"),
+            title: "Bei dir treten Schmerzen abends häufiger auf",
+            subtitle: "Vor allem zwischen 18–22 Uhr",
             systemImage: "moon.stars.fill",
             tint: .petrol
         ),
         HomeInsightCardData(
             id: "sleep",
-            title: HomeLocalized.text(
-                de: "Weniger Schlaf erhöht deine Schmerzintensität",
-                en: "Less sleep raises your pain intensity"
-            ),
-            subtitle: HomeLocalized.text(de: "Unter 6h -> +1.3 Punkte", en: "Under 6h -> +1.3 points"),
+            title: "Weniger Schlaf erhöht deine Schmerzintensität",
+            subtitle: "Unter 6h -> +1.3 Punkte",
             systemImage: "bed.double.fill",
             tint: .sage
         ),
         HomeInsightCardData(
             id: "medication",
-            title: HomeLocalized.text(de: "Medikation hilft in 72% der Fälle", en: "Medication helps in 72% of cases"),
+            title: "Medikation hilft in 72% der Fälle",
             subtitle: nil,
             systemImage: "pills.fill",
             tint: .coral
@@ -839,17 +823,17 @@ private struct HomeCalendarDayCell: View {
 
     private var accessibilityLabel: String {
         let dateText = date.formatted(date: .complete, time: .omitted)
-        let stateText = isToday ? HomeLocalized.text(de: "heute", en: "today") : HomeLocalized.text(de: "Kalendertag", en: "calendar day")
+        let stateText = isToday ? "heute" : "Kalendertag"
 
         guard entries.isEmpty == false else {
-            return "\(dateText), \(stateText), \(HomeLocalized.text(de: "keine Einträge", en: "no entries"))"
+            return "\(dateText), \(stateText), \("keine Einträge")"
         }
 
         let entryText = entries.count == 1
             ? "1 Eintrag"
             : "\(entries.count) Einträge"
         let highestIntensity = entries.map(\.intensity).max() ?? 0
-        return "\(dateText), \(stateText), \(entryText), \(HomeLocalized.text(de: "höchste Intensität", en: "highest intensity")) \(highestIntensity) \(HomeLocalized.text(de: "von", en: "out of")) 10"
+        return "\(dateText), \(stateText), \(entryText), \("höchste Intensität") \(highestIntensity) \("von") 10"
     }
 }
 
@@ -1094,17 +1078,11 @@ private struct HomePatternEmptyState: View {
         }
 
         if recordedCount >= HomePatternPreviewData.minimumEpisodeCount {
-            return HomeLocalized.text(
-                de: "Es gibt schon genug Einträge, aber noch nichts, das in deinen Einträgen auffällig genug ist.",
-                en: "There are enough entries, but nothing in them stands out clearly enough yet."
-            )
+            return "Es gibt schon genug Einträge, aber noch nichts, das in deinen Einträgen auffällig genug ist."
         }
 
         if recordedCount == 0 {
-            return HomeLocalized.text(
-                de: "Wenn du einige Schmerz- oder Migräneeinträge erfasst hast, zeigt Symi hier vorsichtige Hinweise.",
-                en: "Once you have logged a few pain or migraine entries, Symi shows careful hints here."
-            )
+            return "Wenn du einige Schmerz- oder Migräneeinträge erfasst hast, zeigt Symi hier vorsichtige Hinweise."
         }
 
         return "\(recordedCount) von \(HomePatternPreviewData.minimumEpisodeCount) nötigen Schmerz- oder Migräneeinträgen sind vorhanden. Sobald mehr Daten da sind, sucht Symi nach vorsichtigen Mustern."
@@ -1195,21 +1173,21 @@ private struct HomeInsightsContent: View {
 
                         if !topTriggers.isEmpty {
                             FrequencyInsightCard(
-                                title: HomeLocalized.text(de: "Häufige Auslöser", en: "Frequent triggers"),
+                                title: "Häufige Auslöser",
                                 systemImage: "tag",
                                 summaries: topTriggers,
                                 tint: AppTheme.coral(for: colorScheme),
-                                detail: HomeLocalized.text(de: "in deinen Einträgen auffällig", en: "stands out in your entries")
+                                detail: "in deinen Einträgen auffällig"
                             )
                         }
 
                         if !topMedications.isEmpty {
                             FrequencyInsightCard(
-                                title: HomeLocalized.text(de: "Medikation", en: "Medication"),
+                                title: "Medikation",
                                 systemImage: "pills",
                                 summaries: topMedications,
                                 tint: AppTheme.petrol(for: colorScheme),
-                                detail: HomeLocalized.text(de: "in diesem Zeitraum dokumentiert", en: "documented in this period")
+                                detail: "in diesem Zeitraum dokumentiert"
                             )
                         }
                     }

--- a/Symi/Sources/Features/InputFlow/Styling/InputFlowTheme.swift
+++ b/Symi/Sources/Features/InputFlow/Styling/InputFlowTheme.swift
@@ -32,40 +32,40 @@ enum InputFlowStepCatalog {
     static let steps: [InputFlowStepMetadata] = [
         InputFlowStepMetadata(
             id: .headache,
-            title: EntryFlowLocalized.text(de: "Kopfschmerz", en: "Headache"),
-            subtitle: EntryFlowLocalized.text(de: "Wie stark ist es gerade?", en: "How strong is it right now?"),
+            title: "Kopfschmerz",
+            subtitle: "Wie stark ist es gerade?",
             symbolName: "waveform.path.ecg",
             theme: .pain,
             status: nil
         ),
         InputFlowStepMetadata(
             id: .medication,
-            title: EntryFlowLocalized.text(de: "Medikation", en: "Medication"),
-            subtitle: EntryFlowLocalized.text(de: "Hast du etwas genommen?", en: "Did you take anything?"),
+            title: "Medikation",
+            subtitle: "Hast du etwas genommen?",
             symbolName: "pills.fill",
             theme: .medication,
             status: nil
         ),
         InputFlowStepMetadata(
             id: .triggers,
-            title: EntryFlowLocalized.text(de: "Auslöser", en: "Triggers"),
-            subtitle: EntryFlowLocalized.text(de: "Was könnte eine Rolle gespielt haben?", en: "What might have played a role?"),
+            title: "Auslöser",
+            subtitle: "Was könnte eine Rolle gespielt haben?",
             symbolName: "brain.head.profile",
             theme: .trigger,
             status: nil
         ),
         InputFlowStepMetadata(
             id: .note,
-            title: EntryFlowLocalized.text(de: "Notiz", en: "Note"),
-            subtitle: EntryFlowLocalized.text(de: "Was möchtest du festhalten?", en: "What do you want to note?"),
+            title: "Notiz",
+            subtitle: "Was möchtest du festhalten?",
             symbolName: "note.text",
             theme: .note,
             status: nil
         ),
         InputFlowStepMetadata(
             id: .review,
-            title: EntryFlowLocalized.text(de: "Eintrag prüfen", en: "Review entry"),
-            subtitle: EntryFlowLocalized.text(de: "Alles bereit zum Speichern.", en: "Everything is ready to save."),
+            title: "Eintrag prüfen",
+            subtitle: "Alles bereit zum Speichern.",
             symbolName: "checkmark.seal.fill",
             theme: .review,
             status: nil

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -11,11 +11,11 @@ enum EpisodeType: String, CaseIterable, Codable, Identifiable {
     nonisolated var displayName: String {
         switch self {
         case .migraine:
-            String(localized: "Migräne")
+            "Migräne"
         case .headache:
-            String(localized: "Kopfschmerz")
+            "Kopfschmerz"
         case .unclear:
-            String(localized: "Unklar")
+            "Unklar"
         }
     }
 
@@ -49,26 +49,26 @@ enum MenstruationStatus: String, CaseIterable, Codable, Identifiable {
     nonisolated var displayName: String {
         switch self {
         case .unknown:
-            String(localized: "Nicht angegeben")
+            "Nicht angegeben"
         case .none:
-            String(localized: "Nein")
+            "Nein"
         case .active:
-            String(localized: "Aktuell")
+            "Aktuell"
         case .expected:
-            String(localized: "Erwartet")
+            "Erwartet"
         }
     }
 
     nonisolated var accuracyDescription: String {
         switch self {
         case .unknown:
-            String(localized: "Keine Zyklusangabe aus der App.")
+            "Keine Zyklusangabe aus der App."
         case .none:
-            String(localized: "App-Angabe ohne Health-Flow-Sample.")
+            "App-Angabe ohne Health-Flow-Sample."
         case .active:
-            String(localized: "Aktuelle App-Angabe ohne Stärke oder Health-Flow-Sample.")
+            "Aktuelle App-Angabe ohne Stärke oder Health-Flow-Sample."
         case .expected:
-            String(localized: "Erwartete App-Angabe, keine echte Blutungsprobe.")
+            "Erwartete App-Angabe, keine echte Blutungsprobe."
         }
     }
 
@@ -109,15 +109,15 @@ enum MedicationCategory: String, CaseIterable, Codable, Identifiable {
     nonisolated var displayName: String {
         switch self {
         case .triptan:
-            String(localized: "Triptan")
+            "Triptan"
         case .nsar:
-            String(localized: "NSAR")
+            "NSAR"
         case .paracetamol:
-            String(localized: "Paracetamol")
+            "Paracetamol"
         case .antiemetic:
-            String(localized: "Antiemetikum")
+            "Antiemetikum"
         case .other:
-            String(localized: "Sonstiges")
+            "Sonstiges"
         }
     }
 
@@ -154,11 +154,11 @@ enum MedicationEffectiveness: String, CaseIterable, Codable, Identifiable {
     nonisolated var displayName: String {
         switch self {
         case .none:
-            String(localized: "Keine")
+            "Keine"
         case .partial:
-            String(localized: "Teilweise")
+            "Teilweise"
         case .good:
-            String(localized: "Gut")
+            "Gut"
         }
     }
 


### PR DESCRIPTION
## Summary
- remove EntryFlowLocalized, InsightLocalized, and HomeLocalized custom locale helpers
- replace String(localized:) and helper calls with plain German strings
- keep the PDF export formatter working directly from its German format keys

Closes #300

## Validation
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'