### PR TITLE
Release-Build für Home-Preview-Daten reparieren

### DIFF
--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -614,7 +614,6 @@ private struct HomeInsightCardData: Identifiable, Equatable {
         }
     }
 
-#if DEBUG
     static let previewCards = [
         HomeInsightCardData(
             id: "weekday",
@@ -631,7 +630,6 @@ private struct HomeInsightCardData: Identifiable, Equatable {
             tint: .coral
         )
     ]
-#endif
 }
 
 private struct HomeMonthCalendarView: View {


### PR DESCRIPTION
## Änderungen
- `HomeInsightCardData.previewCards` ist auch im Release-Build verfügbar, damit der SwiftUI-`#Preview`-Block keine nur in `DEBUG` definierte Property referenziert.
- Die Daten bleiben private Preview-Hilfsdaten und werden im produktiven Home-Insight-Pfad nicht verwendet.

## Validierung
- `swiftlint`
- `xcodebuild build -project Symi.xcodeproj -scheme Symi -configuration Release -destination 'generic/platform=iOS Simulator'`

Follow-up zu #327 / Closes #326