### PR TITLE
Sync continuous medication deletions

### DIFF
--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -73,7 +73,7 @@ struct ScreenshotEnvironment {
 enum ScreenshotBootstrap {
     @MainActor
     static func makeEnvironment(seedName: String) throws -> ScreenshotEnvironment {
-        let schema = Schema(versionedSchema: SymiSchemaV7.self)
+        let schema = Schema(versionedSchema: SymiSchemaV8.self)
         let storeURL = FileManager.default.temporaryDirectory.appending(path: "Symi-Screenshots-\(UUID().uuidString).store")
         let configuration = ModelConfiguration(
             "default",

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -69,7 +69,7 @@ struct SymiApp: App {
         storeURL overrideStoreURL: URL? = nil,
         applicationSupportDirectoryURL: URL? = nil
     ) throws -> AppRuntimeEnvironment {
-        let schema = Schema(versionedSchema: SymiSchemaV7.self)
+        let schema = Schema(versionedSchema: SymiSchemaV8.self)
         let storeURL = try resolvedStoreURL(
             overrideStoreURL: overrideStoreURL,
             launchConfiguration: launchConfiguration,
@@ -158,7 +158,7 @@ struct SymiApp: App {
 
     @MainActor
     private static func makeRecoveryContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: SymiSchemaV7.self)
+        let schema = Schema(versionedSchema: SymiSchemaV8.self)
         let configuration = ModelConfiguration(
             "recovery",
             schema: schema,

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -75,8 +75,13 @@ struct ContinuousMedicationRecord: Identifiable, Equatable, Sendable {
     nonisolated let endDate: Date?
     nonisolated let createdAt: Date
     nonisolated let updatedAt: Date
+    nonisolated let deletedAt: Date?
 
     nonisolated var isActive: Bool {
+        guard deletedAt == nil else {
+            return false
+        }
+
         guard let endDate else {
             return true
         }

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -187,6 +187,7 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
 
     nonisolated func fetchAll() throws -> [ContinuousMedicationRecord] {
         let descriptor = FetchDescriptor<ContinuousMedication>(
+            predicate: #Predicate<ContinuousMedication> { $0.deletedAt == nil },
             sortBy: [SortDescriptor(\ContinuousMedication.startDate, order: .reverse), SortDescriptor(\ContinuousMedication.name)]
         )
         return try readContext().fetch(descriptor).map(ContinuousMedicationRecord.init)
@@ -196,11 +197,15 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
         let dayStart = Calendar.current.startOfDay(for: date)
         let descriptor = FetchDescriptor<ContinuousMedication>(
             predicate: #Predicate<ContinuousMedication> { medication in
-                medication.startDate <= dayStart && (medication.endDate == nil || medication.endDate! >= dayStart)
+                medication.deletedAt == nil && medication.startDate <= dayStart
             },
             sortBy: [SortDescriptor(\ContinuousMedication.name)]
         )
-        return try readContext().fetch(descriptor).map(ContinuousMedicationRecord.init)
+        return try readContext().fetch(descriptor)
+            .filter { medication in
+                medication.endDate.map { $0 >= dayStart } ?? true
+            }
+            .map(ContinuousMedicationRecord.init)
     }
 
     @discardableResult
@@ -242,7 +247,7 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
             return
         }
 
-        context.delete(medication)
+        medication.markDeleted()
         try context.save()
         NotificationCenter.default.post(name: .symiLocalSyncDataDidChange, object: nil)
     }
@@ -516,7 +521,8 @@ private extension ContinuousMedicationRecord {
             startDate: medication.startDate,
             endDate: medication.endDate,
             createdAt: medication.createdAt,
-            updatedAt: medication.updatedAt
+            updatedAt: medication.updatedAt,
+            deletedAt: medication.deletedAt
         )
     }
 }

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -262,7 +262,8 @@ struct LocalSyncRepository {
             startDate: payload.startDate,
             endDate: payload.endDate,
             createdAt: payload.createdAt,
-            updatedAt: envelope.modifiedAt
+            updatedAt: envelope.modifiedAt,
+            deletedAt: envelope.deletedAt
         )
 
         target.name = payload.name
@@ -272,6 +273,7 @@ struct LocalSyncRepository {
         target.endDate = payload.endDate
         target.createdAt = payload.createdAt
         target.updatedAt = envelope.modifiedAt
+        target.deletedAt = envelope.deletedAt
 
         if existing == nil {
             context.insert(target)
@@ -685,6 +687,7 @@ extension ContinuousMedication {
             entityType: .continuousMedication,
             modifiedAt: updatedAt,
             authorDeviceID: deviceID,
+            deletedAt: deletedAt,
             payload: .continuousMedication(
                 SyncContinuousMedicationPayload(
                     id: id.uuidString,

--- a/Symi/Sources/Models/CurrentModelAliases.swift
+++ b/Symi/Sources/Models/CurrentModelAliases.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SwiftData
 
-typealias Episode = SymiSchemaV7.Episode
-typealias MedicationEntry = SymiSchemaV7.MedicationEntry
-typealias MedicationDefinition = SymiSchemaV7.MedicationDefinition
-typealias ContinuousMedication = SymiSchemaV7.ContinuousMedication
-typealias ContinuousMedicationCheck = SymiSchemaV7.ContinuousMedicationCheck
-typealias WeatherSnapshot = SymiSchemaV7.WeatherSnapshot
+typealias Episode = SymiSchemaV8.Episode
+typealias MedicationEntry = SymiSchemaV8.MedicationEntry
+typealias MedicationDefinition = SymiSchemaV8.MedicationDefinition
+typealias ContinuousMedication = SymiSchemaV8.ContinuousMedication
+typealias ContinuousMedicationCheck = SymiSchemaV8.ContinuousMedicationCheck
+typealias WeatherSnapshot = SymiSchemaV8.WeatherSnapshot
 // Doctor- und Terminmodelle wurden mit Schema V5 aus dem aktiven Datenmodell entfernt.

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -346,7 +346,7 @@ extension Episode {
 
 extension ContinuousMedication {
     var isActive: Bool {
-        endDate == nil || (endDate ?? .distantPast) >= Calendar.current.startOfDay(for: .now)
+        deletedAt == nil && (endDate == nil || (endDate ?? .distantPast) >= Calendar.current.startOfDay(for: .now))
     }
 
     var detailText: String {
@@ -355,6 +355,17 @@ extension ContinuousMedication {
 
     func markUpdated(at date: Date = .now) {
         updatedAt = date
+        deletedAt = nil
+    }
+
+    func markDeleted(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = date
+    }
+
+    func restore(at date: Date = .now) {
+        updatedAt = date
+        deletedAt = nil
     }
 
     func end(on date: Date = .now) {

--- a/Symi/Sources/Models/SymiMigrationPlan.swift
+++ b/Symi/Sources/Models/SymiMigrationPlan.swift
@@ -10,7 +10,8 @@ enum SymiMigrationPlan: SchemaMigrationPlan {
             SymiSchemaV4.self,
             SymiSchemaV5.self,
             SymiSchemaV6.self,
-            SymiSchemaV7.self
+            SymiSchemaV7.self,
+            SymiSchemaV8.self
         ]
     }
     static var stages: [MigrationStage] {
@@ -117,6 +118,10 @@ enum SymiMigrationPlan: SchemaMigrationPlan {
                     try? FileManager.default.removeItem(at: v6IntensityLevelMigrationURL)
                     try context.save()
                 }
+            ),
+            .lightweight(
+                fromVersion: SymiSchemaV7.self,
+                toVersion: SymiSchemaV8.self
             )
         ]
     }

--- a/Symi/Sources/Models/SymiSchemaV8.swift
+++ b/Symi/Sources/Models/SymiSchemaV8.swift
@@ -1,0 +1,316 @@
+import Foundation
+import SwiftData
+
+enum SymiSchemaV8: VersionedSchema {
+    static let versionIdentifier = Schema.Version(8, 0, 0)
+    static var models: [any PersistentModel.Type] {
+        [
+            Episode.self,
+            MedicationEntry.self,
+            MedicationDefinition.self,
+            ContinuousMedication.self,
+            ContinuousMedicationCheck.self,
+            WeatherSnapshot.self
+        ]
+    }
+
+    @Model
+    final class Episode {
+        @Attribute(.unique) var id: UUID
+        var startedAt: Date
+        var endedAt: Date?
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+        var typeRaw: String
+        var intensityLevelRaw: String = PainIntensityLevel.medium.rawValue
+        var painLocation: String
+        var painCharacter: String
+        var notes: String
+        var symptomsStorage: String
+        var triggersStorage: String
+        var functionalImpact: String
+        var menstruationStatusRaw: String
+
+        @Relationship(deleteRule: .cascade, inverse: \MedicationEntry.episode)
+        var medications: [MedicationEntry]
+
+        @Relationship(deleteRule: .cascade, inverse: \ContinuousMedicationCheck.episode)
+        var continuousMedicationChecks: [ContinuousMedicationCheck]
+
+        @Relationship(deleteRule: .cascade, inverse: \WeatherSnapshot.episode)
+        var weatherSnapshot: WeatherSnapshot?
+
+        init(
+            id: UUID = UUID(),
+            startedAt: Date,
+            endedAt: Date? = nil,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil,
+            typeRaw: String,
+            intensityLevelRaw: String = PainIntensityLevel.medium.rawValue,
+            painLocation: String = "",
+            painCharacter: String = "",
+            notes: String = "",
+            symptomsStorage: String = "",
+            triggersStorage: String = "",
+            functionalImpact: String = "",
+            menstruationStatusRaw: String = MenstruationStatus.unknown.rawValue,
+            medications: [MedicationEntry] = [],
+            continuousMedicationChecks: [ContinuousMedicationCheck] = []
+        ) {
+            self.id = id
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+            self.typeRaw = typeRaw
+            self.intensityLevelRaw = intensityLevelRaw
+            self.painLocation = painLocation
+            self.painCharacter = painCharacter
+            self.notes = notes
+            self.symptomsStorage = symptomsStorage
+            self.triggersStorage = triggersStorage
+            self.functionalImpact = functionalImpact
+            self.menstruationStatusRaw = menstruationStatusRaw
+            self.medications = medications
+            self.continuousMedicationChecks = continuousMedicationChecks
+        }
+
+        convenience init(
+            id: UUID = UUID(),
+            startedAt: Date,
+            endedAt: Date? = nil,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil,
+            typeRaw: String,
+            intensity: Int,
+            painLocation: String = "",
+            painCharacter: String = "",
+            notes: String = "",
+            symptomsStorage: String = "",
+            triggersStorage: String = "",
+            functionalImpact: String = "",
+            menstruationStatusRaw: String = MenstruationStatus.unknown.rawValue,
+            medications: [MedicationEntry] = [],
+            continuousMedicationChecks: [ContinuousMedicationCheck] = []
+        ) {
+            self.init(
+                id: id,
+                startedAt: startedAt,
+                endedAt: endedAt,
+                updatedAt: updatedAt,
+                deletedAt: deletedAt,
+                typeRaw: typeRaw,
+                intensityLevelRaw: PainIntensityLevel(intensity: intensity).rawValue,
+                painLocation: painLocation,
+                painCharacter: painCharacter,
+                notes: notes,
+                symptomsStorage: symptomsStorage,
+                triggersStorage: triggersStorage,
+                functionalImpact: functionalImpact,
+                menstruationStatusRaw: menstruationStatusRaw,
+                medications: medications,
+                continuousMedicationChecks: continuousMedicationChecks
+            )
+        }
+    }
+
+    @Model
+    final class MedicationEntry {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var categoryRaw: String
+        var dosage: String
+        var quantity: Int
+        var takenAt: Date
+        var effectivenessRaw: String
+        var reliefStartedAt: Date?
+        var isRepeatDose: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            categoryRaw: String,
+            dosage: String,
+            quantity: Int = 1,
+            takenAt: Date,
+            effectivenessRaw: String,
+            reliefStartedAt: Date? = nil,
+            isRepeatDose: Bool = false,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.dosage = dosage
+            self.quantity = quantity
+            self.takenAt = takenAt
+            self.effectivenessRaw = effectivenessRaw
+            self.reliefStartedAt = reliefStartedAt
+            self.isRepeatDose = isRepeatDose
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class MedicationDefinition {
+        @Attribute(.unique) var catalogKey: String
+        var groupID: String
+        var groupTitle: String
+        var groupFooter: String?
+        var name: String
+        var categoryRaw: String
+        var suggestedDosage: String
+        var sortOrder: Int
+        var isCustom: Bool
+        var createdAt: Date
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+
+        init(
+            catalogKey: String,
+            groupID: String,
+            groupTitle: String,
+            groupFooter: String? = nil,
+            name: String,
+            categoryRaw: String,
+            suggestedDosage: String,
+            sortOrder: Int,
+            isCustom: Bool,
+            createdAt: Date = .now,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil
+        ) {
+            self.catalogKey = catalogKey
+            self.groupID = groupID
+            self.groupTitle = groupTitle
+            self.groupFooter = groupFooter
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.suggestedDosage = suggestedDosage
+            self.sortOrder = sortOrder
+            self.isCustom = isCustom
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+        }
+    }
+
+    @Model
+    final class ContinuousMedication {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var dosage: String
+        var frequency: String
+        var startDate: Date
+        var endDate: Date?
+        var createdAt: Date
+        var updatedAt: Date
+        var deletedAt: Date?
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            dosage: String = "",
+            frequency: String = "",
+            startDate: Date,
+            endDate: Date? = nil,
+            createdAt: Date = .now,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.dosage = dosage
+            self.frequency = frequency
+            self.startDate = startDate
+            self.endDate = endDate
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+        }
+    }
+
+    @Model
+    final class ContinuousMedicationCheck {
+        @Attribute(.unique) var id: UUID
+        var continuousMedicationID: UUID
+        var name: String
+        var dosage: String
+        var frequency: String
+        var wasTaken: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            continuousMedicationID: UUID,
+            name: String,
+            dosage: String = "",
+            frequency: String = "",
+            wasTaken: Bool,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.continuousMedicationID = continuousMedicationID
+            self.name = name
+            self.dosage = dosage
+            self.frequency = frequency
+            self.wasTaken = wasTaken
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class WeatherSnapshot {
+        @Attribute(.unique) var id: UUID
+        var recordedAt: Date
+        var temperature: Double?
+        var condition: String
+        var humidity: Double?
+        var pressure: Double?
+        var precipitation: Double?
+        var weatherCode: Int?
+        var source: String
+        var dayRangeStart: Date?
+        var dayRangeEnd: Date?
+        var contextRangeStart: Date?
+        var contextRangeEnd: Date?
+        var contextPointsStorage: String = ""
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            recordedAt: Date,
+            temperature: Double? = nil,
+            condition: String = "",
+            humidity: Double? = nil,
+            pressure: Double? = nil,
+            precipitation: Double? = nil,
+            weatherCode: Int? = nil,
+            source: String = "",
+            dayRangeStart: Date? = nil,
+            dayRangeEnd: Date? = nil,
+            contextRangeStart: Date? = nil,
+            contextRangeEnd: Date? = nil,
+            contextPointsStorage: String = "",
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.recordedAt = recordedAt
+            self.temperature = temperature
+            self.condition = condition
+            self.humidity = humidity
+            self.pressure = pressure
+            self.precipitation = precipitation
+            self.weatherCode = weatherCode
+            self.source = source
+            self.dayRangeStart = dayRangeStart
+            self.dayRangeEnd = dayRangeEnd
+            self.contextRangeStart = contextRangeStart
+            self.contextRangeEnd = contextRangeEnd
+            self.contextPointsStorage = contextPointsStorage
+            self.episode = episode
+        }
+    }
+}

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -276,7 +276,7 @@ struct DataTransferHealthContextTests {
 }
 
 private func makeInMemoryContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV7.self)
+    let schema = Schema(versionedSchema: SymiSchemaV8.self)
     let configuration = ModelConfiguration(
         "test-\(UUID().uuidString)",
         schema: schema,

--- a/SymiTests/DomainValidatorTests.swift
+++ b/SymiTests/DomainValidatorTests.swift
@@ -173,7 +173,7 @@ struct DomainValidatorTests {
 }
 
 private func makeInMemoryContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV7.self)
+    let schema = Schema(versionedSchema: SymiSchemaV8.self)
     let configuration = ModelConfiguration(
         "domain-validator-tests-\(UUID().uuidString)",
         schema: schema,

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -57,7 +57,8 @@ struct EntryFlowCoordinatorTests {
                 startDate: .now,
                 endDate: nil,
                 createdAt: .now,
-                updatedAt: .now
+                updatedAt: .now,
+                deletedAt: nil
             )
         ])
         let coordinator = makeCoordinator(continuousMedicationRepository: repository)
@@ -338,7 +339,8 @@ private final class EntryFlowContinuousMedicationRepositoryMock: ContinuousMedic
             startDate: draft.startDate,
             endDate: draft.endDate,
             createdAt: .now,
-            updatedAt: .now
+            updatedAt: .now,
+            deletedAt: nil
         )
     }
     func delete(id: UUID) throws {}

--- a/SymiTests/SwiftDataMigrationFixtureTests.swift
+++ b/SymiTests/SwiftDataMigrationFixtureTests.swift
@@ -435,7 +435,7 @@ private func makeFixtureContainer<SchemaType: VersionedSchema>(
 }
 
 private func makeFixtureCurrentContainer(storeURL: URL) throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV7.self)
+    let schema = Schema(versionedSchema: SymiSchemaV8.self)
     let configuration = ModelConfiguration("migration-fixture-test", schema: schema, url: storeURL, cloudKitDatabase: .none)
     return try ModelContainer(
         for: schema,

--- a/SymiTests/SwiftDataMigrationTests.swift
+++ b/SymiTests/SwiftDataMigrationTests.swift
@@ -268,7 +268,7 @@ private func makeContainer<SchemaType: VersionedSchema>(
 }
 
 private func makeCurrentContainer(storeURL: URL) throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV7.self)
+    let schema = Schema(versionedSchema: SymiSchemaV8.self)
     let configuration = ModelConfiguration("migration-test", schema: schema, url: storeURL, cloudKitDatabase: .none)
     return try ModelContainer(
         for: schema,

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -338,6 +338,76 @@ struct SyncMergeEngineTests {
 
     @Test
     @MainActor
+    func localContinuousMedicationDeleteCreatesTombstoneEnvelope() throws {
+        let stack = try makeSyncTestStack()
+        let repository = SwiftDataContinuousMedicationRepository(modelContainer: stack.container)
+        let medicationID = try repository.save(
+            ContinuousMedicationDraft(
+                name: "Metoprolol",
+                dosage: "47,5 mg",
+                frequency: "morgens",
+                startDate: Date(timeIntervalSince1970: 500)
+            )
+        ).id
+
+        try repository.delete(id: medicationID)
+
+        let envelope = try requireEnvelope(
+            from: stack.repository,
+            documentID: "continuousMedication:\(medicationID.uuidString)"
+        )
+
+        #expect(envelope.deletedAt != nil)
+        #expect(envelope.payload.continuousMedicationPayload?.name == "Metoprolol")
+        #expect(try repository.fetchAll().isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func remoteContinuousMedicationTombstoneSoftDeletesLocalMedication() throws {
+        let stack = try makeSyncTestStack()
+        let repository = SwiftDataContinuousMedicationRepository(modelContainer: stack.container)
+        let medicationID = try repository.save(
+            ContinuousMedicationDraft(
+                name: "Magnesium",
+                dosage: "300 mg",
+                frequency: "abends",
+                startDate: Date(timeIntervalSince1970: 500)
+            )
+        ).id
+        let deletionDate = Date(timeIntervalSince1970: 2_000)
+        let remoteEnvelope = SyncDocumentEnvelope(
+            documentID: "continuousMedication:\(medicationID.uuidString)",
+            entityType: .continuousMedication,
+            modifiedAt: deletionDate,
+            authorDeviceID: "device-remote",
+            deletedAt: deletionDate,
+            payload: .continuousMedication(
+                SyncContinuousMedicationPayload(
+                    id: medicationID.uuidString,
+                    name: "Magnesium",
+                    dosage: "300 mg",
+                    frequency: "abends",
+                    startDate: Date(timeIntervalSince1970: 500),
+                    endDate: nil,
+                    createdAt: Date(timeIntervalSince1970: 400)
+                )
+            )
+        )
+
+        try stack.repository.apply(remote: remoteEnvelope)
+
+        let storedEnvelope = try requireEnvelope(
+            from: stack.repository,
+            documentID: "continuousMedication:\(medicationID.uuidString)"
+        )
+
+        #expect(storedEnvelope.deletedAt == deletionDate)
+        #expect(try repository.fetchActive(on: Date(timeIntervalSince1970: 2_500)).isEmpty)
+    }
+
+    @Test
+    @MainActor
     func remoteEpisodeSyncAppliesContinuousMedicationChecksAndHealthContext() throws {
         let stack = try makeSyncTestStack()
         let episodeID = UUID(uuidString: "22222222-3333-4444-5555-666666666666")!
@@ -838,7 +908,7 @@ private extension Array {
 
 @MainActor
 private func makeSyncTestStack(provider: FakeSyncProvider? = nil) throws -> SyncTestStack {
-    let schema = Schema(versionedSchema: SymiSchemaV7.self)
+    let schema = Schema(versionedSchema: SymiSchemaV8.self)
     let configuration = ModelConfiguration(
         "sync-tests-\(UUID().uuidString)",
         schema: schema,


### PR DESCRIPTION
## Summary
- add SwiftData schema V8 with deletedAt support for continuous medications
- soft-delete continuous medications locally and propagate tombstone envelopes
- apply remote continuous medication tombstones and hide deleted medication from normal fetches
- add sync coverage for local and remote continuous medication deletions

## Verification
- swiftlint
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'

Closes #308