### PR TITLE
Therapien und Präventionsmaßnahmen erfassen

### DIFF
--- a/Symi/Resources/Localizable.xcstrings
+++ b/Symi/Resources/Localizable.xcstrings
@@ -7,6 +7,16 @@
     "(empfohlen, wenn du mehrere Geräte nutzt)" : {
 
     },
+    "%@ · %@ · %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ · %2$@ · %3$@"
+          }
+        }
+      }
+    },
     "%@ / 10" : {
       "localizations" : {
         "en" : {
@@ -311,6 +321,9 @@
         }
       }
     },
+    "Aktivieren" : {
+
+    },
     "Aktiviert" : {
 
     },
@@ -333,6 +346,9 @@
           }
         }
       }
+    },
+    "Aktuell laufend" : {
+
     },
     "Aktuelle App-Angabe ohne Stärke oder Health-Flow-Sample." : {
       "localizations" : {
@@ -513,6 +529,9 @@
       }
     },
     "Apple Health. Lese- und Schreibzugriff. %@" : {
+
+    },
+    "Art" : {
 
     },
     "Attribution" : {
@@ -723,6 +742,9 @@
           }
         }
       }
+    },
+    "Bezeichnung" : {
+
     },
     "Bitte wähle, welche Version du behalten möchtest." : {
 
@@ -972,6 +994,9 @@
         }
       }
     },
+    "Details" : {
+
+    },
     "Diagnose" : {
       "localizations" : {
         "en" : {
@@ -1102,7 +1127,11 @@
         }
       }
     },
+    "Dosierung oder Umfang, optional" : {
+
+    },
     "Dosierung, optional" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1211,9 +1240,6 @@
         }
       }
     },
-    "Einnahmen & Anpassungen" : {
-
-    },
     "Einschränkung: %@" : {
       "localizations" : {
         "en" : {
@@ -1243,6 +1269,9 @@
           }
         }
       }
+    },
+    "Eintrag" : {
+
     },
     "Eintrag bearbeiten" : {
       "localizations" : {
@@ -1503,7 +1532,7 @@
     "Freigegeben" : {
 
     },
-    "Frequenz oder Uhrzeit, optional" : {
+    "Frequenz oder Rhythmus, optional" : {
 
     },
     "Funktionelle Einschränkung" : {
@@ -1569,7 +1598,7 @@
     "Heute" : {
 
     },
-    "Hier siehst du den Verlauf deiner regelmäßigen Medikation. Dokumentierte Einnahmen aus Tagebucheinträgen bleiben weiterhin im Tagebuchkontext." : {
+    "Hier bleiben aktive, pausierte und beendete Therapien und Präventionsmaßnahmen historisch nachvollziehbar." : {
 
     },
     "Hilf uns, Symi besser zu machen." : {
@@ -1753,13 +1782,10 @@
         }
       }
     },
-    "Keine aktive regelmäßige Medikation." : {
+    "Keine aktiven Therapien oder Präventionsmaßnahmen." : {
 
     },
     "Keine Änderungen" : {
-
-    },
-    "Keine beendete regelmäßige Medikation." : {
 
     },
     "Keine Diagnose, keine Therapieempfehlung" : {
@@ -1961,6 +1987,15 @@
         }
       }
     },
+    "Maßnahme" : {
+
+    },
+    "Maßnahmen" : {
+
+    },
+    "Maßnahmenverlauf" : {
+
+    },
     "Medikament" : {
       "localizations" : {
         "en" : {
@@ -1991,9 +2026,6 @@
         }
       }
     },
-    "Medikament hinzufügen" : {
-
-    },
     "Medikament nach Namen filtern" : {
       "localizations" : {
         "en" : {
@@ -2023,9 +2055,6 @@
           }
         }
       }
-    },
-    "Medikationsplan" : {
-
     },
     "Medizinischer Hinweis" : {
       "localizations" : {
@@ -2209,6 +2238,9 @@
     "Noch keine Einträge im Therapieverlauf." : {
 
     },
+    "Noch keine Einträge." : {
+
+    },
     "Notiz" : {
       "localizations" : {
         "en" : {
@@ -2228,6 +2260,9 @@
           }
         }
       }
+    },
+    "Notizen, optional" : {
+
     },
     "NSAR" : {
       "localizations" : {
@@ -2398,6 +2433,9 @@
         }
       }
     },
+    "Pausieren" : {
+
+    },
     "PDF-Berichte helfen dir, deine Einträge übersichtlich mitzunehmen. Sie werden nur erstellt und geteilt, wenn du das aktiv auslöst." : {
       "localizations" : {
         "en" : {
@@ -2427,6 +2465,9 @@
           }
         }
       }
+    },
+    "Präventionsmaßnahme hinzufügen" : {
+
     },
     "Projekt auf GitHub öffnen" : {
       "localizations" : {
@@ -2507,9 +2548,6 @@
           }
         }
       }
