### PR TITLE
Make backup import sidecars atomic

### DIFF
--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -256,8 +256,9 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
             }
         }
 
-        try context.save()
-        try mergeEpisodeSidecars(into: healthContextStore)
+        try healthContextStore.save(episodeSidecarChanges()) {
+            try context.save()
+        }
     }
 
     private nonisolated func validateDomainInvariants() throws {
@@ -276,10 +277,8 @@ struct DataTransferSnapshot: @preconcurrency Encodable, Decodable, Sendable {
         }
     }
 
-    private nonisolated func mergeEpisodeSidecars(into healthContextStore: HealthContextStore) throws {
-        for payload in episodes {
-            try payload.applySidecars(to: healthContextStore)
-        }
+    private nonisolated func episodeSidecarChanges() -> [HealthContextSidecarChange] {
+        episodes.compactMap(\.sidecarChange)
     }
 
     private nonisolated static func fileDateString(from date: Date) -> String {
@@ -559,12 +558,12 @@ struct EpisodePayload: Codable, Sendable {
             episode.continuousMedicationChecks.map(\.id) != continuousMedicationChecks.map(\.id)
     }
 
-    nonisolated func applySidecars(to healthContextStore: HealthContextStore) throws {
+    nonisolated var sidecarChange: HealthContextSidecarChange? {
         guard shouldImportHealthContext else {
-            return
+            return nil
         }
 
-        try healthContextStore.save(healthContext, for: id)
+        return HealthContextSidecarChange(episodeID: id, snapshot: healthContext)
     }
 
     nonisolated func domainValidationIssues(path: String) -> [String] {

--- a/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
+++ b/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct HealthContextSidecarChange: Sendable {
+    let episodeID: UUID
+    let snapshot: HealthContextSnapshotData?
+}
+
 final class HealthContextStore: Sendable {
     private let directoryURL: URL
 
@@ -28,6 +33,33 @@ final class HealthContextStore: Sendable {
         try ProtectedFileStorage.applyProtection(to: url)
     }
 
+    nonisolated func save(_ changes: [HealthContextSidecarChange], committing commit: () throws -> Void) throws {
+        guard !changes.isEmpty else {
+            try commit()
+            return
+        }
+
+        let backupDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("Symi-HealthContext-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: backupDirectoryURL, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: backupDirectoryURL)
+        }
+
+        let backups = try sidecarBackups(for: changes.map(\.episodeID), in: backupDirectoryURL)
+
+        do {
+            for change in changes {
+                try save(change.snapshot, for: change.episodeID)
+            }
+
+            try commit()
+        } catch {
+            try? restoreSidecars(from: backups)
+            throw error
+        }
+    }
+
     nonisolated func load(for episodeID: UUID) -> HealthContextRecord? {
         let url = fileURL(for: episodeID)
         let decoder = JSONDecoder()
@@ -42,4 +74,37 @@ final class HealthContextStore: Sendable {
     nonisolated private func fileURL(for episodeID: UUID) -> URL {
         directoryURL.appendingPathComponent("\(episodeID.uuidString).json")
     }
+
+    nonisolated private func sidecarBackups(for episodeIDs: [UUID], in backupDirectoryURL: URL) throws -> [SidecarBackup] {
+        try Array(Set(episodeIDs)).map { episodeID in
+            let originalURL = fileURL(for: episodeID)
+            let backupURL = backupDirectoryURL.appendingPathComponent("\(episodeID.uuidString).json")
+
+            guard FileManager.default.fileExists(atPath: originalURL.path) else {
+                return SidecarBackup(originalURL: originalURL, backupURL: nil)
+            }
+
+            try FileManager.default.copyItem(at: originalURL, to: backupURL)
+            return SidecarBackup(originalURL: originalURL, backupURL: backupURL)
+        }
+    }
+
+    nonisolated private func restoreSidecars(from backups: [SidecarBackup]) throws {
+        for backup in backups {
+            if FileManager.default.fileExists(atPath: backup.originalURL.path) {
+                try FileManager.default.removeItem(at: backup.originalURL)
+            }
+
+            if let backupURL = backup.backupURL {
+                try ProtectedFileStorage.createProtectedDirectory(at: directoryURL)
+                try FileManager.default.copyItem(at: backupURL, to: backup.originalURL)
+                try ProtectedFileStorage.applyProtection(to: backup.originalURL)
+            }
+        }
+    }
+}
+
+private struct SidecarBackup {
+    let originalURL: URL
+    let backupURL: URL?
 }

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -217,18 +217,23 @@ struct DataTransferHealthContextTests {
         let blockedBaseURL = try makeTemporaryDirectory()
         try Data("blockiert".utf8).write(to: blockedBaseURL.appending(path: "Symi"))
         let blockedHealthStore = HealthContextStore(baseURL: blockedBaseURL)
+        let targetContainer = try makeInMemoryContainer()
+        try seedEpisode(id: episodeID, notes: "Lokaler Stand", in: targetContainer)
 
         var didThrow = false
         do {
             _ = try SwiftDataExportRepository(
-                modelContainer: try makeInMemoryContainer(),
+                modelContainer: targetContainer,
                 healthContextStore: blockedHealthStore
             ).importBackup(from: backupURL)
         } catch {
             didThrow = true
         }
 
+        let storedEpisode = try #require(try ModelContext(targetContainer).fetch(FetchDescriptor<Episode>()).first)
         #expect(didThrow)
+        #expect(storedEpisode.notes == "Lokaler Stand")
+        #expect(blockedHealthStore.load(for: episodeID) == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make HealthContext sidecar writes rollbackable around backup import commits
- move backup import persistence through the sidecar transaction so Sidecar-Fehler keine SwiftData-Änderungen speichern
- extend the HealthContext import failure regression test to verify existing SwiftData remains unchanged

## Validation
- swiftlint
- xcodebuild test -project Symi.xcodeproj -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SymiTests/DataTransferHealthContextTests/importThrowsWhenHealthContextCannotBeWritten
- xcodebuild test -project Symi.xcodeproj -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:SymiTests/DataTransferHealthContextTests

Closes #309