### PR TITLE
[codex] Fix report date range export

### DIFF
--- a/Symi/Sources/Core/Export/ExportCore.swift
+++ b/Symi/Sources/Core/Export/ExportCore.swift
@@ -157,6 +157,12 @@ final class DataExportController {
         }
     }
 
+    func setDateRange(startDate: Date, endDate: Date, debounce: Duration? = .milliseconds(350)) {
+        self.startDate = startDate
+        self.endDate = endDate
+        scheduleSummaryReload(debounce: debounce)
+    }
+
     func reloadSummary() async {
         await reloadSummary(startDate: startDate, endDate: endDate)
     }
@@ -371,8 +377,7 @@ final class DataExportController {
     }
 
     private static func defaultDateRange(calendar: Calendar = .current, now: Date = .now) -> (startDate: Date, endDate: Date) {
-        let startOfCurrentMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: now)) ?? now
-        let startDate = calendar.date(byAdding: .month, value: -2, to: startOfCurrentMonth) ?? now
+        let startDate = calendar.date(byAdding: .month, value: -1, to: now) ?? now
         return (startDate, now)
     }
 

--- a/Symi/Sources/Features/Export/DataExportView.swift
+++ b/Symi/Sources/Features/Export/DataExportView.swift
@@ -126,7 +126,10 @@ struct ReportView: View {
             }
         }
         .sheet(isPresented: $isDateSelectionPresented) {
-            ReportDateSelectionSheet(selectedDateRange: $selectedDateRange)
+            ReportDateSelectionSheet(
+                selectedDateRange: selectedDateRange,
+                selectDateRange: selectDateRange
+            )
                 .presentationDetents([.height(320)])
                 .presentationDragIndicator(.visible)
         }
