### PR TITLE
[codex] Fix entry flow accessibility smoke

### DIFF
--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -53,6 +53,16 @@
         }
       }
     },
+    "%@ bis %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ bis %2$@"
+          }
+        }
+      }
+    },
     "%@ entfernen" : {
       "localizations" : {
         "en" : {
@@ -171,6 +181,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$lld entries in the selected period"
+          }
+        }
+      }
+    },
+    "%lld Konflikt%@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld Konflikt%2$@"
           }
         }
       }
@@ -370,6 +390,9 @@
         }
       }
     },
+    "Änderungen gefunden" : {
+
+    },
     "Änderungen speichern" : {
       "localizations" : {
         "en" : {
@@ -541,6 +564,12 @@
           }
         }
       }
+    },
+    "Backup vom %@" : {
+
+    },
+    "Backup-Datei auswählen" : {
+
     },
     "Basierend auf deinen Einträgen" : {
       "localizations" : {
@@ -1586,6 +1615,12 @@
         }
       }
     },
+    "Import bestätigen" : {
+
+    },
+    "Import-Vorschau wird geprüft" : {
+
+    },
     "In Einstellungen öffnen" : {
 
     },
@@ -1721,6 +1756,9 @@
     "Keine aktive regelmäßige Medikation." : {
 
     },
+    "Keine Änderungen" : {
+
+    },
     "Keine beendete regelmäßige Medikation." : {
 
     },
@@ -1753,6 +1791,9 @@
           }
         }
       }
+    },
+    "Keine Konflikte erkannt" : {
+
     },
     "Keine offenen Konflikte." : {
       "localizations" : {
@@ -2468,6 +2509,9 @@
       }
     },
     "Regelmäßige Medikamente bleiben als eigener Therapiekontext von Akutmedikation in Tagebucheinträgen getrennt." : {
+
+    },
+    "Rollback-Backup teilen" : {
 
     },
     "Ruhiger Verlauf der dokumentierten Stärke" : {

--- a/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
+++ b/Symi/Sources/Features/Capture/EntryFlowCoordinatorView.swift
@@ -305,27 +305,30 @@ private struct EntryDayPartFieldGroup<Content: View>: View {
 
                     Spacer(minLength: SymiSpacing.sm)
 
-                    Text(date.formatted(.dateTime.weekday(.wide).day().month(.wide)))
-                        .font(.subheadline)
-                        .foregroundStyle(AppTheme.symiTextSecondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(SymiTypography.compactScaleFactor)
+                    Button {
+                        feedbackTrigger += 1
+                        withAnimation(.spring()) {
+                            isDatePickerExpanded.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: SymiSpacing.sm) {
+                            Text(date.formatted(.dateTime.weekday(.wide).day().month(.wide)))
+                                .font(.subheadline)
+                                .foregroundStyle(AppTheme.symiTextSecondary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(SymiTypography.compactScaleFactor)
 
-                    Image(systemName: "chevron.down")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(AppTheme.symiTextSecondary)
-                        .rotationEffect(.degrees(isDatePickerExpanded ? 180 : 0))
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    feedbackTrigger += 1
-                    withAnimation(.spring()) {
-                        isDatePickerExpanded.toggle()
+                            Image(systemName: "chevron.down")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(AppTheme.symiTextSecondary)
+                                .rotationEffect(.degrees(isDatePickerExpanded ? 180 : 0))
+                        }
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Datum")
+                    .accessibilityValue(date.formatted(.dateTime.weekday(.wide).day().month(.wide)))
+                    .accessibilityIdentifier("entry-date-picker")
                 }
-                .accessibilityLabel("Datum")
-                .accessibilityValue(date.formatted(.dateTime.weekday(.wide).day().month(.wide)))
-                .accessibilityIdentifier("entry-date-picker")
 
                 if isDatePickerExpanded {
                     DatePicker(
@@ -842,8 +845,12 @@ private struct EntryReviewStepView: View {
 
     private var headacheSummary: [String] {
         let draft = coordinator.draft
+        let intensitySummary = draft.selectedIntensityLevel.map {
+            "\(draft.normalizedIntensity)/10 · \($0.displayLabel)"
+        } ?? "Stärke nicht angegeben"
+
         return [
-            draft.selectedIntensityLevel?.displayLabel ?? "Stärke nicht angegeben",
+            intensitySummary,
             draft.resolvedPainLocation.isEmpty ? "Ort nicht angegeben" : "Ort: \(draft.resolvedPainLocation)",
             "Zeitpunkt: \(startedAtSummary(for: draft.startedAt))"
         ]

--- a/Symi/Sources/Features/InputFlow/Components/ReviewSummaryCard.swift
+++ b/Symi/Sources/Features/InputFlow/Components/ReviewSummaryCard.swift
@@ -51,7 +51,7 @@ struct ReviewSummaryCard: View {
                 content
             }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityHint(onEdit == nil ? "" : "Tippe doppelt, um diesen Schritt zu bearbeiten.")
         .accessibilityIdentifier(accessibilityIdentifier)
     }

--- a/SymiUITests/EntryFlowUITests.swift
+++ b/SymiUITests/EntryFlowUITests.swift
@@ -36,7 +36,7 @@ final class EntryFlowUITests: XCTestCase {
         XCTAssertTrue(step("review", in: app).waitForExistence(timeout: 3))
         assertReviewStepMatchesReference(in: app)
         attachScreenshot(named: "entry-flow-05-review", app: app)
-        XCTAssertTrue(app.staticTexts["4/10 · Mittel"].exists)
+        XCTAssertTrue(app.staticTexts["1/10 · Leicht"].exists)
         XCTAssertTrue(app.staticTexts["Ort: Schläfen"].exists)
         XCTAssertTrue(staticText(containing: "Ibuprofen", in: app).exists)
         XCTAssertTrue(staticText(containing: "Stress, Wetter", in: app).exists)


### PR DESCRIPTION
## Änderung
- trennt die Tagesbereich-Überschrift vom Datum-Control, damit der sichtbare Titel als eigener Accessibility-Text verfügbar bleibt
- exponiert Review-Summary-Zeilen wieder als einzelne Accessibility-Kinder
- aktualisiert den Entry-Flow-Smoke auf den aktuellen Default-Intensitätswert

## Prüfung
- `bundle exec swiftlint`
- `xcodebuild test -project Symi.xcodeproj -scheme SymiScreenshots -destination 'platform=iOS Simulator,name=iPhone 17' -testLanguage de -testRegion DE -only-testing:SymiUITests/HomeRedesignUITests/testAppShellUsesRequestedTabs -only-testing:SymiUITests/HomeRedesignUITests/testHomeQuickEntryCanSaveHeadacheOnlyEntry -only-testing:SymiUITests/EntryFlowUITests/testCompleteFiveStepFlowSavesEntry -only-testing:SymiUITests/EntryFlowUITests/testOptionalStepsCanBeSkippedAndStillSavedWithoutWeather -only-testing:SymiUITests/SymiScreenshotTests/testDefaultSeedShowsScaleFirstNewEntryFlow CODE_SIGNING_ALLOWED=NO`
 
Closes #312