### PR TITLE
[codex] Fix HealthContext sidecar load errors

### DIFF
--- a/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
+++ b/Symi/Sources/Infrastructure/Health/HealthContextStore.swift
@@ -6,6 +6,17 @@ struct HealthContextSidecarChange: Sendable {
 }
 
 final class HealthContextStore: Sendable {
+    enum LoadError: LocalizedError {
+        case unreadableSidecar(episodeID: UUID, underlyingError: Error)
+
+        var errorDescription: String? {
+            switch self {
+            case let .unreadableSidecar(episodeID, _):
+                return "Der Apple-Health-Kontext für Eintrag \(episodeID.uuidString) konnte nicht gelesen werden."
+            }
+        }
+    }
+
     private let directoryURL: URL
 
     init(baseURL: URL? = nil) {
@@ -61,14 +72,25 @@ final class HealthContextStore: Sendable {
     }
 
     nonisolated func load(for episodeID: UUID) -> HealthContextRecord? {
+        try? loadIfPresent(for: episodeID)
+    }
+
+    nonisolated func loadIfPresent(for episodeID: UUID) throws -> HealthContextRecord? {
         let url = fileURL(for: episodeID)
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        guard let data = try? Data(contentsOf: url), let snapshot = try? decoder.decode(HealthContextSnapshotData.self, from: data) else {
+        guard FileManager.default.fileExists(atPath: url.path) else {
             return nil
         }
 
-        return HealthContextRecord(snapshot: snapshot)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        do {
+            let data = try Data(contentsOf: url)
+            let snapshot = try decoder.decode(HealthContextSnapshotData.self, from: data)
+            return HealthContextRecord(snapshot: snapshot)
+        } catch {
+            throw LoadError.unreadableSidecar(episodeID: episodeID, underlyingError: error)
+        }
     }
 
     nonisolated private func fileURL(for episodeID: UUID) -> URL {

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -404,7 +404,9 @@ final class SwiftDataExportRepository: ExportRepository, Sendable {
             FetchDescriptor<Episode>(sortBy: [SortDescriptor(\Episode.startedAt, order: .reverse)]),
             batchSize: Self.fetchBatchSize
         ) { batch in
-            episodes += batch.map { EpisodePayload(episode: $0, healthContext: healthContextStore.load(for: $0.id)) }
+            episodes += try batch.map {
+                EpisodePayload(episode: $0, healthContext: try healthContextStore.loadIfPresent(for: $0.id))
+            }
         }
 
         try readContext.fetchBatches(

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -22,7 +22,7 @@ struct LocalSyncRepository {
             batchSize: Self.fetchBatchSize
         ) { episodes in
             try episodes.forEach(DomainValidator.validate)
-            envelopes += episodes.map { $0.syncEnvelope(deviceID: deviceID, healthContextStore: healthContextStore) }
+            envelopes += try episodes.map { try $0.syncEnvelope(deviceID: deviceID, healthContextStore: healthContextStore) }
         }
 
         try context.fetchBatches(
@@ -608,8 +608,8 @@ enum RemoteSyncPayloadValidator {
 }
 
 extension Episode {
-    func syncEnvelope(deviceID: String, healthContextStore: HealthContextStore) -> SyncDocumentEnvelope {
-        let healthContext = healthContextStore.load(for: id).map(HealthContextSnapshotData.init)
+    func syncEnvelope(deviceID: String, healthContextStore: HealthContextStore) throws -> SyncDocumentEnvelope {
+        let healthContext = try healthContextStore.loadIfPresent(for: id).map(HealthContextSnapshotData.init)
 
         return SyncDocumentEnvelope(
             documentID: "episode:\(id.uuidString)",

--- a/SymiTests/DataExportControllerTests.swift
+++ b/SymiTests/DataExportControllerTests.swift
@@ -155,7 +155,7 @@ private func makeRecord(startedAt: Date) -> EpisodeExportRecord {
 }
 
 private func waitUntil(
-    timeout: Duration = .seconds(10),
+    timeout: Duration = .seconds(30),
     condition: @MainActor @escaping () -> Bool
 ) async throws {
     let clock = ContinuousClock()

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -109,6 +109,46 @@ struct DataTransferHealthContextTests {
     }
 
     @Test
+    func backupExportThrowsWhenExistingHealthContextSidecarIsCorrupt() throws {
+        let episodeID = UUID()
+        let sourceContainer = try makeInMemoryContainer()
+        let baseURL = try makeTemporaryDirectory()
+        let sourceHealthStore = HealthContextStore(baseURL: baseURL)
+        try seedEpisode(id: episodeID, in: sourceContainer)
+        try writeCorruptHealthContextSidecar(baseURL: baseURL, episodeID: episodeID)
+
+        do {
+            _ = try SwiftDataExportRepository(
+                modelContainer: sourceContainer,
+                healthContextStore: sourceHealthStore
+            ).createBackup()
+            Issue.record("Backup-Export sollte bei korruptem HealthContext-Sidecar fehlschlagen.")
+        } catch HealthContextStore.LoadError.unreadableSidecar(let failedEpisodeID, _) {
+            #expect(failedEpisodeID == episodeID)
+        }
+    }
+
+    @Test
+    func syncEnvelopeThrowsWhenExistingHealthContextSidecarIsCorrupt() throws {
+        let episodeID = UUID()
+        let container = try makeInMemoryContainer()
+        let baseURL = try makeTemporaryDirectory()
+        let healthStore = HealthContextStore(baseURL: baseURL)
+        try seedEpisode(id: episodeID, in: container)
+        try writeCorruptHealthContextSidecar(baseURL: baseURL, episodeID: episodeID)
+
+        do {
+            _ = try LocalSyncRepository(
+                modelContainer: container,
+                healthContextStore: healthStore
+            ).envelope(documentID: "episode:\(episodeID.uuidString)", deviceID: "test-device")
+            Issue.record("Sync-Envelope sollte bei korruptem HealthContext-Sidecar fehlschlagen.")
+        } catch HealthContextStore.LoadError.unreadableSidecar(let failedEpisodeID, _) {
+            #expect(failedEpisodeID == episodeID)
+        }
+    }
+
+    @Test
     func explicitNullHealthContextRemovesExistingContext() throws {
         let episodeID = UUID()
         let sourceContainer = try makeInMemoryContainer()
@@ -420,6 +460,15 @@ private func backupURLByAddingExplicitNullHealthContext(to backupURL: URL) throw
     let url = try makeTemporaryDirectory().appending(path: "explicit-null-health-context.json5")
     try explicitNullData.write(to: url, options: .atomic)
     return url
+}
+
+private func writeCorruptHealthContextSidecar(baseURL: URL, episodeID: UUID) throws {
+    let sidecarDirectoryURL = baseURL
+        .appendingPathComponent("Symi", isDirectory: true)
+        .appendingPathComponent("HealthContext", isDirectory: true)
+    try FileManager.default.createDirectory(at: sidecarDirectoryURL, withIntermediateDirectories: true)
+    try Data("kein gültiger HealthContext".utf8)
+        .write(to: sidecarDirectoryURL.appendingPathComponent("\(episodeID.uuidString).json"), options: .atomic)
 }
 
 private func makeLegacyGermanBackupURL(episodeID: UUID) throws -> URL {


### PR DESCRIPTION
## Summary
- add a throwing HealthContext sidecar load path that distinguishes missing files from unreadable or corrupt files
- make sync envelope creation and backup export fail on unreadable existing HealthContext sidecars instead of emitting `healthContext: null`
- add regression tests for corrupt sidecars in backup export and local sync

## Validation
- `swiftlint`
- `xcodebuild test -scheme Symi -destination 'platform=iOS Simulator,name=iPhone 16'`

Closes #310