@@ -142,6 +145,12 @@ struct ReportView: View {
 
     private func openDateSelection() {
         isDateSelectionPresented = true
+    }
+
+    private func selectDateRange(_ range: ReportDateRange) {
+        selectedDateRange = range
+        let dateRange = range.dateRange()
+        controller.setDateRange(startDate: dateRange.startDate, endDate: dateRange.endDate)
     }
 
     private func presentReportPreview(_ url: URL) {
@@ -203,7 +212,6 @@ private enum ReportDateRange: String, CaseIterable, Identifiable {
     case last7Days
     case lastMonth
     case last3Months
-    case custom
 
     var id: String { rawValue }
 
@@ -215,9 +223,21 @@ private enum ReportDateRange: String, CaseIterable, Identifiable {
             "Letzter Monat"
         case .last3Months:
             "Letzte 3 Monate"
-        case .custom:
-            "Benutzerdefiniert"
         }
+    }
+
+    func dateRange(calendar: Calendar = .current, now: Date = .now) -> (startDate: Date, endDate: Date) {
+        let startDate: Date
+        switch self {
+        case .last7Days:
+            startDate = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+        case .lastMonth:
+            startDate = calendar.date(byAdding: .month, value: -1, to: now) ?? now
+        case .last3Months:
+            startDate = calendar.date(byAdding: .month, value: -3, to: now) ?? now
+        }
+
+        return (startDate, now)
     }
 }
 
@@ -345,7 +365,8 @@ private struct FloatingReportButton: View {
 }
 
 private struct ReportDateSelectionSheet: View {
-    @Binding var selectedDateRange: ReportDateRange
+    let selectedDateRange: ReportDateRange
+    let selectDateRange: (ReportDateRange) -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -357,7 +378,7 @@ private struct ReportDateSelectionSheet: View {
             VStack(spacing: SymiSpacing.xs) {
                 ForEach(ReportDateRange.allCases) { range in
                     Button {
-                        selectedDateRange = range
+                        selectDateRange(range)
                         dismiss()
                     } label: {
                         HStack(spacing: SymiSpacing.md) {

--- a/SymiTests/CoreArchitectureTests.swift
+++ b/SymiTests/CoreArchitectureTests.swift
@@ -135,26 +135,26 @@ struct CoreArchitectureTests {
     func episodeDayPartProvidesCentralClassificationAndDisplayText() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        let expectations: [(Int, EpisodeDayPart, String, String, Int)] = [
-            (4, .nacht, "In der Nacht", "moon.stars.fill", 23),
-            (5, .morgens, "Am Morgen", "sunrise.fill", 8),
-            (10, .morgens, "Am Morgen", "sunrise.fill", 8),
-            (11, .mittags, "Am Nachmittag", "sun.max.fill", 13),
-            (16, .mittags, "Am Nachmittag", "sun.max.fill", 13),
-            (17, .abends, "Am Abend", "sunset.fill", 19),
-            (21, .abends, "Am Abend", "sunset.fill", 19),
-            (22, .nacht, "In der Nacht", "moon.stars.fill", 23)
+        let expectations: [DayPartExpectation] = [
+            DayPartExpectation(hour: 4, dayPart: .nacht, label: "In der Nacht", symbolName: "moon.stars.fill", representativeHour: 23),
+            DayPartExpectation(hour: 5, dayPart: .morgens, label: "Am Morgen", symbolName: "sunrise.fill", representativeHour: 8),
+            DayPartExpectation(hour: 10, dayPart: .morgens, label: "Am Morgen", symbolName: "sunrise.fill", representativeHour: 8),
+            DayPartExpectation(hour: 11, dayPart: .mittags, label: "Am Nachmittag", symbolName: "sun.max.fill", representativeHour: 13),
+            DayPartExpectation(hour: 16, dayPart: .mittags, label: "Am Nachmittag", symbolName: "sun.max.fill", representativeHour: 13),
+            DayPartExpectation(hour: 17, dayPart: .abends, label: "Am Abend", symbolName: "sunset.fill", representativeHour: 19),
+            DayPartExpectation(hour: 21, dayPart: .abends, label: "Am Abend", symbolName: "sunset.fill", representativeHour: 19),
+            DayPartExpectation(hour: 22, dayPart: .nacht, label: "In der Nacht", symbolName: "moon.stars.fill", representativeHour: 23)
         ]
 
         for expectation in expectations {
-            let date = calendar.date(from: DateComponents(year: 2026, month: 4, day: 28, hour: expectation.0))!
+            let date = calendar.date(from: DateComponents(year: 2026, month: 4, day: 28, hour: expectation.hour))!
             let dayPart = EpisodeDayPart(date: date, calendar: calendar)
 
-            #expect(dayPart == expectation.1)
-            #expect(dayPart.contextualLabel == expectation.2)
-            #expect(dayPart.symbolName == expectation.3)
-            #expect(dayPart.representativeHour == expectation.4)
-            #expect(JournalEntryContext.timeOfDay(for: date, calendar: calendar) == expectation.2)
+            #expect(dayPart == expectation.dayPart)
+            #expect(dayPart.contextualLabel == expectation.label)
+            #expect(dayPart.symbolName == expectation.symbolName)
+            #expect(dayPart.representativeHour == expectation.representativeHour)
+            #expect(JournalEntryContext.timeOfDay(for: date, calendar: calendar) == expectation.label)
         }
     }
 
@@ -769,6 +769,14 @@ struct CoreArchitectureTests {
         #expect(syncService.didDeleteCloudData == true)
     }
 
+}
+
+private struct DayPartExpectation {
+    let hour: Int
+    let dayPart: EpisodeDayPart
+    let label: String
+    let symbolName: String
+    let representativeHour: Int
 }
 
 private final class EpisodeRepositoryMock: EpisodeRepository, Sendable {

--- a/SymiTests/DataExportControllerTests.swift
+++ b/SymiTests/DataExportControllerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 @testable import Symi
 
@@ -94,22 +95,25 @@ private func waitUntil(
     }
 }
 
-private final class SpyExportRepository: ExportRepository, @unchecked Sendable {
-    private let lock = NSLock()
-    private var lockedSummaryRequests: [SpyDateRange] = []
-    private var lockedPDFSummaries: [ExportPeriodSummary] = []
+private struct SpyExportRepositoryState: Sendable {
+    var summaryRequests: [SpyDateRange] = []
+    var pdfSummaries: [ExportPeriodSummary] = []
+}
+
+private final class SpyExportRepository: ExportRepository {
+    private let state = OSAllocatedUnfairLock(initialState: SpyExportRepositoryState())
 
     var summaryRequests: [SpyDateRange] {
-        lock.withLock { lockedSummaryRequests }
+        state.withLock { $0.summaryRequests }
     }
 
     var pdfSummaries: [ExportPeriodSummary] {
-        lock.withLock { lockedPDFSummaries }
+        state.withLock { $0.pdfSummaries }
     }
 
     nonisolated func buildSummary(startDate: Date, endDate: Date) throws -> ExportPeriodSummary {
-        lock.withLock {
-            lockedSummaryRequests.append(SpyDateRange(startDate: startDate, endDate: endDate))
+        state.withLock {
+            $0.summaryRequests.append(SpyDateRange(startDate: startDate, endDate: endDate))
         }
 
         return ExportPeriodSummary(
@@ -120,8 +124,8 @@ private final class SpyExportRepository: ExportRepository, @unchecked Sendable {
     }
 
     nonisolated func createPDF(summary: ExportPeriodSummary, mode: PDFReportMode) throws -> URL {
-        lock.withLock {
-            lockedPDFSummaries.append(summary)
+        state.withLock {
+            $0.pdfSummaries.append(summary)
         }
         return FileManager.default.temporaryDirectory.appendingPathComponent("report-\(UUID().uuidString).pdf")
     }

--- a/SymiTests/DataExportControllerTests.swift
+++ b/SymiTests/DataExportControllerTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+@testable import Symi
+
+@MainActor
+struct DataExportControllerTests {
+    @Test
+    func dateRangeUpdateReloadsSummaryWithSelectedDates() async throws {
+        let repository = SpyExportRepository()
+        let controller = DataExportController(repository: repository)
+        let firstRange = makeDateRange(startDay: 1, endDay: 7)
+        let secondRange = makeDateRange(startDay: 8, endDay: 14)
+
+        controller.setDateRange(startDate: firstRange.startDate, endDate: firstRange.endDate, debounce: nil)
+        try await waitUntil {
+            repository.summaryRequests.count == 1 &&
+                controller.summary.startDate == firstRange.startDate &&
+                controller.summary.endDate == firstRange.endDate
+        }
+
+        controller.setDateRange(startDate: secondRange.startDate, endDate: secondRange.endDate, debounce: nil)
+        try await waitUntil {
+            repository.summaryRequests.count == 2 &&
+                controller.summary.startDate == secondRange.startDate &&
+                controller.summary.endDate == secondRange.endDate
+        }
+
+        #expect(repository.summaryRequests == [firstRange, secondRange])
+        #expect(controller.summary.startDate == secondRange.startDate)
+        #expect(controller.summary.endDate == secondRange.endDate)
+    }
+
+    @Test
+    func createPDFUsesSummaryForSelectedDateRange() async throws {
+        let repository = SpyExportRepository()
+        let controller = DataExportController(repository: repository)
+        let selectedRange = makeDateRange(startDay: 3, endDay: 10)
+
+        controller.setDateRange(startDate: selectedRange.startDate, endDate: selectedRange.endDate, debounce: nil)
+        try await waitUntil {
+            repository.summaryRequests.count == 1 &&
+                controller.summary.startDate == selectedRange.startDate &&
+                controller.summary.endDate == selectedRange.endDate
+        }
+
+        controller.createPDF()
+        try await waitUntil { repository.pdfSummaries.count == 1 }
+
+        let pdfSummary = try #require(repository.pdfSummaries.first)
+        #expect(pdfSummary.startDate == selectedRange.startDate)
+        #expect(pdfSummary.endDate == selectedRange.endDate)
+    }
+}
+
+private struct SpyDateRange: Equatable, Sendable {
+    let startDate: Date
+    let endDate: Date
+}
+
+private func makeDateRange(startDay: Int, endDay: Int) -> SpyDateRange {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    let startDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: startDay, hour: 9))!
+    let endDate = calendar.date(from: DateComponents(year: 2026, month: 4, day: endDay, hour: 18))!
+    return SpyDateRange(startDate: startDate, endDate: endDate)
+}
+
+private func makeRecord(startedAt: Date) -> EpisodeExportRecord {
+    EpisodeExportRecord(
+        episode: Episode(
+            startedAt: startedAt,
+            type: .migraine,
+            intensity: 6,
+            painLocation: "Stirn",
+            painCharacter: "Pulsierend"
+        ),
+        healthContext: nil
+    )
+}
+
+private func waitUntil(
+    timeout: Duration = .seconds(10),
+    condition: @MainActor @escaping () -> Bool
+) async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now + timeout
+
+    while !(await condition()) {
+        if clock.now >= deadline {
+            Issue.record("Bedingung wurde nicht rechtzeitig erfüllt.")
+            return
+        }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+}
+
+private final class SpyExportRepository: ExportRepository, @unchecked Sendable {
+    private let lock = NSLock()
+    private var lockedSummaryRequests: [SpyDateRange] = []
+    private var lockedPDFSummaries: [ExportPeriodSummary] = []
+
+    var summaryRequests: [SpyDateRange] {
+        lock.withLock { lockedSummaryRequests }
+    }
+
+    var pdfSummaries: [ExportPeriodSummary] {
+        lock.withLock { lockedPDFSummaries }
+    }
+
+    nonisolated func buildSummary(startDate: Date, endDate: Date) throws -> ExportPeriodSummary {
+        lock.withLock {
+            lockedSummaryRequests.append(SpyDateRange(startDate: startDate, endDate: endDate))
+        }
+
+        return ExportPeriodSummary(
+            startDate: startDate,
+            endDate: endDate,
+            records: [makeRecord(startedAt: startDate)]
+        )
+    }
+
+    nonisolated func createPDF(summary: ExportPeriodSummary, mode: PDFReportMode) throws -> URL {
+        lock.withLock {
+            lockedPDFSummaries.append(summary)
+        }
+        return FileManager.default.temporaryDirectory.appendingPathComponent("report-\(UUID().uuidString).pdf")
+    }
+
+    nonisolated func createBackup() throws -> URL {
+        throw DataTransferError.invalidFormat
+    }
+
+    nonisolated func previewBackupImport(from url: URL) throws -> BackupImportPreview {
+        throw DataTransferError.invalidFormat
+    }
+
+    nonisolated func importBackup(from url: URL) throws -> BackupImportResult {
+        throw DataTransferError.invalidFormat
+    }
+}


### PR DESCRIPTION
## Was geändert wurde
- Zeitraum-Auswahl im Bericht schreibt jetzt konkrete Start-/Enddaten in den DataExportController.
- Der Controller-Default entspricht der UI-Vorauswahl „Letzter Monat“.
- Die nicht implementierte benutzerdefinierte Auswahl ist aus der Range-Liste entfernt, damit jede sichtbare Option exportfähig ist.
- Controller-Tests decken zwei unterschiedliche Zeiträume sowie den PDF-Aufruf mit der geladenen Summary ab.

## Validierung
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination "platform=iOS Simulator,name=iPhone 17" CODE_SIGNING_ALLOWED=NO

Closes #306