### PR TITLE
Surface Apple Health save warnings

### DIFF
--- a/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
+++ b/Symi/Sources/Core/Episodes/EntryFlowCoordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 
 enum EntryFlowStep: String, CaseIterable, Identifiable, Hashable, Sendable {
     case headache
@@ -12,8 +13,38 @@ enum EntryFlowStep: String, CaseIterable, Identifiable, Hashable, Sendable {
 }
 
 enum EntryFlowSaveResult: Equatable, Sendable {
-    case saved(UUID)
+    case saved(UUID, healthWarning: String?)
     case failed(String)
+}
+
+enum EpisodeHealthSaveWarning: Equatable, Sendable {
+    case contextUnavailable
+    case writeFailed
+    case contextUnavailableAndWriteFailed
+
+    var message: String {
+        switch self {
+        case .contextUnavailable:
+            "Dein Eintrag wurde lokal gespeichert. Apple-Health-Kontext konnte nicht gelesen werden."
+        case .writeFailed:
+            "Dein Eintrag wurde lokal gespeichert. Das Schreiben nach Apple Health ist fehlgeschlagen."
+        case .contextUnavailableAndWriteFailed:
+            "Dein Eintrag wurde lokal gespeichert. Apple-Health-Kontext konnte nicht gelesen und der Eintrag nicht nach Apple Health geschrieben werden."
+        }
+    }
+
+    static func make(contextFailed: Bool, writeFailed: Bool) -> EpisodeHealthSaveWarning? {
+        switch (contextFailed, writeFailed) {
+        case (true, true):
+            .contextUnavailableAndWriteFailed
+        case (true, false):
+            .contextUnavailable
+        case (false, true):
+            .writeFailed
+        case (false, false):
+            nil
+        }
+    }
 }
 
 enum EntryStartedAtPreset: String, CaseIterable, Identifiable, Sendable {
@@ -94,6 +125,7 @@ final class EntryContinuousMedicationController {
 @Observable
 final class EntryFlowCoordinator {
     static let steps: [EntryFlowStep] = [.headache, .medication, .triggers, .note, .review]
+    private static let healthLogger = Logger(subsystem: "Symi", category: "Health")
 
     let symptomOptions = EpisodeSymptomOption.allCases.map(\.displayLabel)
     let triggerOptions = EpisodeTriggerOption.allCases.map(\.displayLabel)
@@ -313,14 +345,18 @@ final class EntryFlowCoordinator {
 
             do {
                 let weatherSnapshot = try await weatherSnapshotForSave(startedAt: draftForSave.startedAt)
-                let healthContext = await healthContextForSave(draft: draftForSave)
+                let healthContextResult = await healthContextForSave(draft: draftForSave)
                 let savedID = try await saveEpisodeUseCase.execute(
                     draftForSave,
                     weatherSnapshot: weatherSnapshot,
-                    healthContext: healthContext
+                    healthContext: healthContextResult.snapshot
                 )
-                await writeHealthSampleIfNeeded(episodeID: savedID, draft: draftForSave)
-                saveResult = .saved(savedID)
+                let writeFailed = await writeHealthSampleIfNeeded(episodeID: savedID, draft: draftForSave)
+                let healthWarning = EpisodeHealthSaveWarning.make(
+                    contextFailed: healthContextResult.failed,
+                    writeFailed: writeFailed
+                )
+                saveResult = .saved(savedID, healthWarning: healthWarning?.message)
 
                 if resetAfterSave {
                     cancel()
@@ -343,18 +379,23 @@ final class EntryFlowCoordinator {
         return resolution.snapshot
     }
 
-    private func healthContextForSave(draft: EpisodeDraft) async -> HealthContextSnapshotData? {
+    private func healthContextForSave(draft: EpisodeDraft) async -> (snapshot: HealthContextSnapshotData?, failed: Bool) {
         do {
-            return try await healthService.contextSnapshot(for: draft)
+            return (try await healthService.contextSnapshot(for: draft), false)
         } catch {
-            return nil
+            Self.healthLogger.warning("Apple-Health-Kontext konnte nicht gelesen werden: \(error.localizedDescription, privacy: .public)")
+            return (nil, true)
         }
     }
 
-    private func writeHealthSampleIfNeeded(episodeID: UUID, draft: EpisodeDraft) async {
+    private func writeHealthSampleIfNeeded(episodeID: UUID, draft: EpisodeDraft) async -> Bool {
         do {
             try await healthService.writeEpisode(id: episodeID, draft: draft)
-        } catch {}
+            return false
+        } catch {
+            Self.healthLogger.warning("Apple-Health-Sample konnte nicht geschrieben werden: \(error.localizedDescription, privacy: .public)")
+            return true
+        }
     }
 
     private func saveFailureMessage(for error: Error) -> String {

--- a/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeEditorController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 
 enum WeatherLoadState: Equatable {
     case idle
@@ -365,6 +366,8 @@ final class EpisodeMedicationSelectionController {
 @MainActor
 @Observable
 final class EpisodeEditorController {
+    private static let healthLogger = Logger(subsystem: "Symi", category: "Health")
+
     let mode: EpisodeEditorMode
     let symptomOptions = EpisodeSymptomOption.allCases.map(\.displayLabel)
     let triggerOptions = EpisodeTriggerOption.allCases.map(\.displayLabel)
@@ -374,6 +377,7 @@ final class EpisodeEditorController {
     var saveMessageVisible = false
     var isSaving = false
     var weatherLoadState: WeatherLoadState = .idle
+    private(set) var healthSaveWarningMessage: String?
 
     private var saveValidationMessage: String?
     private let saveEpisodeUseCase: SaveEpisodeUseCase
@@ -421,7 +425,7 @@ final class EpisodeEditorController {
     }
 
     var validationMessage: String? {
-        saveValidationMessage ?? medicationController.validationMessage
+        saveValidationMessage ?? healthSaveWarningMessage ?? medicationController.validationMessage
     }
 
     var syncStalenessWarning: String? {
@@ -441,6 +445,7 @@ final class EpisodeEditorController {
         }
 
         saveValidationMessage = nil
+        healthSaveWarningMessage = nil
         medicationController.validationMessage = nil
         isSaving = true
 
@@ -451,13 +456,23 @@ final class EpisodeEditorController {
                 do {
                     let draftForSave = makeDraftForSave()
                     let weatherSnapshot = try await weatherSnapshotForSave(startedAt: draftForSave.startedAt)
-                    let healthContext = await healthContextForSave(draft: draftForSave)
-                    let savedID = try await saveEpisodeUseCase.execute(draftForSave, weatherSnapshot: weatherSnapshot, healthContext: healthContext)
-                    await writeHealthSampleIfNeeded(episodeID: savedID, draft: draftForSave)
+                    let healthContextResult = await healthContextForSave(draft: draftForSave)
+                    let savedID = try await saveEpisodeUseCase.execute(
+                        draftForSave,
+                        weatherSnapshot: weatherSnapshot,
+                        healthContext: healthContextResult.snapshot
+                    )
+                    let writeFailed = await writeHealthSampleIfNeeded(episodeID: savedID, draft: draftForSave)
                     await medicationController.reloadDefinitions()
                     saveValidationMessage = nil
+                    healthSaveWarningMessage = EpisodeHealthSaveWarning.make(
+                        contextFailed: healthContextResult.failed,
+                        writeFailed: writeFailed
+                    )?.message
 
-                    if mode == .create, onSaved == nil {
+                    if healthSaveWarningMessage != nil {
+                        saveMessageVisible = true
+                    } else if mode == .create, onSaved == nil {
                         draft = EpisodeDraft.makeNew()
                         medicationController.resetSelections()
                         weatherLoadState = .idle
@@ -521,17 +536,22 @@ final class EpisodeEditorController {
         return resolution.snapshot
     }
 
-    private func healthContextForSave(draft: EpisodeDraft) async -> HealthContextSnapshotData? {
+    private func healthContextForSave(draft: EpisodeDraft) async -> (snapshot: HealthContextSnapshotData?, failed: Bool) {
         do {
-            return try await healthService.contextSnapshot(for: draft)
+            return (try await healthService.contextSnapshot(for: draft), false)
         } catch {
-            return nil
+            Self.healthLogger.warning("Apple-Health-Kontext konnte nicht gelesen werden: \(error.localizedDescription, privacy: .public)")
+            return (nil, true)
         }
     }
 
-    private func writeHealthSampleIfNeeded(episodeID: UUID, draft: EpisodeDraft) async {
+    private func writeHealthSampleIfNeeded(episodeID: UUID, draft: EpisodeDraft) async -> Bool {
         do {
             try await healthService.writeEpisode(id: episodeID, draft: draft)
-        } catch {}
+            return false
+        } catch {
+            Self.healthLogger.warning("Apple-Health-Sample konnte nicht geschrieben werden: \(error.localizedDescription, privacy: .public)")
+            return true
+        }
     }
 }

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -35,7 +35,11 @@ struct EntryFlowCoordinatorView: View {
         .alert("Eintrag gespeichert", isPresented: savedBinding) {
             Button("OK", role: .cancel, action: finishAfterSave)
         } message: {
-            Text("Dein Eintrag wurde lokal gespeichert.")
+            if case .saved(_, let healthWarning) = coordinator.saveResult, let healthWarning {
+                Text(healthWarning)
+            } else {
+                Text("Dein Eintrag wurde lokal gespeichert.")
+            }
         }
         .alert("Eintrag konnte nicht gespeichert werden", isPresented: failedBinding) {
             Button("OK", role: .cancel) {

--- a/Symi/Sources/Features/Capture/EpisodeEditorView.swift
+++ b/Symi/Sources/Features/Capture/EpisodeEditorView.swift
@@ -67,7 +67,7 @@ struct EpisodeEditorView: View {
         .alert("Eintrag gespeichert", isPresented: $controller.saveMessageVisible) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("Dein Eintrag wurde lokal gespeichert.")
+            Text(controller.healthSaveWarningMessage ?? "Dein Eintrag wurde lokal gespeichert.")
         }
         .sheet(item: $medicationController.customMedicationEditor) { editorState in
             NavigationStack {

--- a/SymiTests/EntryFlowCoordinatorTests.swift
+++ b/SymiTests/EntryFlowCoordinatorTests.swift
@@ -105,7 +105,7 @@ struct EntryFlowCoordinatorTests {
         #expect(repository.lastSavedDraft?.type == .headache)
         #expect(repository.lastSavedDraft?.intensity == 4)
         #expect(repository.lastSavedDraft?.resolvedPainLocation == "Schläfen, Stirn")
-        #expect(coordinator.saveResult == .saved(repository.savedID))
+        #expect(coordinator.saveResult == .saved(repository.savedID, healthWarning: nil))
     }
 
     @Test
@@ -147,6 +147,67 @@ struct EntryFlowCoordinatorTests {
         #expect(repository.lastWeatherSnapshot == makeWeatherSnapshot())
         #expect(repository.lastHealthContext == makeHealthContext())
         #expect(healthService.writtenEpisodeID == repository.savedID)
+    }
+
+    @Test
+    func reviewSaveSurfacesHealthContextFailureWithoutBlockingLocalSave() async throws {
+        let repository = EntryFlowEpisodeRepositoryMock()
+        let healthService = EntryFlowHealthServiceMock(contextError: EntryFlowHealthError.context)
+        let coordinator = makeCoordinator(repository: repository, healthService: healthService)
+        coordinator.draft.intensity = 4
+
+        coordinator.saveHeadacheOnly()
+        try await waitForSaveResult(on: coordinator)
+
+        #expect(repository.saveCount == 1)
+        #expect(repository.lastHealthContext == nil)
+        #expect(coordinator.saveResult == .saved(
+            repository.savedID,
+            healthWarning: EpisodeHealthSaveWarning.contextUnavailable.message
+        ))
+    }
+
+    @Test
+    func reviewSaveSurfacesHealthWriteFailureWithoutBlockingLocalSave() async throws {
+        let repository = EntryFlowEpisodeRepositoryMock()
+        let healthService = EntryFlowHealthServiceMock(writeError: EntryFlowHealthError.write)
+        let coordinator = makeCoordinator(repository: repository, healthService: healthService)
+        coordinator.draft.intensity = 4
+
+        coordinator.saveHeadacheOnly()
+        try await waitForSaveResult(on: coordinator)
+
+        #expect(repository.saveCount == 1)
+        #expect(healthService.writtenEpisodeID == repository.savedID)
+        #expect(coordinator.saveResult == .saved(
+            repository.savedID,
+            healthWarning: EpisodeHealthSaveWarning.writeFailed.message
+        ))
+    }
+
+    @Test
+    func editorSaveSurfacesHealthWriteFailureWithoutBlockingLocalSave() async throws {
+        let repository = EntryFlowEpisodeRepositoryMock()
+        let healthService = EntryFlowHealthServiceMock(writeError: EntryFlowHealthError.write)
+        let controller = EpisodeEditorController(
+            episodeID: nil,
+            initialStartedAt: nil,
+            episodeRepository: repository,
+            medicationRepository: EntryFlowMedicationRepositoryMock(),
+            syncService: EntryFlowSyncServiceMock(),
+            weatherContextService: EntryFlowWeatherContextMock(),
+            healthService: healthService
+        )
+        controller.draft.intensity = 4
+
+        controller.save(onSaved: nil, onDismiss: {})
+        try await waitForEditorSave(on: controller)
+
+        #expect(repository.saveCount == 1)
+        #expect(healthService.writtenEpisodeID == repository.savedID)
+        #expect(controller.healthSaveWarningMessage == EpisodeHealthSaveWarning.writeFailed.message)
+        #expect(controller.validationMessage == EpisodeHealthSaveWarning.writeFailed.message)
+        #expect(controller.saveMessageVisible)
     }
 
     @Test
@@ -192,7 +253,7 @@ struct EntryFlowCoordinatorTests {
         #expect(repository.saveCount == 1)
         #expect(repository.lastSavedDraft?.selectedTriggers.isEmpty == true)
         #expect(repository.lastWeatherSnapshot == nil)
-        #expect(coordinator.saveResult == .saved(repository.savedID))
+        #expect(coordinator.saveResult == .saved(repository.savedID, healthWarning: nil))
     }
 
     private func makeCoordinator(
@@ -249,10 +310,26 @@ struct EntryFlowCoordinatorTests {
 
         throw EntryFlowTestError.timedOut
     }
+
+    private func waitForEditorSave(on controller: EpisodeEditorController) async throws {
+        for _ in 0 ..< 100 {
+            if controller.saveMessageVisible || controller.validationMessage != nil {
+                return
+            }
+            await Task.yield()
+        }
+
+        throw EntryFlowTestError.timedOut
+    }
 }
 
 private enum EntryFlowTestError: Error {
     case timedOut
+}
+
+private enum EntryFlowHealthError: Error {
+    case context
+    case write
 }
 
 private final class EntryFlowEpisodeRepositoryMock: EpisodeRepository, Sendable {
@@ -346,6 +423,23 @@ private final class EntryFlowContinuousMedicationRepositoryMock: ContinuousMedic
     func delete(id: UUID) throws {}
 }
 
+private final class EntryFlowSyncServiceMock: SyncService {
+    var isEnabled = false
+    var status = SyncStatusSnapshot()
+    var conflicts: [SyncConflict] = []
+
+    func setSyncEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+    }
+
+    func refreshStatus() {}
+    func syncNow() async {}
+    func disableSyncAndDeleteCloudData() async {}
+    func retryLastError() async {}
+    func resolveConflictKeepingLocal(_ conflict: SyncConflict) async {}
+    func resolveConflictUsingRemote(_ conflict: SyncConflict) async {}
+}
+
 @MainActor
 private final class EntryFlowWeatherContextMock: EpisodeWeatherContextProviding {
     let snapshot: WeatherSnapshotData?
@@ -377,10 +471,14 @@ private final class EntryFlowWeatherContextMock: EpisodeWeatherContextProviding 
 
 private final class EntryFlowHealthServiceMock: HealthService {
     let snapshot: HealthContextSnapshotData?
+    let contextError: Error?
+    let writeError: Error?
     var writtenEpisodeID: UUID?
 
-    init(snapshot: HealthContextSnapshotData? = nil) {
+    init(snapshot: HealthContextSnapshotData? = nil, contextError: Error? = nil, writeError: Error? = nil) {
         self.snapshot = snapshot
+        self.contextError = contextError
+        self.writeError = writeError
     }
 
     var readDefinitions: [HealthDataTypeDefinition] { [] }
@@ -390,9 +488,18 @@ private final class EntryFlowHealthServiceMock: HealthService {
     func setEnabled(_ enabled: Bool, for type: HealthDataTypeID, direction: HealthDataDirection) {}
     func requestReadAuthorization() async throws {}
     func requestWriteAuthorization() async throws {}
-    func contextSnapshot(for draft: EpisodeDraft) async throws -> HealthContextSnapshotData? { snapshot }
+    func contextSnapshot(for draft: EpisodeDraft) async throws -> HealthContextSnapshotData? {
+        if let contextError {
+            throw contextError
+        }
+
+        return snapshot
+    }
 
     func writeEpisode(id: UUID, draft: EpisodeDraft) async throws {
         writtenEpisodeID = id
+        if let writeError {
+            throw writeError
+        }
     }
 }


### PR DESCRIPTION
## Änderungen

- HealthContext- und HealthKit-Schreibfehler werden beim Speichern als nichtblockierende Warnung gesammelt.

- Entry Flow und Editor zeigen die Warnung im gespeicherten Zustand an und loggen die Fehler über die Health-Kategorie.

- Tests decken Context- und Write-Fehler ab, während die lokale Speicherung erfolgreich bleibt.


## Prüfung

- `swiftlint`

- `xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SymiTests/EntryFlowCoordinatorTests`


Closes #311




