### PR TITLE
[codex] Restrict demo data to debug builds

### DIFF
--- a/Symi/Sources/App/AppStoreScreenshotMode.swift
+++ b/Symi/Sources/App/AppStoreScreenshotMode.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftData
 
+#if DEBUG
 enum AppStoreScreenshotMode {
     private static let enabledKeys = [
         "APP_STORE_SCREENSHOTS",
@@ -273,3 +274,22 @@ enum AppStoreScreenshotMode {
         }
     }
 }
+#else
+enum AppStoreScreenshotMode {
+    static var isEnabled: Bool {
+        false
+    }
+
+    static func resetStoreIfNeeded() throws {}
+
+    static func seed(into container: ModelContainer) {}
+
+    static func sampleDraft(initialStartedAt: Date?) -> EpisodeDraft {
+        preconditionFailure("Screenshot mode is unavailable in Release builds.")
+    }
+
+    static func sampleWeatherSnapshot(for startedAt: Date) -> WeatherSnapshotData {
+        preconditionFailure("Screenshot mode is unavailable in Release builds.")
+    }
+}
+#endif

--- a/Symi/Sources/App/ScreenshotSupport.swift
+++ b/Symi/Sources/App/ScreenshotSupport.swift
@@ -16,11 +16,18 @@ struct AppLaunchConfiguration {
     }
 
     init(arguments: [String], environment: [String: String]) {
+        self.isRunningTests = environment["XCTestConfigurationFilePath"] != nil
+
+        #if DEBUG
         let isFastlaneSnapshot = Self.boolValue(for: "-FASTLANE_SNAPSHOT", in: arguments) ?? false
         self.isScreenshotMode = isFastlaneSnapshot || arguments.contains("-ui_testing")
-        self.isRunningTests = environment["XCTestConfigurationFilePath"] != nil
         self.screenshotRoute = Self.value(for: "-mt_screenshot_screen", in: arguments).flatMap(ScreenshotRoute.init(rawValue:))
         self.screenshotSeedName = Self.value(for: "-mt_screenshot_seed", in: arguments) ?? "default"
+        #else
+        self.isScreenshotMode = false
+        self.screenshotRoute = nil
+        self.screenshotSeedName = "default"
+        #endif
     }
 
     private static func value(for key: String, in arguments: [String]) -> String? {
@@ -62,6 +69,7 @@ struct ScreenshotSeed {
     let newEntryDate: Date
 }
 
+#if DEBUG
 struct ScreenshotEnvironment {
     let modelContainer: ModelContainer
     let appContainer: AppContainer
@@ -368,3 +376,4 @@ private final class ScreenshotLocationService: LocationService {
         CLLocation(latitude: 48.2082, longitude: 16.3738)
     }
 }
+#endif

--- a/Symi/Sources/App/SymiApp.swift
+++ b/Symi/Sources/App/SymiApp.swift
@@ -110,6 +110,7 @@ struct SymiApp: App {
     @MainActor
     static func makeInitialStartupState(launchConfiguration: AppLaunchConfiguration) -> AppStartupState {
         do {
+            #if DEBUG
             if launchConfiguration.isScreenshotMode {
                 let environment = try ScreenshotBootstrap.makeEnvironment(seedName: launchConfiguration.screenshotSeedName)
                 return .app(
@@ -122,6 +123,7 @@ struct SymiApp: App {
                     )
                 )
             }
+            #endif
 
             return .app(try makeAppRuntimeEnvironment(launchConfiguration: launchConfiguration))
         } catch PersistentStoreLoadError.recoveryRequired(let context) {
@@ -350,6 +352,7 @@ private struct AppRootView: View {
 
     @ViewBuilder
     private func appContent(environment: AppRuntimeEnvironment) -> some View {
+        #if DEBUG
         if launchConfiguration.isScreenshotMode, let screenshotSeed = environment.screenshotSeed {
             ScreenshotRootView(
                 appContainer: environment.appContainer,
@@ -359,6 +362,9 @@ private struct AppRootView: View {
         } else {
             AppShellView(appContainer: environment.appContainer)
         }
+        #else
+        AppShellView(appContainer: environment.appContainer)
+        #endif
     }
 
     private func presentUsageDataConsentPromptIfNeeded() {

--- a/Symi/Sources/Features/Home/HomeView.swift
+++ b/Symi/Sources/Features/Home/HomeView.swift
@@ -614,6 +614,7 @@ private struct HomeInsightCardData: Identifiable, Equatable {
         }
     }
 
+    #if DEBUG
     static let previewCards = [
         HomeInsightCardData(
             id: "weekday",
@@ -630,6 +631,7 @@ private struct HomeInsightCardData: Identifiable, Equatable {
             tint: .coral
         )
     ]
+    #endif
 }
 
 private struct HomeMonthCalendarView: View {
@@ -708,26 +710,18 @@ private struct HomeMonthCalendarView: View {
 
     private var weekdaySymbols: [String] {
         let symbols = calendar.shortStandaloneWeekdaySymbols
-        guard symbols.count == 7 else {
-            return [
-                "MO",
-                "DI",
-                "MI",
-                "DO",
-                "FR",
-                "SA",
-                "SO"
-            ]
-        }
+        guard symbols.count == 7 else { return symbols.map { $0.uppercased(with: calendar.locale ?? .current) } }
 
-        return Array(symbols[1...6] + symbols[0...0]).map { $0.uppercased() }
+        let firstWeekdayIndex = max(0, min(6, calendar.firstWeekday - 1))
+        let orderedSymbols = symbols[firstWeekdayIndex...] + symbols[..<firstWeekdayIndex]
+        return orderedSymbols.map { $0.uppercased(with: calendar.locale ?? .current) }
     }
 
     private var dayCells: [HomeCalendarDay] {
         let startOfMonth = calendar.startOfMonth(for: month)
         let range = calendar.range(of: .day, in: .month, for: startOfMonth) ?? 1 ..< 1
         let weekday = calendar.component(.weekday, from: startOfMonth)
-        let leadingEmptyDays = (weekday + 5) % 7
+        let leadingEmptyDays = (weekday - calendar.firstWeekday + 7) % 7
 
         var cells = Array(repeating: HomeCalendarDay(date: nil), count: leadingEmptyDays)
         cells += range.compactMap { day -> HomeCalendarDay? in
@@ -1693,6 +1687,7 @@ private extension View {
     }
 }
 
+#if DEBUG
 #Preview("Home Hero States") {
     NavigationStack {
         ScrollView {
@@ -1735,3 +1730,4 @@ private extension View {
         .homeScreen()
     }
 }
+#endif


### PR DESCRIPTION
## Änderungen

- Screenshot- und Demo-Bootstrap werden nur noch in Debug-Builds kompiliert.
- Release-Builds ignorieren Screenshot-/UI-Test-Launch-Argumente und enthalten nur nicht aktivierbare Screenshot-Stubs.
- Home-Preview-Karten bleiben auf SwiftUI-Previews beschränkt.
- Die Kalender-Wochentage kommen aus `Calendar.shortStandaloneWeekdaySymbols` und folgen `calendar.firstWeekday`.

## Warum

Demo-Daten und Startmodus-Overrides dürfen nicht versehentlich in Release-Builds ausgeliefert werden. Die Änderung trennt Screenshot-/Debug-Infrastruktur klar vom Produktcode.

Closes #331

## Validierung

- `swiftlint lint --config .swiftlint.yml`
- `xcodebuild -project Symi.xcodeproj -scheme Symi -configuration Debug -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -project Symi.xcodeproj -scheme Symi -configuration Release -destination 'generic/platform=iOS Simulator' build`
- Release-Binary per `strings` auf bekannte Demo-/Screenshot-Strings geprüft.