-    },
-    "Regelmäßige Medikamente bleiben als eigener Therapiekontext von Akutmedikation in Tagebucheinträgen getrennt." : {
-
     },
     "Rollback-Backup teilen" : {
 
@@ -2970,6 +3008,12 @@
       }
     },
     "Therapie" : {
+
+    },
+    "Therapie hinzufügen" : {
+
+    },
+    "Therapien und Präventionsmaßnahmen bleiben als eigener Verlauf von Akutmedikation in Tagebucheinträgen getrennt." : {
 
     },
     "Tippe doppelt, um diesen Schritt zu bearbeiten." : {

--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -73,7 +73,7 @@ struct ScreenshotEnvironment {
 enum ScreenshotBootstrap {
     @MainActor
     static func makeEnvironment(seedName: String) throws -> ScreenshotEnvironment {
-        let schema = Schema(versionedSchema: SymiSchemaV8.self)
+        let schema = Schema(versionedSchema: SymiSchemaV9.self)
         let storeURL = FileManager.default.temporaryDirectory.appending(path: "Symi-Screenshots-\(UUID().uuidString).store")
         let configuration = ModelConfiguration(
             "default",

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -69,7 +69,7 @@ struct SymiApp: App {
         storeURL overrideStoreURL: URL? = nil,
         applicationSupportDirectoryURL: URL? = nil
     ) throws -> AppRuntimeEnvironment {
-        let schema = Schema(versionedSchema: SymiSchemaV8.self)
+        let schema = Schema(versionedSchema: SymiSchemaV9.self)
         let storeURL = try resolvedStoreURL(
             overrideStoreURL: overrideStoreURL,
             launchConfiguration: launchConfiguration,
@@ -158,7 +158,7 @@ struct SymiApp: App {
 
     @MainActor
     private static func makeRecoveryContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: SymiSchemaV8.self)
+        let schema = Schema(versionedSchema: SymiSchemaV9.self)
         let configuration = ModelConfiguration(
             "recovery",
             schema: schema,

--- a/Symi/Sources/Core/Episodes/EpisodeCore.swift
+++ b/Symi/Sources/Core/Episodes/EpisodeCore.swift
@@ -71,26 +71,120 @@ struct ContinuousMedicationRecord: Identifiable, Equatable, Sendable {
     nonisolated let name: String
     nonisolated let dosage: String
     nonisolated let frequency: String
+    nonisolated let kind: TherapyMeasureKind
+    nonisolated let category: String
+    nonisolated let status: TherapyMeasureStatus
+    nonisolated let notes: String
     nonisolated let startDate: Date
     nonisolated let endDate: Date?
     nonisolated let createdAt: Date
     nonisolated let updatedAt: Date
     nonisolated let deletedAt: Date?
 
+    nonisolated init(
+        id: UUID,
+        name: String,
+        dosage: String,
+        frequency: String,
+        kind: TherapyMeasureKind = .therapy,
+        category: String = "",
+        status: TherapyMeasureStatus = .active,
+        notes: String = "",
+        startDate: Date,
+        endDate: Date?,
+        createdAt: Date,
+        updatedAt: Date,
+        deletedAt: Date?
+    ) {
+        self.id = id
+        self.name = name
+        self.dosage = dosage
+        self.frequency = frequency
+        self.kind = kind
+        self.category = category
+        self.status = status
+        self.notes = notes
+        self.startDate = startDate
+        self.endDate = endDate
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
+    }
+
     nonisolated var isActive: Bool {
-        guard deletedAt == nil else {
-            return false
-        }
-
-        guard let endDate else {
-            return true
-        }
-
-        return endDate >= Calendar.current.startOfDay(for: .now)
+        status == .active && deletedAt == nil && isCurrentOnDate(.now)
     }
 
     nonisolated var detailText: String {
         MedicationTextFormatter.detailText(dosage: dosage, frequency: frequency)
+    }
+
+    nonisolated var categoryText: String {
+        category.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? kind.defaultCategory : category
+    }
+
+    nonisolated func isCurrentOnDate(_ date: Date) -> Bool {
+        guard deletedAt == nil else {
+            return false
+        }
+
+        let dayStart = Calendar.current.startOfDay(for: date)
+        guard startDate <= dayStart else {
+            return false
+        }
+
+        return endDate.map { $0 >= dayStart } ?? true
+    }
+}
+
+enum TherapyMeasureKind: String, CaseIterable, Identifiable, Sendable {
+    case therapy
+    case prevention
+
+    nonisolated var id: String { rawValue }
+
+    nonisolated var title: String {
+        switch self {
+        case .therapy: "Therapie"
+        case .prevention: "Prävention"
+        }
+    }
+
+    nonisolated var pluralTitle: String {
+        switch self {
+        case .therapy: "Therapien"
+        case .prevention: "Präventionsmaßnahmen"
+        }
+    }
+
+    nonisolated var defaultCategory: String {
+        switch self {
+        case .therapy: "Medikamentös"
+        case .prevention: "Alltag"
+        }
+    }
+
+    nonisolated var icon: String {
+        switch self {
+        case .therapy: "cross.case.fill"
+        case .prevention: "leaf.fill"
+        }
+    }
+}
+
+enum TherapyMeasureStatus: String, CaseIterable, Identifiable, Sendable {
+    case active
+    case paused
+    case ended
+
+    nonisolated var id: String { rawValue }
+
+    nonisolated var title: String {
+        switch self {
+        case .active: "Aktiv"
+        case .paused: "Pausiert"
+        case .ended: "Beendet"
+        }
     }
 }
 
@@ -141,6 +235,10 @@ struct ContinuousMedicationDraft: Identifiable, Equatable, Sendable {
     nonisolated var name: String
     nonisolated var dosage: String
     nonisolated var frequency: String
+    nonisolated var kind: TherapyMeasureKind
+    nonisolated var category: String
+    nonisolated var status: TherapyMeasureStatus
+    nonisolated var notes: String
     nonisolated var startDate: Date
     nonisolated var endDate: Date?
 
@@ -153,6 +251,10 @@ struct ContinuousMedicationDraft: Identifiable, Equatable, Sendable {
         name: String = "",
         dosage: String = "",
         frequency: String = "",
+        kind: TherapyMeasureKind = .therapy,
+        category: String = "",
+        status: TherapyMeasureStatus = .active,
+        notes: String = "",
         startDate: Date = .now,
         endDate: Date? = nil
     ) {
@@ -160,6 +262,10 @@ struct ContinuousMedicationDraft: Identifiable, Equatable, Sendable {
         self.name = name
         self.dosage = dosage
         self.frequency = frequency
+        self.kind = kind
+        self.category = category
+        self.status = status
+        self.notes = notes
         self.startDate = startDate
         self.endDate = endDate
     }
@@ -170,6 +276,10 @@ struct ContinuousMedicationDraft: Identifiable, Equatable, Sendable {
             name: record.name,
             dosage: record.dosage,
             frequency: record.frequency,
+            kind: record.kind,
+            category: record.category,
+            status: record.status,
+            notes: record.notes,
             startDate: record.startDate,
             endDate: record.endDate
         )

--- a/Symi/Sources/Core/Therapy/TherapyDomain.swift
+++ b/Symi/Sources/Core/Therapy/TherapyDomain.swift
@@ -61,16 +61,22 @@ final class TherapyViewModel {
 
     var todayMedications: [TherapyMedicationItem] {
         medications
-            .filter(\.isActive)
+            .filter { $0.kind == .therapy && $0.isActive }
             .map(TherapyMedicationItem.init(record:))
     }
 
-    var activeMedications: [ContinuousMedicationRecord] {
-        medications.filter(\.isActive)
+    var currentMeasures: [ContinuousMedicationRecord] {
+        medications.filter { $0.status == .active && $0.isCurrentOnDate(.now) }
     }
 
-    var endedMedications: [ContinuousMedicationRecord] {
-        medications.filter { !$0.isActive }
+    var historicalMeasures: [ContinuousMedicationRecord] {
+        medications.filter { $0.status != .active || !$0.isCurrentOnDate(.now) }
+    }
+
+    func measures(kind: TherapyMeasureKind, status: TherapyMeasureStatus? = nil) -> [ContinuousMedicationRecord] {
+        medications.filter { medication in
+            medication.kind == kind && (status.map { medication.status == $0 } ?? true)
+        }
     }
 
     func load() {
@@ -90,8 +96,8 @@ final class TherapyViewModel {
         }
     }
 
-    func presentMedicationEditor(for medication: ContinuousMedicationRecord?) {
-        medicationEditor = medication.map(ContinuousMedicationDraft.init(record:)) ?? ContinuousMedicationDraft()
+    func presentMedicationEditor(for medication: ContinuousMedicationRecord?, kind: TherapyMeasureKind = .therapy) {
+        medicationEditor = medication.map(ContinuousMedicationDraft.init(record:)) ?? ContinuousMedicationDraft(kind: kind)
         message = nil
     }
 
@@ -105,6 +111,9 @@ final class TherapyViewModel {
         let repository = repository
         var normalizedDraft = draft
         normalizedDraft.name = trimmedName
+        if normalizedDraft.category.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            normalizedDraft.category = normalizedDraft.kind.defaultCategory
+        }
 
         do {
             _ = try await Task.detached(priority: .userInitiated) {
@@ -118,13 +127,16 @@ final class TherapyViewModel {
         }
     }
 
-    func endMedication(id: UUID) {
+    func updateStatus(id: UUID, status: TherapyMeasureStatus) {
         let repository = repository
         Task { [weak self] in
             guard let self else { return }
             guard let medication = medications.first(where: { $0.id == id }) else { return }
             var draft = ContinuousMedicationDraft(record: medication)
-            draft.endDate = .now
+            draft.status = status
+            if status == .ended, draft.endDate == nil {
+                draft.endDate = .now
+            }
 
             do {
                 _ = try await Task.detached(priority: .userInitiated) {
@@ -132,7 +144,23 @@ final class TherapyViewModel {
                 }.value
                 load()
             } catch {
-                message = "Medikament konnte nicht beendet werden."
+                message = "Eintrag konnte nicht aktualisiert werden."
+            }
+        }
+    }
+
+    func deleteMeasure(id: UUID) {
+        let repository = repository
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                try await Task.detached(priority: .userInitiated) {
+                    try repository.delete(id: id)
+                }.value
+                load()
+            } catch {
+                message = "Eintrag konnte nicht gelöscht werden."
             }
         }
     }

--- a/Symi/Sources/Features/Export/DataTransfer.swift
+++ b/Symi/Sources/Features/Export/DataTransfer.swift
@@ -773,6 +773,10 @@ struct ContinuousMedicationPayload: Codable, Sendable {
     let name: String
     let dosage: String
     let frequency: String
+    let kindRaw: String
+    let category: String
+    let statusRaw: String
+    let notes: String
     let startDate: Date
     let endDate: Date?
     let createdAt: Date
@@ -783,10 +787,30 @@ struct ContinuousMedicationPayload: Codable, Sendable {
         self.name = medication.name
         self.dosage = medication.dosage
         self.frequency = medication.frequency
+        self.kindRaw = medication.kindRaw
+        self.category = medication.category
+        self.statusRaw = medication.statusRaw
+        self.notes = medication.notes
         self.startDate = medication.startDate
         self.endDate = medication.endDate
         self.createdAt = medication.createdAt
         self.updatedAt = medication.updatedAt
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.dosage = try container.decode(String.self, forKey: .dosage)
+        self.frequency = try container.decode(String.self, forKey: .frequency)
+        self.kindRaw = try container.decodeIfPresent(String.self, forKey: .kindRaw) ?? TherapyMeasureKind.therapy.rawValue
+        self.category = try container.decodeIfPresent(String.self, forKey: .category) ?? TherapyMeasureKind.therapy.defaultCategory
+        self.statusRaw = try container.decodeIfPresent(String.self, forKey: .statusRaw) ?? TherapyMeasureStatus.active.rawValue
+        self.notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? ""
+        self.startDate = try container.decode(Date.self, forKey: .startDate)
+        self.endDate = try container.decodeIfPresent(Date.self, forKey: .endDate)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+        self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
 
     nonisolated func makeModel() -> ContinuousMedication {
@@ -795,6 +819,10 @@ struct ContinuousMedicationPayload: Codable, Sendable {
             name: name,
             dosage: dosage,
             frequency: frequency,
+            kindRaw: kindRaw,
+            category: category,
+            statusRaw: statusRaw,
+            notes: notes,
             startDate: startDate,
             endDate: endDate,
             createdAt: createdAt,
@@ -806,6 +834,10 @@ struct ContinuousMedicationPayload: Codable, Sendable {
         medication.name = name
         medication.dosage = dosage
         medication.frequency = frequency
+        medication.kindRaw = kindRaw
+        medication.category = category
+        medication.statusRaw = statusRaw
+        medication.notes = notes
         medication.startDate = startDate
         medication.endDate = endDate
         medication.createdAt = createdAt

--- a/Symi/Sources/Features/Therapy/TherapyView.swift
+++ b/Symi/Sources/Features/Therapy/TherapyView.swift
@@ -146,8 +146,8 @@ private struct TherapyNavigationSection: View {
                 } label: {
                     TherapyNavigationRow(
                         icon: "list.bullet.clipboard",
-                        title: "Medikationsplan",
-                        subtitle: "Alle Medikamente & Zeitpläne"
+                        title: "Therapien & Prävention",
+                        subtitle: "Maßnahmen anlegen und verwalten"
                     )
                 }
                 .buttonStyle(.plain)
@@ -161,7 +161,7 @@ private struct TherapyNavigationSection: View {
                     TherapyNavigationRow(
                         icon: "clock.arrow.circlepath",
                         title: "Verlauf",
-                        subtitle: "Einnahmen & Anpassungen"
+                        subtitle: "Aktive, pausierte und beendete Maßnahmen"
                     )
                 }
                 .buttonStyle(.plain)
@@ -209,39 +209,54 @@ struct TherapyPlanView: View {
         List {
             Section {
                 Button {
-                    viewModel.presentMedicationEditor(for: nil)
+                    viewModel.presentMedicationEditor(for: nil, kind: .therapy)
                 } label: {
-                    Label("Medikament hinzufügen", systemImage: "plus")
+                    Label("Therapie hinzufügen", systemImage: "plus")
+                }
+
+                Button {
+                    viewModel.presentMedicationEditor(for: nil, kind: .prevention)
+                } label: {
+                    Label("Präventionsmaßnahme hinzufügen", systemImage: "plus")
                 }
             } footer: {
-                Text("Regelmäßige Medikamente bleiben als eigener Therapiekontext von Akutmedikation in Tagebucheinträgen getrennt.")
+                Text("Therapien und Präventionsmaßnahmen bleiben als eigener Verlauf von Akutmedikation in Tagebucheinträgen getrennt.")
             }
 
-            Section("Aktuell") {
-                if viewModel.activeMedications.isEmpty {
-                    Text("Keine aktive regelmäßige Medikation.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(viewModel.activeMedications) { medication in
-                        TherapyPlanMedicationRow(
-                            medication: medication,
-                            onEdit: { viewModel.presentMedicationEditor(for: medication) },
-                            onEnd: { viewModel.endMedication(id: medication.id) }
-                        )
+            ForEach(TherapyMeasureKind.allCases) { kind in
+                Section(kind.pluralTitle) {
+                    let measures = viewModel.measures(kind: kind)
+                    if measures.isEmpty {
+                        Text("Noch keine Einträge.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(measures) { measure in
+                            TherapyPlanMedicationRow(
+                                medication: measure,
+                                onEdit: { viewModel.presentMedicationEditor(for: measure) },
+                                onPause: { viewModel.updateStatus(id: measure.id, status: .paused) },
+                                onResume: { viewModel.updateStatus(id: measure.id, status: .active) },
+                                onEnd: { viewModel.updateStatus(id: measure.id, status: .ended) },
+                                onDelete: { viewModel.deleteMeasure(id: measure.id) }
+                            )
+                        }
                     }
                 }
             }
 
-            Section("Beendet") {
-                if viewModel.endedMedications.isEmpty {
-                    Text("Keine beendete regelmäßige Medikation.")
+            Section("Aktuell laufend") {
+                if viewModel.currentMeasures.isEmpty {
+                    Text("Keine aktiven Therapien oder Präventionsmaßnahmen.")
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(viewModel.endedMedications) { medication in
+                    ForEach(viewModel.currentMeasures) { medication in
                         TherapyPlanMedicationRow(
                             medication: medication,
                             onEdit: { viewModel.presentMedicationEditor(for: medication) },
-                            onEnd: nil
+                            onPause: { viewModel.updateStatus(id: medication.id, status: .paused) },
+                            onResume: { viewModel.updateStatus(id: medication.id, status: .active) },
+                            onEnd: { viewModel.updateStatus(id: medication.id, status: .ended) },
+                            onDelete: { viewModel.deleteMeasure(id: medication.id) }
                         )
                     }
                 }
@@ -254,7 +269,7 @@ struct TherapyPlanView: View {
                 }
             }
         }
-        .navigationTitle("Medikationsplan")
+        .navigationTitle("Maßnahmen")
         .brandGroupedScreen()
         .sheet(item: $viewModel.medicationEditor) { draft in
             NavigationStack {
@@ -290,24 +305,15 @@ struct TherapyHistoryView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(viewModel.medications) { medication in
-                        VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
-                            Text(medication.name)
-                                .font(.headline)
-                            Text(medication.detailText.isEmpty ? "Keine Dosierung oder Frequenz angegeben." : medication.detailText)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                            Text(dateRangeText(for: medication))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+                        TherapyMeasureSummary(medication: medication)
                         .padding(.vertical, SymiSpacing.xxs)
                         .brandGroupedRow()
                     }
                 }
             } header: {
-                Text("Einnahmen & Anpassungen")
+                Text("Maßnahmenverlauf")
             } footer: {
-                Text("Hier siehst du den Verlauf deiner regelmäßigen Medikation. Dokumentierte Einnahmen aus Tagebucheinträgen bleiben weiterhin im Tagebuchkontext.")
+                Text("Hier bleiben aktive, pausierte und beendete Therapien und Präventionsmaßnahmen historisch nachvollziehbar.")
             }
         }
         .navigationTitle("Verlauf")
@@ -333,7 +339,10 @@ struct TherapyHistoryView: View {
 private struct TherapyPlanMedicationRow: View {
     let medication: ContinuousMedicationRecord
     let onEdit: () -> Void
+    let onPause: () -> Void
+    let onResume: () -> Void
     let onEnd: (() -> Void)?
+    let onDelete: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: SymiSpacing.xs) {
@@ -341,34 +350,96 @@ private struct TherapyPlanMedicationRow: View {
                 VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
                     Text(medication.name)
                         .font(.headline)
-                    if !medication.detailText.isEmpty {
-                        Text(medication.detailText)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
+                    Text(summaryText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
 
                 Spacer()
 
-                Text(medication.isActive ? "Aktiv" : "Beendet")
+                Text(medication.status.title)
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(medication.isActive ? AppTheme.symiSage : .secondary)
+                    .foregroundStyle(statusColor)
             }
 
             Text(dateRangeText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            if !medication.notes.isEmpty {
+                Text(medication.notes)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             HStack {
                 Button("Bearbeiten", action: onEdit)
-                if let onEnd {
+                if medication.status == .active {
+                    Button("Pausieren", action: onPause)
+                } else {
+                    Button("Aktivieren", action: onResume)
+                }
+                if let onEnd, medication.status != .ended {
                     Button("Beenden", role: .destructive, action: onEnd)
                 }
+                Button("Löschen", role: .destructive, action: onDelete)
             }
             .buttonStyle(.borderless)
         }
         .padding(.vertical, SymiSpacing.xxs)
         .brandGroupedRow()
+    }
+
+    private var dateRangeText: String {
+        let start = medication.startDate.formatted(date: .abbreviated, time: .omitted)
+        guard let endDate = medication.endDate else {
+            return "Seit \(start)"
+        }
+
+        return "\(start) bis \(endDate.formatted(date: .abbreviated, time: .omitted))"
+    }
+
+    private var summaryText: String {
+        [
+            medication.kind.title,
+            medication.categoryText,
+            medication.detailText.isEmpty ? nil : medication.detailText
+        ]
+        .compactMap { $0 }
+        .joined(separator: " · ")
+    }
+
+    private var statusColor: Color {
+        switch medication.status {
+        case .active:
+            AppTheme.symiSage
+        case .paused:
+            .orange
+        case .ended:
+            .secondary
+        }
+    }
+}
+
+private struct TherapyMeasureSummary: View {
+    let medication: ContinuousMedicationRecord
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: SymiSpacing.xxs) {
+            Text(medication.name)
+                .font(.headline)
+            Text("\(medication.kind.title) · \(medication.categoryText) · \(medication.status.title)")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text(dateRangeText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if !medication.notes.isEmpty {
+                Text(medication.notes)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     private var dateRangeText: String {
@@ -402,11 +473,29 @@ private struct TherapyMedicationEditorSheet: View {
 
     var body: some View {
         Form {
-            Section("Medikament") {
-                TextField("Name", text: $draft.name)
+            Section("Eintrag") {
+                Picker("Art", selection: $draft.kind) {
+                    ForEach(TherapyMeasureKind.allCases) { kind in
+                        Text(kind.title).tag(kind)
+                    }
+                }
+
+                TextField("Bezeichnung", text: $draft.name)
                     .textInputAutocapitalization(.words)
-                TextField("Dosierung, optional", text: $draft.dosage)
-                TextField("Frequenz oder Uhrzeit, optional", text: $draft.frequency)
+                TextField("Kategorie", text: $draft.category)
+                    .textInputAutocapitalization(.words)
+                Picker("Status", selection: $draft.status) {
+                    ForEach(TherapyMeasureStatus.allCases) { status in
+                        Text(status.title).tag(status)
+                    }
+                }
+            }
+
+            Section("Details") {
+                TextField("Dosierung oder Umfang, optional", text: $draft.dosage)
+                TextField("Frequenz oder Rhythmus, optional", text: $draft.frequency)
+                TextField("Notizen, optional", text: $draft.notes, axis: .vertical)
+                    .lineLimit(3...6)
             }
 
             Section("Zeitraum") {
@@ -424,7 +513,7 @@ private struct TherapyMedicationEditorSheet: View {
                 }
             }
         }
-        .navigationTitle(draft.id == nil ? "Medikament" : "Bearbeiten")
+        .navigationTitle(draft.id == nil ? "Maßnahme" : "Bearbeiten")
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Abbrechen") {
@@ -437,6 +526,9 @@ private struct TherapyMedicationEditorSheet: View {
                     var normalizedDraft = draft
                     if !hasEndDate {
                         normalizedDraft.endDate = nil
+                    }
+                    if normalizedDraft.category.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        normalizedDraft.category = normalizedDraft.kind.defaultCategory
                     }
                     onSave(normalizedDraft)
                     dismiss()

--- a/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
+++ b/Symi/Sources/Infrastructure/Persistence/SwiftDataCoreRepositories.swift
@@ -203,7 +203,7 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
         )
         return try readContext().fetch(descriptor)
             .filter { medication in
-                medication.endDate.map { $0 >= dayStart } ?? true
+                medication.kind == .therapy && medication.status == .active && (medication.endDate.map { $0 >= dayStart } ?? true)
             }
             .map(ContinuousMedicationRecord.init)
     }
@@ -214,6 +214,9 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
         let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDosage = draft.dosage.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedFrequency = draft.frequency.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedCategory = draft.category.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNotes = draft.notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedCategory = trimmedCategory.isEmpty ? draft.kind.defaultCategory : trimmedCategory
 
         let medication: ContinuousMedication
         if let id = draft.id, let existing = try fetchMedication(id: id, in: context) {
@@ -221,6 +224,10 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
             medication.name = trimmedName
             medication.dosage = trimmedDosage
             medication.frequency = trimmedFrequency
+            medication.kind = draft.kind
+            medication.category = normalizedCategory
+            medication.status = draft.status
+            medication.notes = trimmedNotes
             medication.startDate = draft.startDate
             medication.endDate = draft.endDate
             medication.markUpdated()
@@ -229,6 +236,10 @@ final class SwiftDataContinuousMedicationRepository: ContinuousMedicationReposit
                 name: trimmedName,
                 dosage: trimmedDosage,
                 frequency: trimmedFrequency,
+                kindRaw: draft.kind.rawValue,
+                category: normalizedCategory,
+                statusRaw: draft.status.rawValue,
+                notes: trimmedNotes,
                 startDate: draft.startDate,
                 endDate: draft.endDate
             )
@@ -520,6 +531,10 @@ private extension ContinuousMedicationRecord {
             name: medication.name,
             dosage: medication.dosage,
             frequency: medication.frequency,
+            kind: medication.kind,
+            category: medication.category,
+            status: medication.status,
+            notes: medication.notes,
             startDate: medication.startDate,
             endDate: medication.endDate,
             createdAt: medication.createdAt,

--- a/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
+++ b/Symi/Sources/Infrastructure/Sync/LocalSyncRepository.swift
@@ -259,6 +259,10 @@ struct LocalSyncRepository {
             name: payload.name,
             dosage: payload.dosage,
             frequency: payload.frequency,
+            kindRaw: payload.kindRaw,
+            category: payload.category,
+            statusRaw: payload.statusRaw,
+            notes: payload.notes,
             startDate: payload.startDate,
             endDate: payload.endDate,
             createdAt: payload.createdAt,
@@ -269,6 +273,10 @@ struct LocalSyncRepository {
         target.name = payload.name
         target.dosage = payload.dosage
         target.frequency = payload.frequency
+        target.kindRaw = payload.kindRaw
+        target.category = payload.category
+        target.statusRaw = payload.statusRaw
+        target.notes = payload.notes
         target.startDate = payload.startDate
         target.endDate = payload.endDate
         target.createdAt = payload.createdAt
@@ -526,6 +534,10 @@ enum RemoteSyncPayloadValidator {
             name: payload.name,
             dosage: payload.dosage,
             frequency: payload.frequency,
+            kindRaw: payload.kindRaw,
+            category: payload.category,
+            statusRaw: payload.statusRaw,
+            notes: payload.notes,
             startDate: payload.startDate,
             endDate: payload.endDate,
             createdAt: payload.createdAt
@@ -694,6 +706,10 @@ extension ContinuousMedication {
                     name: name,
                     dosage: dosage,
                     frequency: frequency,
+                    kindRaw: kindRaw,
+                    category: category,
+                    statusRaw: statusRaw,
+                    notes: notes,
                     startDate: startDate,
                     endDate: endDate,
                     createdAt: createdAt

--- a/Symi/Sources/Models/CurrentModelAliases.swift
+++ b/Symi/Sources/Models/CurrentModelAliases.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SwiftData
 
-typealias Episode = SymiSchemaV8.Episode
-typealias MedicationEntry = SymiSchemaV8.MedicationEntry
-typealias MedicationDefinition = SymiSchemaV8.MedicationDefinition
-typealias ContinuousMedication = SymiSchemaV8.ContinuousMedication
-typealias ContinuousMedicationCheck = SymiSchemaV8.ContinuousMedicationCheck
-typealias WeatherSnapshot = SymiSchemaV8.WeatherSnapshot
+typealias Episode = SymiSchemaV9.Episode
+typealias MedicationEntry = SymiSchemaV9.MedicationEntry
+typealias MedicationDefinition = SymiSchemaV9.MedicationDefinition
+typealias ContinuousMedication = SymiSchemaV9.ContinuousMedication
+typealias ContinuousMedicationCheck = SymiSchemaV9.ContinuousMedicationCheck
+typealias WeatherSnapshot = SymiSchemaV9.WeatherSnapshot
 // Doctor- und Terminmodelle wurden mit Schema V5 aus dem aktiven Datenmodell entfernt.

--- a/Symi/Sources/Models/EpisodeModels.swift
+++ b/Symi/Sources/Models/EpisodeModels.swift
@@ -345,8 +345,35 @@ extension Episode {
 }
 
 extension ContinuousMedication {
+    var kind: TherapyMeasureKind {
+        get { TherapyMeasureKind(rawValue: kindRaw) ?? .therapy }
+        set { kindRaw = newValue.rawValue }
+    }
+
+    var status: TherapyMeasureStatus {
+        get { TherapyMeasureStatus(rawValue: statusRaw) ?? inferredStatus }
+        set { statusRaw = newValue.rawValue }
+    }
+
+    private var inferredStatus: TherapyMeasureStatus {
+        isCurrentOnDate(.now) ? .active : .ended
+    }
+
     var isActive: Bool {
-        deletedAt == nil && (endDate == nil || (endDate ?? .distantPast) >= Calendar.current.startOfDay(for: .now))
+        status == .active && isCurrentOnDate(.now)
+    }
+
+    func isCurrentOnDate(_ date: Date) -> Bool {
+        guard deletedAt == nil else {
+            return false
+        }
+
+        let dayStart = Calendar.current.startOfDay(for: date)
+        guard startDate <= dayStart else {
+            return false
+        }
+
+        return endDate.map { $0 >= dayStart } ?? true
     }
 
     var detailText: String {

--- a/Symi/Sources/Models/SymiMigrationPlan.swift
+++ b/Symi/Sources/Models/SymiMigrationPlan.swift
@@ -11,7 +11,8 @@ enum SymiMigrationPlan: SchemaMigrationPlan {
             SymiSchemaV5.self,
             SymiSchemaV6.self,
             SymiSchemaV7.self,
-            SymiSchemaV8.self
+            SymiSchemaV8.self,
+            SymiSchemaV9.self
         ]
     }
     static var stages: [MigrationStage] {
@@ -122,6 +123,10 @@ enum SymiMigrationPlan: SchemaMigrationPlan {
             .lightweight(
                 fromVersion: SymiSchemaV7.self,
                 toVersion: SymiSchemaV8.self
+            ),
+            .lightweight(
+                fromVersion: SymiSchemaV8.self,
+                toVersion: SymiSchemaV9.self
             )
         ]
     }

--- a/Symi/Sources/Models/SymiSchemaV9.swift
+++ b/Symi/Sources/Models/SymiSchemaV9.swift
@@ -1,0 +1,328 @@
+import Foundation
+import SwiftData
+
+enum SymiSchemaV9: VersionedSchema {
+    static let versionIdentifier = Schema.Version(9, 0, 0)
+    static var models: [any PersistentModel.Type] {
+        [
+            Episode.self,
+            MedicationEntry.self,
+            MedicationDefinition.self,
+            ContinuousMedication.self,
+            ContinuousMedicationCheck.self,
+            WeatherSnapshot.self
+        ]
+    }
+
+    @Model
+    final class Episode {
+        @Attribute(.unique) var id: UUID
+        var startedAt: Date
+        var endedAt: Date?
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+        var typeRaw: String
+        var intensityLevelRaw: String = PainIntensityLevel.medium.rawValue
+        var painLocation: String
+        var painCharacter: String
+        var notes: String
+        var symptomsStorage: String
+        var triggersStorage: String
+        var functionalImpact: String
+        var menstruationStatusRaw: String
+
+        @Relationship(deleteRule: .cascade, inverse: \MedicationEntry.episode)
+        var medications: [MedicationEntry]
+
+        @Relationship(deleteRule: .cascade, inverse: \ContinuousMedicationCheck.episode)
+        var continuousMedicationChecks: [ContinuousMedicationCheck]
+
+        @Relationship(deleteRule: .cascade, inverse: \WeatherSnapshot.episode)
+        var weatherSnapshot: WeatherSnapshot?
+
+        init(
+            id: UUID = UUID(),
+            startedAt: Date,
+            endedAt: Date? = nil,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil,
+            typeRaw: String,
+            intensityLevelRaw: String = PainIntensityLevel.medium.rawValue,
+            painLocation: String = "",
+            painCharacter: String = "",
+            notes: String = "",
+            symptomsStorage: String = "",
+            triggersStorage: String = "",
+            functionalImpact: String = "",
+            menstruationStatusRaw: String = MenstruationStatus.unknown.rawValue,
+            medications: [MedicationEntry] = [],
+            continuousMedicationChecks: [ContinuousMedicationCheck] = []
+        ) {
+            self.id = id
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+            self.typeRaw = typeRaw
+            self.intensityLevelRaw = intensityLevelRaw
+            self.painLocation = painLocation
+            self.painCharacter = painCharacter
+            self.notes = notes
+            self.symptomsStorage = symptomsStorage
+            self.triggersStorage = triggersStorage
+            self.functionalImpact = functionalImpact
+            self.menstruationStatusRaw = menstruationStatusRaw
+            self.medications = medications
+            self.continuousMedicationChecks = continuousMedicationChecks
+        }
+
+        convenience init(
+            id: UUID = UUID(),
+            startedAt: Date,
+            endedAt: Date? = nil,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil,
+            typeRaw: String,
+            intensity: Int,
+            painLocation: String = "",
+            painCharacter: String = "",
+            notes: String = "",
+            symptomsStorage: String = "",
+            triggersStorage: String = "",
+            functionalImpact: String = "",
+            menstruationStatusRaw: String = MenstruationStatus.unknown.rawValue,
+            medications: [MedicationEntry] = [],
+            continuousMedicationChecks: [ContinuousMedicationCheck] = []
+        ) {
+            self.init(
+                id: id,
+                startedAt: startedAt,
+                endedAt: endedAt,
+                updatedAt: updatedAt,
+                deletedAt: deletedAt,
+                typeRaw: typeRaw,
+                intensityLevelRaw: PainIntensityLevel(intensity: intensity).rawValue,
+                painLocation: painLocation,
+                painCharacter: painCharacter,
+                notes: notes,
+                symptomsStorage: symptomsStorage,
+                triggersStorage: triggersStorage,
+                functionalImpact: functionalImpact,
+                menstruationStatusRaw: menstruationStatusRaw,
+                medications: medications,
+                continuousMedicationChecks: continuousMedicationChecks
+            )
+        }
+    }
+
+    @Model
+    final class MedicationEntry {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var categoryRaw: String
+        var dosage: String
+        var quantity: Int
+        var takenAt: Date
+        var effectivenessRaw: String
+        var reliefStartedAt: Date?
+        var isRepeatDose: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            categoryRaw: String,
+            dosage: String,
+            quantity: Int = 1,
+            takenAt: Date,
+            effectivenessRaw: String,
+            reliefStartedAt: Date? = nil,
+            isRepeatDose: Bool = false,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.dosage = dosage
+            self.quantity = quantity
+            self.takenAt = takenAt
+            self.effectivenessRaw = effectivenessRaw
+            self.reliefStartedAt = reliefStartedAt
+            self.isRepeatDose = isRepeatDose
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class MedicationDefinition {
+        @Attribute(.unique) var catalogKey: String
+        var groupID: String
+        var groupTitle: String
+        var groupFooter: String?
+        var name: String
+        var categoryRaw: String
+        var suggestedDosage: String
+        var sortOrder: Int
+        var isCustom: Bool
+        var createdAt: Date
+        var updatedAt: Date = Date.now
+        var deletedAt: Date?
+
+        init(
+            catalogKey: String,
+            groupID: String,
+            groupTitle: String,
+            groupFooter: String? = nil,
+            name: String,
+            categoryRaw: String,
+            suggestedDosage: String,
+            sortOrder: Int,
+            isCustom: Bool,
+            createdAt: Date = .now,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil
+        ) {
+            self.catalogKey = catalogKey
+            self.groupID = groupID
+            self.groupTitle = groupTitle
+            self.groupFooter = groupFooter
+            self.name = name
+            self.categoryRaw = categoryRaw
+            self.suggestedDosage = suggestedDosage
+            self.sortOrder = sortOrder
+            self.isCustom = isCustom
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+        }
+    }
+
+    @Model
+    final class ContinuousMedication {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var dosage: String
+        var frequency: String
+        var kindRaw: String = "therapy"
+        var category: String = ""
+        var statusRaw: String = "active"
+        var notes: String = ""
+        var startDate: Date
+        var endDate: Date?
+        var createdAt: Date
+        var updatedAt: Date
+        var deletedAt: Date?
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            dosage: String = "",
+            frequency: String = "",
+            kindRaw: String = "therapy",
+            category: String = "",
+            statusRaw: String = "active",
+            notes: String = "",
+            startDate: Date,
+            endDate: Date? = nil,
+            createdAt: Date = .now,
+            updatedAt: Date = .now,
+            deletedAt: Date? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.dosage = dosage
+            self.frequency = frequency
+            self.kindRaw = kindRaw
+            self.category = category
+            self.statusRaw = statusRaw
+            self.notes = notes
+            self.startDate = startDate
+            self.endDate = endDate
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.deletedAt = deletedAt
+        }
+    }
+
+    @Model
+    final class ContinuousMedicationCheck {
+        @Attribute(.unique) var id: UUID
+        var continuousMedicationID: UUID
+        var name: String
+        var dosage: String
+        var frequency: String
+        var wasTaken: Bool
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            continuousMedicationID: UUID,
+            name: String,
+            dosage: String = "",
+            frequency: String = "",
+            wasTaken: Bool,
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.continuousMedicationID = continuousMedicationID
+            self.name = name
+            self.dosage = dosage
+            self.frequency = frequency
+            self.wasTaken = wasTaken
+            self.episode = episode
+        }
+    }
+
+    @Model
+    final class WeatherSnapshot {
+        @Attribute(.unique) var id: UUID
+        var recordedAt: Date
+        var temperature: Double?
+        var condition: String
+        var humidity: Double?
+        var pressure: Double?
+        var precipitation: Double?
+        var weatherCode: Int?
+        var source: String
+        var dayRangeStart: Date?
+        var dayRangeEnd: Date?
+        var contextRangeStart: Date?
+        var contextRangeEnd: Date?
+        var contextPointsStorage: String = ""
+        var episode: Episode?
+
+        init(
+            id: UUID = UUID(),
+            recordedAt: Date,
+            temperature: Double? = nil,
+            condition: String = "",
+            humidity: Double? = nil,
+            pressure: Double? = nil,
+            precipitation: Double? = nil,
+            weatherCode: Int? = nil,
+            source: String = "",
+            dayRangeStart: Date? = nil,
+            dayRangeEnd: Date? = nil,
+            contextRangeStart: Date? = nil,
+            contextRangeEnd: Date? = nil,
+            contextPointsStorage: String = "",
+            episode: Episode? = nil
+        ) {
+            self.id = id
+            self.recordedAt = recordedAt
+            self.temperature = temperature
+            self.condition = condition
+            self.humidity = humidity
+            self.pressure = pressure
+            self.precipitation = precipitation
+            self.weatherCode = weatherCode
+            self.source = source
+            self.dayRangeStart = dayRangeStart
+            self.dayRangeEnd = dayRangeEnd
+            self.contextRangeStart = contextRangeStart
+            self.contextRangeEnd = contextRangeEnd
+            self.contextPointsStorage = contextPointsStorage
+            self.episode = episode
+        }
+    }
+}

--- a/Symi/Sources/Shared/SyncCore.swift
+++ b/Symi/Sources/Shared/SyncCore.swift
@@ -562,6 +562,10 @@ public struct SyncContinuousMedicationPayload: Codable, Equatable, Sendable {
     public nonisolated var name: String
     public nonisolated var dosage: String
     public nonisolated var frequency: String
+    public nonisolated var kindRaw: String
+    public nonisolated var category: String
+    public nonisolated var statusRaw: String
+    public nonisolated var notes: String
     public nonisolated var startDate: Date
     public nonisolated var endDate: Date?
     public nonisolated var createdAt: Date
@@ -571,6 +575,10 @@ public struct SyncContinuousMedicationPayload: Codable, Equatable, Sendable {
         name: String,
         dosage: String,
         frequency: String,
+        kindRaw: String = "therapy",
+        category: String = "Medikamentös",
+        statusRaw: String = "active",
+        notes: String = "",
         startDate: Date,
         endDate: Date?,
         createdAt: Date
@@ -579,9 +587,28 @@ public struct SyncContinuousMedicationPayload: Codable, Equatable, Sendable {
         self.name = name
         self.dosage = dosage
         self.frequency = frequency
+        self.kindRaw = kindRaw
+        self.category = category
+        self.statusRaw = statusRaw
+        self.notes = notes
         self.startDate = startDate
         self.endDate = endDate
         self.createdAt = createdAt
+    }
+
+    public nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.dosage = try container.decode(String.self, forKey: .dosage)
+        self.frequency = try container.decode(String.self, forKey: .frequency)
+        self.kindRaw = try container.decodeIfPresent(String.self, forKey: .kindRaw) ?? "therapy"
+        self.category = try container.decodeIfPresent(String.self, forKey: .category) ?? "Medikamentös"
+        self.statusRaw = try container.decodeIfPresent(String.self, forKey: .statusRaw) ?? "active"
+        self.notes = try container.decodeIfPresent(String.self, forKey: .notes) ?? ""
+        self.startDate = try container.decode(Date.self, forKey: .startDate)
+        self.endDate = try container.decodeIfPresent(Date.self, forKey: .endDate)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
     }
 }
 
@@ -783,6 +810,10 @@ public enum SyncMergeEngine {
                 name: mergedValue(field: "name", base: base?.name, local: local.name, remote: remote.name, conflicts: &conflicts).value,
                 dosage: mergedValue(field: "dosage", base: base?.dosage, local: local.dosage, remote: remote.dosage, conflicts: &conflicts).value,
                 frequency: mergedValue(field: "frequency", base: base?.frequency, local: local.frequency, remote: remote.frequency, conflicts: &conflicts).value,
+                kindRaw: mergedValue(field: "kindRaw", base: base?.kindRaw, local: local.kindRaw, remote: remote.kindRaw, conflicts: &conflicts).value,
+                category: mergedValue(field: "category", base: base?.category, local: local.category, remote: remote.category, conflicts: &conflicts).value,
+                statusRaw: mergedValue(field: "statusRaw", base: base?.statusRaw, local: local.statusRaw, remote: remote.statusRaw, conflicts: &conflicts).value,
+                notes: mergedValue(field: "notes", base: base?.notes, local: local.notes, remote: remote.notes, conflicts: &conflicts).value,
                 startDate: mergedValue(field: "startDate", base: base?.startDate, local: local.startDate, remote: remote.startDate, conflicts: &conflicts).value,
                 endDate: mergedValue(field: "endDate", base: base?.endDate, local: local.endDate, remote: remote.endDate, conflicts: &conflicts).value,
                 createdAt: mergedValue(field: "createdAt", base: base?.createdAt, local: local.createdAt, remote: remote.createdAt, conflicts: &conflicts).value

--- a/SymiTests/DataTransferHealthContextTests.swift
+++ b/SymiTests/DataTransferHealthContextTests.swift
@@ -321,7 +321,7 @@ struct DataTransferHealthContextTests {
 }
 
 private func makeInMemoryContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV8.self)
+    let schema = Schema(versionedSchema: SymiSchemaV9.self)
     let configuration = ModelConfiguration(
         "test-\(UUID().uuidString)",
         schema: schema,

--- a/SymiTests/DomainValidatorTests.swift
+++ b/SymiTests/DomainValidatorTests.swift
@@ -173,7 +173,7 @@ struct DomainValidatorTests {
 }
 
 private func makeInMemoryContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV8.self)
+    let schema = Schema(versionedSchema: SymiSchemaV9.self)
     let configuration = ModelConfiguration(
         "domain-validator-tests-\(UUID().uuidString)",
         schema: schema,

--- a/SymiTests/SwiftDataMigrationFixtureTests.swift
+++ b/SymiTests/SwiftDataMigrationFixtureTests.swift
@@ -435,7 +435,7 @@ private func makeFixtureContainer<SchemaType: VersionedSchema>(
 }
 
 private func makeFixtureCurrentContainer(storeURL: URL) throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV8.self)
+    let schema = Schema(versionedSchema: SymiSchemaV9.self)
     let configuration = ModelConfiguration("migration-fixture-test", schema: schema, url: storeURL, cloudKitDatabase: .none)
     return try ModelContainer(
         for: schema,

--- a/SymiTests/SwiftDataMigrationTests.swift
+++ b/SymiTests/SwiftDataMigrationTests.swift
@@ -268,7 +268,7 @@ private func makeContainer<SchemaType: VersionedSchema>(
 }
 
 private func makeCurrentContainer(storeURL: URL) throws -> ModelContainer {
-    let schema = Schema(versionedSchema: SymiSchemaV8.self)
+    let schema = Schema(versionedSchema: SymiSchemaV9.self)
     let configuration = ModelConfiguration("migration-test", schema: schema, url: storeURL, cloudKitDatabase: .none)
     return try ModelContainer(
         for: schema,

--- a/SymiTests/SyncMergeEngineTests.swift
+++ b/SymiTests/SyncMergeEngineTests.swift
@@ -908,7 +908,7 @@ private extension Array {
 
 @MainActor
 private func makeSyncTestStack(provider: FakeSyncProvider? = nil) throws -> SyncTestStack {
-    let schema = Schema(versionedSchema: SymiSchemaV8.self)
+    let schema = Schema(versionedSchema: SymiSchemaV9.self)
     let configuration = ModelConfiguration(
         "sync-tests-\(UUID().uuidString)",
         schema: schema,


### PR DESCRIPTION
## Zusammenfassung
- erweitert die Therapie-Erfassung um Therapien und Präventionsmaßnahmen mit Kategorie, Status, Zeitraum und Notizen
- ergänzt SwiftData Schema V9 inklusive Migration sowie Export/Import und Sync der neuen Felder
- aktualisiert die Therapie-UI für Anlegen, Bearbeiten, Pausieren, Aktivieren, Beenden und Löschen

## Tests
- swiftlint
- xcodebuild test -project Symi.xcodeproj -scheme SymiTests -destination 'platform=iOS Simulator,name=iPhone 17'\n\nCloses #59