### PR TITLE
Centralize episode option enums

### DIFF
--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -60,61 +60,6 @@ enum EntryStartedAtPreset: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
-enum EntryDayPartPreset: String, CaseIterable, Identifiable, Sendable {
-    case morgens
-    case mittags
-    case abends
-    case nacht
-
-    var id: String { rawValue }
-
-    var dayPart: EpisodeDayPart {
-        switch self {
-        case .morgens:
-            .morgens
-        case .mittags:
-            .mittags
-        case .abends:
-            .abends
-        case .nacht:
-            .nacht
-        }
-    }
-
-    var title: String {
-        dayPart.label
-    }
-
-    var symbolName: String {
-        switch self {
-        case .morgens:
-            "sunrise.fill"
-        case .mittags:
-            "sun.max.fill"
-        case .abends:
-            "sunset.fill"
-        case .nacht:
-            "moon.stars.fill"
-        }
-    }
-
-    func date(on referenceDate: Date = .now, calendar: Calendar = .current) -> Date {
-        let hour: Int
-        switch self {
-        case .morgens:
-            hour = 8
-        case .mittags:
-            hour = 13
-        case .abends:
-            hour = 19
-        case .nacht:
-            hour = 23
-        }
-
-        return calendar.date(bySettingHour: hour, minute: 0, second: 0, of: referenceDate) ?? referenceDate
-    }
-}
-
 @MainActor
 @Observable
 final class EntryContinuousMedicationController {
@@ -150,33 +95,9 @@ final class EntryContinuousMedicationController {
 final class EntryFlowCoordinator {
     static let steps: [EntryFlowStep] = [.headache, .medication, .triggers, .note, .review]
 
-    let symptomOptions = [
-        "Übelkeit",
-        "Lichtempfindlichkeit",
-        "Geräuschempfindlichkeit",
-        "Aura",
-        "Kiefer-/Aufbissschmerz",
-        "Pochen, Pulsieren"
-    ]
-    let triggerOptions = [
-        "Wetter",
-        "Stress",
-        "Erhöhte Arbeitsbelastung",
-        "Regel",
-        "Schlafdauer",
-        "Sport",
-        "Ernährung",
-        "Bildschirmzeit",
-        "Bewegung",
-        "Flüssigkeit"
-    ]
-    let painLocationOptions = [
-        "Stirn",
-        "Schläfen",
-        "Nacken",
-        "Einseitig",
-        "Überall"
-    ]
+    let symptomOptions = EpisodeSymptomOption.allCases.map(\.displayLabel)
+    let triggerOptions = EpisodeTriggerOption.allCases.map(\.displayLabel)
+    let painLocationOptions = PainLocationOption.allCases.map(\.displayLabel)
     let medicationController: EpisodeMedicationSelectionController
     let continuousMedicationController: EntryContinuousMedicationController
 
@@ -301,8 +222,8 @@ final class EntryFlowCoordinator {
         weatherLoadState = .idle
     }
 
-    func selectDayPartPreset(_ preset: EntryDayPartPreset, referenceDate: Date = .now, calendar: Calendar = .current) {
-        draft.startedAt = preset.date(on: referenceDate, calendar: calendar)
+    func selectDayPart(_ dayPart: EpisodeDayPart, referenceDate: Date = .now, calendar: Calendar = .current) {
+        draft.startedAt = dayPart.date(on: referenceDate, calendar: calendar)
         weatherLoadState = .idle
     }
 

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -218,6 +218,39 @@ enum EpisodeDayPart: String, CaseIterable, Codable, Identifiable, Sendable {
 
     nonisolated var id: String { rawValue }
 
+    nonisolated var metadata: EpisodeDayPartMetadata {
+        switch self {
+        case .morgens:
+            EpisodeDayPartMetadata(
+                label: "Morgens",
+                contextualLabel: "Am Morgen",
+                symbolName: "sunrise.fill",
+                representativeHour: 8
+            )
+        case .mittags:
+            EpisodeDayPartMetadata(
+                label: "Mittags",
+                contextualLabel: "Am Nachmittag",
+                symbolName: "sun.max.fill",
+                representativeHour: 13
+            )
+        case .abends:
+            EpisodeDayPartMetadata(
+                label: "Abends",
+                contextualLabel: "Am Abend",
+                symbolName: "sunset.fill",
+                representativeHour: 19
+            )
+        case .nacht:
+            EpisodeDayPartMetadata(
+                label: "Nacht",
+                contextualLabel: "In der Nacht",
+                symbolName: "moon.stars.fill",
+                representativeHour: 23
+            )
+        }
+    }
+
     nonisolated init(date: Date, calendar: Calendar = .current) {
         let hour = calendar.component(.hour, from: date)
 
@@ -234,29 +267,23 @@ enum EpisodeDayPart: String, CaseIterable, Codable, Identifiable, Sendable {
     }
 
     nonisolated var label: String {
-        switch self {
-        case .morgens:
-            "Morgens"
-        case .mittags:
-            "Mittags"
-        case .abends:
-            "Abends"
-        case .nacht:
-            "Nacht"
-        }
+        metadata.label
     }
 
     nonisolated var contextualLabel: String {
-        switch self {
-        case .morgens:
-            "Am Morgen"
-        case .mittags:
-            "Am Nachmittag"
-        case .abends:
-            "Am Abend"
-        case .nacht:
-            "In der Nacht"
-        }
+        metadata.contextualLabel
+    }
+
+    nonisolated var symbolName: String {
+        metadata.symbolName
+    }
+
+    nonisolated var representativeHour: Int {
+        metadata.representativeHour
+    }
+
+    nonisolated func date(on referenceDate: Date = .now, calendar: Calendar = .current) -> Date {
+        calendar.date(bySettingHour: representativeHour, minute: 0, second: 0, of: referenceDate) ?? referenceDate
     }
 }
 

--- a/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
@@ -366,15 +366,8 @@ final class EpisodeMedicationSelectionController {
 @Observable
 final class EpisodeEditorController {
     let mode: EpisodeEditorMode
-    let symptomOptions = [
-        "Übelkeit",
-        "Lichtempfindlichkeit",
-        "Geräuschempfindlichkeit",
-        "Aura",
-        "Kiefer-/Aufbissschmerz",
-        "Pochen, Pulsieren"
-    ]
-    let triggerOptions = ["Wetter", "Stress", "Erhöhte Arbeitsbelastung", "Regel", "Schlafdauer", "Sport", "Ernährung", "Bildschirmzeit", "Bewegung", "Flüssigkeit"]
+    let symptomOptions = EpisodeSymptomOption.allCases.map(\.displayLabel)
+    let triggerOptions = EpisodeTriggerOption.allCases.map(\.displayLabel)
     let medicationController: EpisodeMedicationSelectionController
 
     var draft: EpisodeDraft

--- a/Symi/Sources/Core/Episodes/EpisodeOptionCatalog.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeOptionCatalog.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+struct PainLocationMetadata: Equatable, Sendable {
+    let storedValue: String
+    let displayLabel: String
+    let imageName: String
+    let isVisibleInEntryFlow: Bool
+}
+
+nonisolated enum PainLocationOption: String, CaseIterable, Codable, Identifiable, Sendable {
+    case forehead
+    case temples
+    case neck
+    case oneSided
+    case everywhere
+
+    nonisolated var id: String { rawValue }
+
+    nonisolated init(storageValue: String) {
+        switch storageValue.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case Self.forehead.rawValue, "Stirn":
+            self = .forehead
+        case Self.temples.rawValue, "Schläfen":
+            self = .temples
+        case Self.neck.rawValue, "Nacken":
+            self = .neck
+        case Self.oneSided.rawValue, "Einseitig", "links frontal":
+            self = .oneSided
+        case Self.everywhere.rawValue, "Überall", "Oberkopf":
+            self = .everywhere
+        default:
+            self = .temples
+        }
+    }
+
+    nonisolated static var entryFlowCases: [PainLocationOption] {
+        allCases.filter(\.metadata.isVisibleInEntryFlow)
+    }
+
+    nonisolated var metadata: PainLocationMetadata {
+        switch self {
+        case .forehead:
+            PainLocationMetadata(
+                storedValue: "Stirn",
+                displayLabel: "Stirn",
+                imageName: "PainLocationForehead",
+                isVisibleInEntryFlow: true
+            )
+        case .temples:
+            PainLocationMetadata(
+                storedValue: "Schläfen",
+                displayLabel: "Schläfen",
+                imageName: "PainLocationTemples",
+                isVisibleInEntryFlow: true
+            )
+        case .neck:
+            PainLocationMetadata(
+                storedValue: "Nacken",
+                displayLabel: "Nacken",
+                imageName: "PainLocationNeck",
+                isVisibleInEntryFlow: false
+            )
+        case .oneSided:
+            PainLocationMetadata(
+                storedValue: "Einseitig",
+                displayLabel: "Einseitig",
+                imageName: "PainLocationLeftTemple",
+                isVisibleInEntryFlow: true
+            )
+        case .everywhere:
+            PainLocationMetadata(
+                storedValue: "Überall",
+                displayLabel: "Überall",
+                imageName: "PainLocationCrown",
+                isVisibleInEntryFlow: true
+            )
+        }
+    }
+
+    nonisolated var storedValue: String {
+        metadata.storedValue
+    }
+
+    nonisolated var displayLabel: String {
+        metadata.displayLabel
+    }
+
+    nonisolated var imageName: String {
+        metadata.imageName
+    }
+}
+
+struct EpisodeDayPartMetadata: Equatable, Sendable {
+    let label: String
+    let contextualLabel: String
+    let symbolName: String
+    let representativeHour: Int
+}
+
+nonisolated enum EpisodeSymptomOption: String, CaseIterable, Codable, Identifiable, Sendable {
+    case nausea
+    case lightSensitivity
+    case soundSensitivity
+    case aura
+    case jawPain
+    case throbbing
+
+    nonisolated var id: String { rawValue }
+
+    nonisolated init(storageValue: String) {
+        switch storageValue.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case Self.nausea.rawValue, "Übelkeit":
+            self = .nausea
+        case Self.lightSensitivity.rawValue, "Lichtempfindlichkeit":
+            self = .lightSensitivity
+        case Self.soundSensitivity.rawValue, "Geräuschempfindlichkeit":
+            self = .soundSensitivity
+        case Self.aura.rawValue, "Aura":
+            self = .aura
+        case Self.jawPain.rawValue, "Kiefer-/Aufbissschmerz":
+            self = .jawPain
+        case Self.throbbing.rawValue, "Pochen, Pulsieren":
+            self = .throbbing
+        default:
+            self = .aura
+        }
+    }
+
+    nonisolated var displayLabel: String {
+        switch self {
+        case .nausea:
+            "Übelkeit"
+        case .lightSensitivity:
+            "Lichtempfindlichkeit"
+        case .soundSensitivity:
+            "Geräuschempfindlichkeit"
+        case .aura:
+            "Aura"
+        case .jawPain:
+            "Kiefer-/Aufbissschmerz"
+        case .throbbing:
+            "Pochen, Pulsieren"
+        }
+    }
+}
+
+struct EpisodeTriggerMetadata: Equatable, Sendable {
+    let displayLabel: String
+    let symbolName: String
+}
+
+nonisolated enum EpisodeTriggerOption: String, CaseIterable, Codable, Identifiable, Sendable {
+    case weather
+    case stress
+    case highWorkload
+    case period
+    case sleepDuration
+    case sport
+    case nutrition
+    case screenTime
+    case movement
+    case fluids
+
+    nonisolated var id: String { rawValue }
+
+    nonisolated init(storageValue: String) {
+        switch storageValue.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case Self.weather.rawValue, "Wetter":
+            self = .weather
+        case Self.stress.rawValue, "Stress":
+            self = .stress
+        case Self.highWorkload.rawValue, "Erhöhte Arbeitsbelastung", "erhöhte Arbeitsbelastung":
+            self = .highWorkload
+        case Self.period.rawValue, "Regel", "Zyklus":
+            self = .period
+        case Self.sleepDuration.rawValue, "Schlafdauer", "Schlaf", "Schlafmangel":
+            self = .sleepDuration
+        case Self.sport.rawValue, "Sport":
+            self = .sport
+        case Self.nutrition.rawValue, "Ernährung":
+            self = .nutrition
+        case Self.screenTime.rawValue, "Bildschirmzeit":
+            self = .screenTime
+        case Self.movement.rawValue, "Bewegung":
+            self = .movement
+        case Self.fluids.rawValue, "Flüssigkeit":
+            self = .fluids
+        default:
+            self = .stress
+        }
+    }
+
+    nonisolated static var entryFlowCases: [EpisodeTriggerOption] {
+        [.stress, .weather, .sleepDuration, .nutrition, .screenTime, .period, .movement, .fluids]
+    }
+
+    nonisolated var metadata: EpisodeTriggerMetadata {
+        switch self {
+        case .weather:
+            EpisodeTriggerMetadata(displayLabel: "Wetter", symbolName: "cloud.sun")
+        case .stress:
+            EpisodeTriggerMetadata(displayLabel: "Stress", symbolName: "brain.head.profile")
+        case .highWorkload:
+            EpisodeTriggerMetadata(displayLabel: "Erhöhte Arbeitsbelastung", symbolName: "briefcase")
+        case .period:
+            EpisodeTriggerMetadata(displayLabel: "Regel", symbolName: "drop")
+        case .sleepDuration:
+            EpisodeTriggerMetadata(displayLabel: "Schlafdauer", symbolName: "moon")
+        case .sport:
+            EpisodeTriggerMetadata(displayLabel: "Sport", symbolName: "figure.run")
+        case .nutrition:
+            EpisodeTriggerMetadata(displayLabel: "Ernährung", symbolName: "fork.knife.circle")
+        case .screenTime:
+            EpisodeTriggerMetadata(displayLabel: "Bildschirmzeit", symbolName: "ipad.landscape.and.iphone")
+        case .movement:
+            EpisodeTriggerMetadata(displayLabel: "Bewegung", symbolName: "figure.walk")
+        case .fluids:
+            EpisodeTriggerMetadata(displayLabel: "Flüssigkeit", symbolName: "waterbottle")
+        }
+    }
+
+    nonisolated var displayLabel: String {
+        metadata.displayLabel
+    }
+
+    nonisolated var symbolName: String {
+        metadata.symbolName
+    }
+}

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -141,17 +141,10 @@ private struct EntryHeadacheStepView: View {
     let onBack: () -> Void
     let onCancel: () -> Void
 
-    @State private var selectedDayPartPreset: EntryDayPartPreset = EntryDayPartPreset(dayPart: EpisodeDayPart(date: .now))
+    @State private var selectedDayPart = EpisodeDayPart(date: .now)
     @State private var selectedDate = Date()
     @State private var isDatePickerExpanded = false
     @State private var dateFeedbackTrigger = 0
-    private let visiblePainLocations: [EntryPainLocationOption] = [
-        .init(title: "Stirn", imageName: "PainLocationForehead"),
-        .init(title: "Schläfen", imageName: "PainLocationTemples"),
-        // .init(title: "Nacken", imageName: "PainLocationNeck"),
-        .init(title: "Einseitig", imageName: "PainLocationLeftTemple"),
-        .init(title: "Überall", imageName: "PainLocationCrown")
-    ]
 
     var body: some View {
         @Bindable var coordinator = coordinator
@@ -180,15 +173,15 @@ private struct EntryHeadacheStepView: View {
 
             InputFlowFieldGroup(title: "Wo spürst du den Schmerz?") {
                 InputFlowHeadacheOptionGrid {
-                    ForEach(visiblePainLocations) { location in
+                    ForEach(PainLocationOption.entryFlowCases) { location in
                         PainLocationSelectionTile(
                             option: location,
-                            isSelected: coordinator.draft.selectedPainLocations.contains(location.title),
+                            isSelected: coordinator.draft.selectedPainLocations.contains(location.displayLabel),
                             theme: .pain,
-                            accessibilityIdentifier: "entry-location-\(location.title)"
+                            accessibilityIdentifier: "entry-location-\(location.displayLabel)"
                         ) {
                             collapseDatePicker()
-                            coordinator.draft.selectedPainLocations.toggleMembership(location.title)
+                            coordinator.draft.selectedPainLocations.toggleMembership(location.displayLabel)
                         }
                     }
                 }
@@ -202,17 +195,17 @@ private struct EntryHeadacheStepView: View {
                 onDateSelect: selectEntryDate
             ) {
                 InputFlowHeadacheOptionGrid {
-                    ForEach(EntryDayPartPreset.allCases) { preset in
+                    ForEach(EpisodeDayPart.allCases) { dayPart in
                         InputFlowSelectionTile(
-                            title: preset.title,
-                            systemImage: preset.symbolName,
-                            isSelected: selectedDayPartPreset == preset,
+                            title: dayPart.label,
+                            systemImage: dayPart.symbolName,
+                            isSelected: selectedDayPart == dayPart,
                             theme: .pain,
-                            accessibilityIdentifier: "entry-daypart-\(preset.rawValue)"
+                            accessibilityIdentifier: "entry-daypart-\(dayPart.rawValue)"
                         ) {
                             collapseDatePicker()
-                            selectedDayPartPreset = preset
-                            coordinator.selectDayPartPreset(preset, referenceDate: coordinator.draft.startedAt)
+                            selectedDayPart = dayPart
+                            coordinator.selectDayPart(dayPart, referenceDate: coordinator.draft.startedAt)
                         }
                     }
                 }
@@ -236,7 +229,7 @@ private struct EntryHeadacheStepView: View {
             coordinator.draft.type = .headache
             coordinator.draft.intensity = coordinator.draft.normalizedIntensity
             selectedDate = coordinator.draft.startedAt
-            selectedDayPartPreset = EntryDayPartPreset(dayPart: EpisodeDayPart(date: coordinator.draft.startedAt))
+            selectedDayPart = EpisodeDayPart(date: coordinator.draft.startedAt)
             seedDefaultPainLocationIfNeeded(coordinator: coordinator)
         }
     }
@@ -244,7 +237,7 @@ private struct EntryHeadacheStepView: View {
     private func selectEntryDate(_ date: Date) {
         selectedDate = date
         coordinator.selectEntryDate(date)
-        selectedDayPartPreset = EntryDayPartPreset(dayPart: EpisodeDayPart(date: coordinator.draft.startedAt))
+        selectedDayPart = EpisodeDayPart(date: coordinator.draft.startedAt)
         collapseDatePicker()
     }
 
@@ -270,7 +263,7 @@ private struct EntryHeadacheStepView: View {
             return
         }
 
-        coordinator.draft.selectedPainLocations = ["Schläfen"]
+        coordinator.draft.selectedPainLocations = [PainLocationOption.temples.displayLabel]
     }
 }
 
@@ -352,21 +345,6 @@ private struct EntryDayPartFieldGroup<Content: View>: View {
             content
         }
         .zIndex(isDatePickerExpanded ? 10 : 0)
-    }
-}
-
-private extension EntryDayPartPreset {
-    init(dayPart: EpisodeDayPart) {
-        switch dayPart {
-        case .morgens:
-            self = .morgens
-        case .mittags:
-            self = .mittags
-        case .abends:
-            self = .abends
-        case .nacht:
-            self = .nacht
-        }
     }
 }
 
@@ -453,17 +431,10 @@ private struct PainIntensitySelectionTile: View {
 
 }
 
-private struct EntryPainLocationOption: Identifiable, Hashable {
-    let title: String
-    let imageName: String
-
-    var id: String { title }
-}
-
 private struct PainLocationSelectionTile: View {
     @Environment(\.colorScheme) private var colorScheme
 
-    let option: EntryPainLocationOption
+    let option: PainLocationOption
     let isSelected: Bool
     let theme: InputFlowStepTheme
     let accessibilityIdentifier: String
@@ -478,7 +449,7 @@ private struct PainLocationSelectionTile: View {
                     .frame(height: SymiSize.headacheLocationImageHeight)
                     .accessibilityHidden(true)
 
-                Text(option.title)
+                Text(option.displayLabel)
                     .font(SymiTypography.flowTileLabel)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(AppTheme.symiTextPrimary)
@@ -508,7 +479,7 @@ private struct PainLocationSelectionTile: View {
             }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(option.title)
+        .accessibilityLabel(option.displayLabel)
         .accessibilityValue(isSelected ? "Ausgewählt" : "Nicht ausgewählt")
         .accessibilityHint(isSelected ? "Entfernt die Auswahl." : "Wählt diese Option aus.")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
@@ -700,17 +671,6 @@ private struct EntryTriggersStepView: View {
     let onBack: () -> Void
     let onCancel: () -> Void
 
-    private let triggerOptions: [EntryTriggerOption] = [
-        EntryTriggerOption(title: "Stress", symbolName: "brain.head.profile"),
-        EntryTriggerOption(title: "Wetter", symbolName: "cloud.sun"),
-        EntryTriggerOption(title: "Schlaf", symbolName: "moon"),
-        EntryTriggerOption(title: "Ernährung", symbolName: "fork.knife.circle"),
-        EntryTriggerOption(title: "Bildschirmzeit", symbolName: "ipad.landscape.and.iphone"),
-        EntryTriggerOption(title: "Zyklus", symbolName: "drop"),
-        EntryTriggerOption(title: "Bewegung", symbolName: "figure.run"),
-        EntryTriggerOption(title: "Flüssigkeit", symbolName: "waterbottle")
-    ]
-
     var body: some View {
         @Bindable var coordinator = coordinator
 
@@ -722,15 +682,15 @@ private struct EntryTriggersStepView: View {
         ) {
             InputFlowFieldGroup(title: "Wähle alle passenden aus.") {
                 InputFlowTileGrid(minimumColumnWidth: SymiSize.flowTwoColumnTileGridMinWidth) {
-                    ForEach(triggerOptions) { option in
+                    ForEach(EpisodeTriggerOption.entryFlowCases) { option in
                         InputFlowSelectionTile(
-                            title: option.title,
+                            title: option.displayLabel,
                             systemImage: option.symbolName,
-                            isSelected: coordinator.draft.selectedTriggers.contains(option.title),
+                            isSelected: coordinator.draft.selectedTriggers.contains(option.displayLabel),
                             theme: .trigger,
-                            accessibilityIdentifier: "entry-trigger-\(option.title)"
+                            accessibilityIdentifier: "entry-trigger-\(option.displayLabel)"
                         ) {
-                            coordinator.draft.selectedTriggers.toggleMembership(option.title)
+                            coordinator.draft.selectedTriggers.toggleMembership(option.displayLabel)
                         }
                     }
                 }
@@ -1240,13 +1200,6 @@ private struct EntryMedicationOption: Identifiable {
     let symbolName: String
     let category: MedicationCategory
     let defaultDosage: String
-
-    var id: String { title }
-}
-
-private struct EntryTriggerOption: Identifiable {
-    let title: String
-    let symbolName: String
 
     var id: String { title }
 }

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -135,15 +135,15 @@ struct CoreArchitectureTests {
     func episodeDayPartProvidesCentralClassificationAndDisplayText() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        let expectations: [(Int, EpisodeDayPart, String)] = [
-            (4, .nacht, "In der Nacht"),
-            (5, .morgens, "Am Morgen"),
-            (10, .morgens, "Am Morgen"),
-            (11, .mittags, "Am Nachmittag"),
-            (16, .mittags, "Am Nachmittag"),
-            (17, .abends, "Am Abend"),
-            (21, .abends, "Am Abend"),
-            (22, .nacht, "In der Nacht")
+        let expectations: [(Int, EpisodeDayPart, String, String, Int)] = [
+            (4, .nacht, "In der Nacht", "moon.stars.fill", 23),
+            (5, .morgens, "Am Morgen", "sunrise.fill", 8),
+            (10, .morgens, "Am Morgen", "sunrise.fill", 8),
+            (11, .mittags, "Am Nachmittag", "sun.max.fill", 13),
+            (16, .mittags, "Am Nachmittag", "sun.max.fill", 13),
+            (17, .abends, "Am Abend", "sunset.fill", 19),
+            (21, .abends, "Am Abend", "sunset.fill", 19),
+            (22, .nacht, "In der Nacht", "moon.stars.fill", 23)
         ]
 
         for expectation in expectations {
@@ -152,6 +152,8 @@ struct CoreArchitectureTests {
 
             #expect(dayPart == expectation.1)
             #expect(dayPart.contextualLabel == expectation.2)
+            #expect(dayPart.symbolName == expectation.3)
+            #expect(dayPart.representativeHour == expectation.4)
             #expect(JournalEntryContext.timeOfDay(for: date, calendar: calendar) == expectation.2)
         }
     }

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -13,7 +13,7 @@ struct EntryFlowCoordinatorTests {
     @Test
     func triggerCatalogContainsRequiredContextOptions() {
         let coordinator = makeCoordinator()
-        let requiredTriggers = ["Wetter", "Stress", "Erhöhte Arbeitsbelastung", "Regel", "Schlafdauer", "Sport"]
+        let requiredTriggers = EpisodeTriggerOption.allCases.map(\.displayLabel)
 
         for trigger in requiredTriggers {
             #expect(coordinator.triggerOptions.contains(trigger))
@@ -154,10 +154,10 @@ struct EntryFlowCoordinatorTests {
         let coordinator = makeCoordinator()
         let referenceDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: 26, hour: 15, minute: 30))!
 
-        coordinator.selectDayPartPreset(.abends, referenceDate: referenceDate, calendar: calendar)
+        coordinator.selectDayPart(.abends, referenceDate: referenceDate, calendar: calendar)
         let selectedHour = calendar.component(.hour, from: coordinator.draft.startedAt)
 
-        #expect(EntryDayPartPreset.abends.dayPart == .abends)
+        #expect(EpisodeDayPart.abends.representativeHour == 19)
         #expect(selectedHour == 19)
         #expect(EntryStartedAtPreset.oneHourAgo.date(relativeTo: referenceDate, calendar: calendar) == referenceDate.addingTimeInterval(-3_600))
     }

--- a/SymiTests/EpisodeOptionCatalogTests.swift
+++ b/SymiTests/EpisodeOptionCatalogTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import Symi
+
+@MainActor
+struct EpisodeOptionCatalogTests {
+    @Test
+    func painLocationMetadataDefinesEntryFlowOptions() {
+        let visibleLocations = PainLocationOption.entryFlowCases
+
+        #expect(visibleLocations.map(\.displayLabel) == ["Stirn", "Schläfen", "Einseitig", "Überall"])
+        #expect(PainLocationOption.allCases.map(\.displayLabel) == ["Stirn", "Schläfen", "Nacken", "Einseitig", "Überall"])
+        #expect(PainLocationOption.forehead.metadata.imageName == "PainLocationForehead")
+        #expect(PainLocationOption.temples.metadata.imageName == "PainLocationTemples")
+        #expect(PainLocationOption.neck.metadata.imageName == "PainLocationNeck")
+        #expect(!PainLocationOption.neck.metadata.isVisibleInEntryFlow)
+    }
+
+    @Test
+    func painLocationParsesStorageAndLegacyValues() {
+        let expectations: [(String, PainLocationOption)] = [
+            ("forehead", .forehead),
+            ("Stirn", .forehead),
+            ("Schläfen", .temples),
+            ("Nacken", .neck),
+            ("Einseitig", .oneSided),
+            ("links frontal", .oneSided),
+            ("Überall", .everywhere),
+            ("Oberkopf", .everywhere)
+        ]
+
+        for expectation in expectations {
+            #expect(PainLocationOption(storageValue: expectation.0) == expectation.1)
+        }
+    }
+
+    @Test
+    func symptomAndTriggerCatalogsProvideStableDisplayValues() {
+        #expect(EpisodeSymptomOption.allCases.map(\.displayLabel) == [
+            "Übelkeit",
+            "Lichtempfindlichkeit",
+            "Geräuschempfindlichkeit",
+            "Aura",
+            "Kiefer-/Aufbissschmerz",
+            "Pochen, Pulsieren"
+        ])
+        #expect(EpisodeTriggerOption.allCases.map(\.displayLabel) == [
+            "Wetter",
+            "Stress",
+            "Erhöhte Arbeitsbelastung",
+            "Regel",
+            "Schlafdauer",
+            "Sport",
+            "Ernährung",
+            "Bildschirmzeit",
+            "Bewegung",
+            "Flüssigkeit"
+        ])
+        #expect(EpisodeTriggerOption.entryFlowCases.map(\.displayLabel) == [
+            "Stress",
+            "Wetter",
+            "Schlafdauer",
+            "Ernährung",
+            "Bildschirmzeit",
+            "Regel",
+            "Bewegung",
+            "Flüssigkeit"
+        ])
+        #expect(EpisodeTriggerOption.sleepDuration.symbolName == "moon")
+        #expect(EpisodeTriggerOption.period.symbolName == "drop")
+        #expect(EpisodeTriggerOption(storageValue: "Schlaf") == .sleepDuration)
+        #expect(EpisodeTriggerOption(storageValue: "Zyklus") == .period)
+    }
+}

--- a/SymiUITests/EntryFlowUITests.swift
+++ b/SymiUITests/EntryFlowUITests.swift
@@ -178,7 +178,7 @@ final class EntryFlowUITests: XCTestCase {
         XCTAssertVisibleText("Wähle alle passenden aus.", in: app)
         XCTAssertTrue(app.buttons["entry-trigger-Stress"].exists)
         XCTAssertTrue(app.buttons["entry-trigger-Wetter"].exists)
-        XCTAssertTrue(app.buttons["entry-trigger-Schlaf"].exists)
+        XCTAssertTrue(app.buttons["entry-trigger-Schlafdauer"].exists)
         XCTAssertTrue(app.buttons["entry-trigger-Ernährung"].exists)
         XCTAssertVisibleText("Du kannst mehrere auswählen.", in: app)
         XCTAssertVisibleText("von 5", in: app)


### PR DESCRIPTION
## Summary
- centralizes pain locations, day-part metadata, symptoms, and triggers in domain enums
- updates entry flow and editor surfaces to consume the shared catalogs
- adds catalog coverage and updates existing tests

## Tests
- xcodebuild test -scheme SymiTests -project Symi.xcodeproj

Closes #301